### PR TITLE
Add merge conflict tooling and Playwright test hardening

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -28,3 +28,16 @@
 *.yml  linguist-language=YAML
 *.yaml linguist-language=YAML
 
+
+# Lockfiles: prefer current branch during merges
+package-lock.json merge=ours
+yarn.lock         merge=ours
+pnpm-lock.yaml    merge=ours
+
+# Tool state / snapshots (keep ours)
+.playwright/**    merge=ours
+playwright-report/** merge=ours
+coverage/**       merge=ours
+
+# Markdown/docs: combine hunks when possible
+*.md merge=union

--- a/.gitconfig.merge-drivers.sample
+++ b/.gitconfig.merge-drivers.sample
@@ -1,0 +1,6 @@
+[merge "ours"]
+    name = keep our version (ignore incoming changes)
+    driver = true
+[merge "union"]
+    name = union lines for text files
+    driver = union

--- a/.github/workflows/conflict-marker-guard.yml
+++ b/.github/workflows/conflict-marker-guard.yml
@@ -1,0 +1,13 @@
+name: Conflict Marker Guard
+on: [push, pull_request]
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fail if conflict markers exist
+        run: |
+          if grep -R --line-number -E '^(<{7}|={7}|>{7})' -- . \
+               --exclude-dir=.git --exclude=.gitmodules; then
+            echo "❌ Conflict markers found. Resolve before merging."; exit 1;
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,17 @@
+name: Tests
+on: [push, pull_request]
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '22' }
+      - run: npm i --no-audit --no-fund || true
+      - name: Check duplicate data-testid
+        run: npm run -s test:ids
+      - name: Playwright
+        if: ${{ success() }}
+        run: |
+          npx playwright install --with-deps
+          npm run -s test:ui

--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ First milestone: **Literary Deviousness** — fiction writing games.
 ## Roadmap (short)
 - /site shell → add game
 - integrate writer-type themes
+
+## Dev tips
+- Make shell scripts executable: `chmod +x scripts/*.sh`
+- If on Windows, use the `.ps1` versions.

--- a/docs/CONFLICTS_AND_TESTS.md
+++ b/docs/CONFLICTS_AND_TESTS.md
@@ -1,0 +1,15 @@
+# Conflicts & Tests — Quick Playbook
+
+## Merge conflicts
+1) List: `scripts/list-conflicts.sh`
+2) Auto-resolve safe files (lockfiles, reports): `scripts/resolve-conflicts.sh`
+3) Manually fix app code: search for <<<<<<< ======= >>>>>>> and edit.
+
+## Playwright stability
+- Retries: 2 on CI, timeouts hardened.
+- Avoid duplicate `data-testid` in the same file.
+- Prefer role/label queries for accessibility when possible.
+
+## Pre-merge checks
+- `npm run test:ids` to spot duplicate test IDs.
+- Ensure no conflict markers remain (CI guard).

--- a/docs/MERGE_STRATEGY.md
+++ b/docs/MERGE_STRATEGY.md
@@ -1,0 +1,17 @@
+# Merge Strategy Helpers
+
+This repo ships with `.gitattributes` rules and a sample Git merge driver configuration to keep noisy files from causing unnecessary conflicts.
+
+## Using the merge drivers
+
+If you want Git to apply the same drivers locally, copy `.gitconfig.merge-drivers.sample` into either your global git config or the repo config:
+
+```sh
+# Global (applies to all repos)
+git config --global include.path "$(pwd)/.gitconfig.merge-drivers.sample"
+
+# Repo-only (within ProjectsFromTheProjects)
+cat .gitconfig.merge-drivers.sample >> .git/config
+```
+
+These drivers ensure lockfiles, generated reports, and documentation resolve more smoothly when merging.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "projects-from-the-projects",
+  "private": true,
+  "scripts": {
+    "test:ids": "node scripts/check-testids.js",
+    "test:ui": "playwright test -c playwright.config.ts",
+    "pretest": "npm run test:ids || true"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.48.0"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  retries: process.env.CI ? 2 : 0,
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  use: {
+    actionTimeout: 10_000,
+    navigationTimeout: 20_000,
+    // baseURL can be set via env if needed
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure'
+  },
+  reporter: process.env.CI ? [['line'], ['html', { open: 'never' }]] : [['list']]
+});

--- a/scripts/check-testids.js
+++ b/scripts/check-testids.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * Scans source files for duplicate data-testid values within the same file,
+ * which often causes Playwright locator collisions.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const roots = ['src', 'app', 'site', 'public']; // adjust as your tree evolves
+const exts  = new Set(['.tsx', '.ts', '.jsx', '.js', '.html', '.svelte', '.vue']);
+
+function walk(dir, files = []) {
+  if (!fs.existsSync(dir)) return files;
+  for (const entry of fs.readdirSync(dir)) {
+    const p = path.join(dir, entry);
+    const st = fs.statSync(p);
+    if (st.isDirectory()) { walk(p, files); }
+    else files.push(p);
+  }
+  return files;
+}
+
+function scanFile(file) {
+  const text = fs.readFileSync(file, 'utf8');
+  const re = /data-testid=["'`]([^"'`]+)["'`]/g;
+  const seen = new Map();
+  let m;
+  while ((m = re.exec(text))) {
+    const val = m[1];
+    seen.set(val, (seen.get(val) || 0) + 1);
+  }
+  const dups = [...seen.entries()].filter(([, n]) => n > 1);
+  if (dups.length) {
+    console.log(`\n${file}`);
+    for (const [val, n] of dups) console.log(`  • "${val}" appears ${n}×`);
+    return 1;
+  }
+  return 0;
+}
+
+let rc = 0;
+for (const root of roots) {
+  if (!fs.existsSync(root)) continue;
+  const files = walk(root).filter(f => exts.has(path.extname(f)));
+  for (const f of files) rc |= scanFile(f);
+}
+if (rc) {
+  console.error('\n❌ Duplicate data-testid values found in the same file. Make them unique (e.g., add -secondary, -sidebar).');
+  process.exit(1);
+} else {
+  console.log('✅ No duplicate data-testid values detected within files.');
+}

--- a/scripts/list-conflicts.ps1
+++ b/scripts/list-conflicts.ps1
@@ -1,0 +1,8 @@
+#!/usr/bin/env pwsh
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+Write-Host "🔎 Listing merge conflicts..."
+$conflicted = git diff --name-only --diff-filter=U
+$conflicted
+Write-Host ""
+Write-Host "Tip: run scripts/resolve-conflicts.ps1 --ours or --theirs for lockfiles and generated outputs."

--- a/scripts/list-conflicts.sh
+++ b/scripts/list-conflicts.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+set -eu
+echo "🔎 Listing merge conflicts..."
+git diff --name-only --diff-filter=U
+echo
+echo "Tip: run scripts/resolve-conflicts.sh --ours or --theirs for lockfiles and generated outputs."

--- a/scripts/resolve-conflicts.ps1
+++ b/scripts/resolve-conflicts.ps1
@@ -1,0 +1,35 @@
+#!/usr/bin/env pwsh
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+param(
+  [string]$Pick = 'auto'
+)
+
+$safePattern = '(package-lock\.json|yarn\.lock|pnpm-lock\.yaml|playwright-report/|coverage/|\.playwright/)'
+$conflicted = git diff --name-only --diff-filter=U
+
+if (-not $conflicted) {
+  Write-Host '✅ No conflicts.'
+  exit 0
+}
+
+foreach ($file in $conflicted) {
+  if ($file -match $safePattern) {
+    switch ($Pick) {
+      '--theirs' { git checkout --theirs -- $file }
+      Default   { git checkout --ours -- $file }
+    }
+    git add -- $file
+    Write-Host "Resolved (safe): $file"
+  }
+  else {
+    Write-Host "⚠️  Manual review needed: $file"
+    Write-Host "   → Open the file and remove conflict markers: <<<<<<< ======= >>>>>>>"
+  }
+}
+
+$left = git diff --name-only --diff-filter=U
+if (-not $left) {
+  Write-Host '🎉 Conflicts resolved for safe files. Stage & commit when done.'
+}

--- a/scripts/resolve-conflicts.sh
+++ b/scripts/resolve-conflicts.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+set -eu
+PICK="${1:-auto}"
+# Files we can safely pick "ours" for:
+SAFE_PAT='(package-lock\\.json|yarn\\.lock|pnpm-lock\\.yaml|playwright-report/|coverage/|\\.playwright/)'
+
+conflicted=$(git diff --name-only --diff-filter=U || true)
+[ -z "$conflicted" ] && { echo "✅ No conflicts."; exit 0; }
+
+for f in $conflicted; do
+  if echo "$f" | grep -E "$SAFE_PAT" >/dev/null 2>&1; then
+    case "$PICK" in
+      --theirs) git checkout --theirs -- "$f";;
+      --ours|auto|*) git checkout --ours -- "$f";;
+    esac
+    git add "$f"
+    echo "Resolved (safe): $f"
+  else
+    echo "⚠️  Manual review needed: $f"
+    echo "   → Open the file and remove conflict markers: <<<<<<< ======= >>>>>>>"
+  fi
+done
+
+left=$(git diff --name-only --diff-filter=U || true)
+[ -z "$left" ] && echo "🎉 Conflicts resolved for safe files. Stage & commit when done."


### PR DESCRIPTION
## Summary
- configure merge driver defaults via .gitattributes and a sample config with supporting docs
- add shell and PowerShell helpers plus CI guard to prevent lingering conflict markers
- introduce Playwright defaults, duplicate data-testid scanner, and related npm/CI scripts with docs updates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5e1a544dc832fa12206895d02e041