### PR TITLE
Add RAG lib exports and docs guard script

### DIFF
--- a/literary-deviousness/scripts/content-guard.js
+++ b/literary-deviousness/scripts/content-guard.js
@@ -1,0 +1,5 @@
+const fs=require("fs");const path=require("path");const dir=path.join(process.cwd(),"docs");
+if(!fs.existsSync(dir)){console.log("No docs/ directory; skipping guard.");process.exit(0);}
+const files=fs.readdirSync(dir).filter(f=>f.endsWith(".md"));const bad=[];
+for(const f of files){const p=path.join(dir,f);const txt=fs.readFileSync(p,"utf8");const re=/```\s*(ts|tsx|typescript|js|javascript)[\s\S]*?```/gi;if(re.test(txt))bad.push(f);}
+if(bad.length){console.error("Docs contain executable code blocks (ts/js). Move code into src/:");bad.forEach(b=>console.error(" - "+b));process.exit(1);}else{console.log("Docs OK: no executable code blocks found.");}

--- a/literary-deviousness/src/lib/index.ts
+++ b/literary-deviousness/src/lib/index.ts
@@ -1,0 +1,7 @@
+export * from "./rag-types";
+export * from "./rag-store.local";
+export * from "./rag-adapter";
+// @ts-ignore optional exports if present
+export * from "./rag-eval";
+// @ts-ignore
+export * from "./llama";

--- a/literary-deviousness/src/lib/rag-adapter.ts
+++ b/literary-deviousness/src/lib/rag-adapter.ts
@@ -1,0 +1,17 @@
+import type { RagQuery, RagResult, RagDimensionScore, RagCitation, RagEvidence } from "@/lib/rag-types";
+function clamp(n: any){const x=Number(n);return isFinite(x)?Math.max(0,Math.min(1,x)):0.5;}
+function normDims(d:any):RagDimensionScore[]{if(!Array.isArray(d))return[];return d.map((x:any)=>({name:String(x?.name??x?.key??"Unknown"),score:clamp(x?.score??x?.value??x?.rating??0.5),rationale:String(x?.rationale??x?.why??x?.note??"")}));}
+function normCites(c:any):RagCitation[]{if(!Array.isArray(c))return[];return c.map((x:any,i:number)=>({id:String(x?.id??`c${i}`),title:String(x?.title??x?.name??"Context"),snippet:String(x?.snippet??x?.text??"").slice(0,240),score:clamp(x?.score??x?.relevance??0.5)}));}
+function normEvid(e:any):RagEvidence[]{if(!Array.isArray(e))return[];return e.map((x:any)=>({quote:String(x?.quote??x?.span??"").slice(0,180),note:String(x?.note??x?.why??""),start:typeof x?.start==="number"?x.start:undefined,end:typeof x?.end==="number"?x.end:undefined}));}
+/** Attempts to import ragGrader.ts and normalize to RagResult. */
+export async function tryGradeWithRagGrader(q:RagQuery,contexts:{title:string;text:string}[]):Promise<RagResult|null>{
+  let mod:any=null; try{mod=await import("@/ragGrader");}catch{try{mod=await import("../../ragGrader");}catch{}}
+  if(!mod) return null; const fn=(mod.grade||mod.evaluate||mod.score||mod.default); if(typeof fn!=="function") return null;
+  let raw:any; try{raw=await fn({text:q.text,level:q.level,writerType:q.writerType,contexts});}
+  catch{try{raw=await fn(q.text,{level:q.level,writerType:q.writerType,contexts});}
+  catch{try{raw=await fn(q.text,contexts,q.level,q.writerType);}catch{return null;}}}
+  if(raw&&typeof raw==="object"&&"overall"in raw&&"dimensions"in raw&&"tips"in raw){
+    return {overall:clamp(raw.overall),dimensions:normDims(raw.dimensions),flags:Array.isArray(raw.flags)?raw.flags:[],tips:Array.isArray(raw.tips)?raw.tips:[],citations:normCites(raw.citations),evidence:normEvid(raw.evidence),model:String(raw.model||"ragGrader"),debug:{...(raw.debug||{}),usedOfflineMock:false}};
+  }
+  return {overall:clamp(raw?.score??raw?.overall??0.5),dimensions:normDims(raw?.axes??raw?.dimensions??[]),flags:Array.isArray(raw?.flags)?raw.flags:[],tips:Array.isArray(raw?.suggestions)?raw.suggestions:Array.isArray(raw?.tips)?raw.tips:[],citations:normCites(raw?.sources??raw?.citations),evidence:normEvid(raw?.evidence),model:"ragGrader",debug:{from:"ragGrader-mapped",usedOfflineMock:false}};
+}

--- a/literary-deviousness/src/lib/rag-store.local.ts
+++ b/literary-deviousness/src/lib/rag-store.local.ts
@@ -1,0 +1,22 @@
+export type StoreDoc = { id: string; title: string; text: string; tags?: string[] };
+export const DOCS: StoreDoc[] = [
+  { id: "beats-basic", title: "Scene Beats — Basics",
+    text: "Opening image sets tone. Inciting incident disrupts normal. Stakes rise. Reversal complicates. Climax demands choice. Resolution sets new normal.",
+    tags: ["structure","beats","level:1"] },
+  { id: "voice-choices", title: "Voice & Choice Quick Guide",
+    text: "Voice comes from diction, rhythm, POV distance, and patterned choices. Avoid paste-gloss: sudden style shifts with no causal reason.",
+    tags: ["voice","style","level:1-3"] },
+  { id: "devices", title: "Device Layering",
+    text: "Layer metaphor, foreshadowing, reversal, motif. Devices must support pressure, not decorate. Echo a chosen device twice to make it felt.",
+    tags: ["devices","structure","level:2-4"] },
+];
+export function retrieveRelevant(query: string, k = 4): StoreDoc[] {
+  const q = (query || "").toLowerCase();
+  const score = (t: string) => {
+    const words = new Set(q.split(/\W+/).filter(Boolean));
+    let hit = 0; for (const w of words) if (t.toLowerCase().includes(w)) hit++;
+    return words.size ? hit / Math.max(6, words.size) : 0;
+  };
+  return [...DOCS].map(d => ({ d, s: (score(d.title)+score(d.text))/2 }))
+    .sort((a,b)=>b.s-a.s).slice(0,k).map(x=>x.d);
+}

--- a/literary-deviousness/src/lib/rag-types.ts
+++ b/literary-deviousness/src/lib/rag-types.ts
@@ -1,0 +1,14 @@
+export type RagQuery = { text: string; level?: number; writerType?: string | null; maxSuggestions?: number; };
+export type RagCitation = { id: string; title: string; snippet: string; score: number; };
+export type RagDimensionScore = { name: string; score: number; rationale: string; };
+export type RagEvidence = { quote: string; note: string; start?: number; end?: number; };
+export type RagResult = {
+  overall: number;
+  dimensions: RagDimensionScore[];
+  flags: string[];
+  tips: string[];
+  citations: RagCitation[];
+  evidence: RagEvidence[];
+  model?: string;
+  debug?: { retrievedCount?: number; usedOfflineMock?: boolean; from?: string };
+};


### PR DESCRIPTION
## Summary
- add RAG type definitions and adapter utilities in the new lib layer
- provide a local document store helper for retrieval-based grading
- add a docs guard script to prevent executable TS/JS snippets in docs
- Run: npm run content:guard

## Testing
- npm run content:guard *(fails: package.json contains comments that break npm)*

------
https://chatgpt.com/codex/tasks/task_e_68e73bf445a0832f95ef23d623f377d3