### PR TITLE
Add Cut Games play route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import Home from './pages/Home';
 import Deck from './pages/Deck';
 import Play from './pages/Play';
 import CutGamesDebug from './dev/CutGamesDebug';
+import CutGames from './pages/CutGames';
+import CutGamesPlay from './pages/CutGamesPlay';
 
 export default function App() {
   return (
@@ -15,6 +17,8 @@ export default function App() {
             <Route path="/" element={<Home />} />
             <Route path="/pack/:id" element={<Deck />} />
             <Route path="/play/:id" element={<Play />} />
+            <Route path="/cut-games" element={<CutGames />} />
+            <Route path="/play/cut-games" element={<CutGamesPlay />} />
             <Route path="/dev/cut-games" element={<CutGamesDebug />} />
             <Route path="*" element={<Home />} />
           </Routes>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,8 +20,19 @@ export function Header() {
                 isActive ? 'bg-brand-accent text-white' : 'text-brand hover:bg-brand/5'
               }`
             }
-          >
+            >
             Home
+          </NavLink>
+          <NavLink
+            to="/cut-games"
+            className={({ isActive }) =>
+              `rounded-full px-3 py-1 transition-colors ${
+                isActive ? 'bg-brand-accent text-white' : 'text-brand hover:bg-brand/5'
+              }`
+            }
+            data-testid="nav-cutgames-link"
+          >
+            Cut Games
           </NavLink>
           <span className="rounded-full bg-brand/90 px-3 py-1 text-xs font-medium uppercase tracking-wide text-white">
             {points} pts

--- a/src/components/cutgames/BeatPitfallPicker.tsx
+++ b/src/components/cutgames/BeatPitfallPicker.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useMemo, useState } from "react";
+import clsx from "clsx";
+import { CatalogBeat, fetchBeats } from "../../lib/cutGamesClient";
+
+type BeatRow = { beat: string; total: number };
+
+type Props = {
+  beat?: string;
+  pitfall?: string;
+  pitfallDisabled?: boolean;
+  introductionCount?: number;
+  initialBeats?: CatalogBeat[];
+  onChange: (next: { beat?: string; pitfall?: string }) => void;
+};
+
+const slugify = (value: string) => value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+
+const formatKey = (value: string) =>
+  value
+    .split(/[_-]/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+
+const normalizeBeats = (rows?: CatalogBeat[] | BeatRow[] | null): BeatRow[] => {
+  if (!Array.isArray(rows)) return [];
+  return rows
+    .map((row) => ({ beat: row.beat, total: row.total ?? 0 }))
+    .filter((row) => Boolean(row.beat))
+    .sort((a, b) => b.total - a.total);
+};
+
+export default function BeatPitfallPicker({
+  beat,
+  pitfall,
+  pitfallDisabled = false,
+  introductionCount,
+  initialBeats,
+  onChange,
+}: Props) {
+  const [beatsIndex, setBeatsIndex] = useState<BeatRow[]>(() => normalizeBeats(initialBeats));
+
+  useEffect(() => {
+    if (!initialBeats || initialBeats.length === 0) return;
+    setBeatsIndex(normalizeBeats(initialBeats));
+  }, [initialBeats]);
+
+  useEffect(() => {
+    if (initialBeats && initialBeats.length > 0) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const beatsResponse = await fetchBeats();
+        if (cancelled) return;
+        setBeatsIndex(normalizeBeats(beatsResponse));
+      } catch (error) {
+        if (!cancelled) setBeatsIndex([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [initialBeats]);
+
+  const topBeats = useMemo(() => beatsIndex.slice(0, 40), [beatsIndex]);
+
+  return (
+    <div className="card space-y-4" data-testid="cutgames-beat-pitfall-picker">
+      <h2 className="text-neutral-100">Optional filters</h2>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-neutral-200">Beat</label>
+          <div
+            className="flex max-h-40 flex-wrap gap-2 overflow-auto rounded-xl border border-neutral-800 p-1"
+            data-testid="cutgames-beat-choices"
+          >
+            <button
+              type="button"
+              className={clsx("chip transition", !beat && "is-on")}
+              onClick={() => onChange({ beat: undefined, pitfall })}
+              data-testid="cutgames-beat-any"
+            >
+              Any beat
+            </button>
+            {topBeats.map((entry) => {
+              const isActive = beat === entry.beat;
+              return (
+                <button
+                  key={entry.beat}
+                  type="button"
+                  className={clsx("chip transition", isActive && "is-on")}
+                  onClick={() =>
+                    onChange({ beat: isActive ? undefined : entry.beat, pitfall })
+                  }
+                  data-testid={`cutgames-beat-${slugify(entry.beat)}`}
+                  title={`${entry.total} scenes`}
+                >
+                  {formatKey(entry.beat)}
+                </button>
+              );
+            })}
+          </div>
+          {beat && (
+            <p className="text-xs text-neutral-400" data-testid="cutgames-intro-count">
+              {introductionCount && introductionCount > 0
+                ? `${introductionCount} introductions available for this beat`
+                : "No introductions recorded for this beat yet"}
+            </p>
+          )}
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-neutral-200" htmlFor="cutgames-pitfall-input">
+            Pitfall (bad mode)
+          </label>
+          <input
+            id="cutgames-pitfall-input"
+            className="w-full rounded-xl border border-neutral-800 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 placeholder:text-neutral-500 focus:border-neutral-500 focus:outline-none disabled:cursor-not-allowed disabled:text-neutral-500"
+            placeholder="e.g., info_dump, floaty_dialogue"
+            value={pitfall ?? ""}
+            onChange={(event) =>
+              onChange({ beat, pitfall: event.target.value ? event.target.value.toLowerCase().replace(/\s+/g, "_") : undefined })
+            }
+            disabled={pitfallDisabled}
+            data-testid="cutgames-pitfall-input"
+          />
+          {pitfallDisabled && (
+            <p className="text-xs text-neutral-500">Pitfalls apply to bad-mode drills only.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/cutgames/ModePicker.tsx
+++ b/src/components/cutgames/ModePicker.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+import { fetchCatalog } from "../../lib/cutGamesClient";
+
+type Mode = { name: string; desc?: string };
+
+type ModePickerProps = {
+  value?: string;
+  onChange: (mode: string) => void;
+};
+
+const FALLBACK_MODES: Mode[] = [
+  { name: "Name", desc: "Identify beats by name" },
+  { name: "Missing", desc: "Find what's missing" },
+  { name: "Fix", desc: "Repair weak writing" },
+  { name: "Order", desc: "Arrange beats in sequence" },
+  { name: "Highlight", desc: "Mark beats in context" },
+  { name: "Why", desc: "Explain the purpose" },
+];
+
+export default function ModePicker({ value, onChange }: ModePickerProps) {
+  const [modes, setModes] = useState<Mode[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const catalog = await fetchCatalog();
+        if (!active) return;
+        const catalogModes: Mode[] = (catalog?.modes ?? []).map((mode: any) => ({
+          name: String(mode?.name ?? ""),
+          desc: mode?.desc,
+        }));
+        const filtered = catalogModes.filter((mode) => mode.name);
+        setModes(filtered.length ? filtered : FALLBACK_MODES);
+      } catch {
+        if (!active) return;
+        setModes(FALLBACK_MODES);
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const selected = value || modes[0]?.name;
+
+  return (
+    <div className="card" data-testid="mode-picker">
+      <h2 className="mb-3">Choose a mode</h2>
+      {loading ? (
+        <div className="pulse">loading modes…</div>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2">
+          {modes.map((mode) => (
+            <button
+              key={mode.name}
+              className={`btn btn-ghost justify-start ${selected === mode.name ? "border-white" : ""}`}
+              onClick={() => onChange(mode.name)}
+              title={mode.desc || ""}
+              data-testid={`mode-option-${mode.name.replace(/\s+/g, "-").toLowerCase()}`}
+            >
+              <span className="mr-2 font-semibold">{mode.name}</span>
+              <span className="text-neutral-400">{mode.desc}</span>
+            </button>
+          ))}
+        </div>
+      )}
+      <div className="mt-3 flex items-center gap-2 text-xs text-neutral-400">
+        <span className="kbd">R</span>
+        <span>start round</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/cutgames/ProgressBar.tsx
+++ b/src/components/cutgames/ProgressBar.tsx
@@ -1,0 +1,18 @@
+import clsx from "clsx";
+
+export default function ProgressBar({ total, index, className }: { total: number; index: number; className?: string }) {
+  const pct = total <= 0 ? 0 : Math.min(100, Math.round((Math.min(total, index + 1) / total) * 100));
+  return (
+    <div
+      className={clsx("progress-track", className)}
+      aria-label="round progress"
+      aria-valuemin={0}
+      aria-valuemax={total > 0 ? total : undefined}
+      aria-valuenow={total > 0 ? Math.min(total, index + 1) : undefined}
+      role="progressbar"
+      data-testid="cutgames-round-progress-bar"
+    >
+      <div className="progress-bar" style={{ width: `${pct}%` }} />
+    </div>
+  );
+}

--- a/src/components/cutgames/ResultsScreen.tsx
+++ b/src/components/cutgames/ResultsScreen.tsx
@@ -1,0 +1,47 @@
+type ResultsScreenProps = {
+  score: number;
+  notes: string[];
+  summary: { completed: number; skipped: number };
+  payload: { mode?: string; beat?: string; pitfall?: string; [key: string]: unknown };
+  onRestart: () => void;
+};
+
+export default function ResultsScreen({
+  score,
+  notes,
+  summary,
+  payload,
+  onRestart,
+}: ResultsScreenProps) {
+  const grade = score >= 90 ? "A" : score >= 80 ? "B" : score >= 70 ? "C" : score >= 60 ? "D" : "F";
+  return (
+    <div className="space-y-4" data-testid="results-screen">
+      <div className="card">
+        <h2 className="mb-1">Round Results</h2>
+        <div className="text-sm text-neutral-400">Mode: {payload?.mode}{payload?.beat ? ` · beat: ${payload.beat}`:""}{payload?.pitfall ? ` · pitfall: ${payload.pitfall}`:""}</div>
+        <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <div className="card"><div className="text-neutral-400 text-sm">Score</div><div className="text-3xl font-bold">{score}</div></div>
+          <div className="card"><div className="text-neutral-400 text-sm">Grade</div><div className="text-3xl font-bold">{grade}</div></div>
+          <div className="card"><div className="text-neutral-400 text-sm">Done / Skipped</div><div className="text-3xl font-bold">{summary.completed} / {summary.skipped}</div></div>
+        </div>
+      </div>
+
+      {/* Professor Ray Ray letter */}
+      <div className="card">
+        <h2 className="mb-3">Letter from Professor Ray Ray</h2>
+        <div className="space-y-2">
+          <p><em>“Surprise, scholar.”</em> You did the thing. Whether you swung like a wrecking ball or stitched like a surgeon, you kept the page alive. Points if you noticed the trap beats trying to mug your attention.</p>
+          <p>Here’s the clean breakdown:</p>
+          <ul className="list-disc pl-6">
+            {notes?.length ? notes.map((note, index) => <li key={index}>{note}</li>) : <li>No major flags this round.</li>}
+          </ul>
+          <p className="text-neutral-400 text-sm">Style Report appears only on this results screen. Keep cooking.</p>
+        </div>
+      </div>
+
+      <div className="flex gap-2">
+        <button className="btn btn-primary" onClick={onRestart} data-testid="btn-restart">Play another round</button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/cutgames/RoundEngine.tsx
+++ b/src/components/cutgames/RoundEngine.tsx
@@ -1,0 +1,357 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  PracticeItem,
+  PracticeMode,
+  RoundItemAnswer,
+  RoundMode,
+  SubmitRoundResponse,
+  fetchPractice,
+  sendTelemetrySkip,
+  submitRound,
+} from "../../lib/cutGamesClient";
+import ProgressBar from "./ProgressBar";
+import SceneCard from "./SceneCard";
+
+const ITEMS_PER_ROUND = 5;
+
+const isEditableTarget = (target: EventTarget | null) => {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName.toLowerCase();
+  return tag === "input" || tag === "textarea" || target.isContentEditable;
+};
+
+type SubmitPayload = Parameters<typeof submitRound>[0];
+type RoundSummary = { completed: number; skipped: number };
+
+export type RoundCompletion = {
+  score: number;
+  notes: string[];
+  id?: string;
+  summary: RoundSummary;
+  payload: SubmitPayload;
+  response: SubmitRoundResponse;
+};
+
+type Props = {
+  modeName: RoundMode;
+  beat?: string;
+  pitfall?: string;
+  practiceModeOverride?: PracticeMode;
+  onDone: (result: RoundCompletion) => void;
+  onSubmitError?: (error: string) => void;
+};
+
+export default function RoundEngine({
+  modeName,
+  beat,
+  pitfall,
+  practiceModeOverride,
+  onDone,
+  onSubmitError,
+}: Props) {
+  const [queue, setQueue] = useState<PracticeItem[]>([]);
+  const [idx, setIdx] = useState(0);
+  const [answer, setAnswer] = useState("");
+  const [answers, setAnswers] = useState<RoundItemAnswer[]>([]);
+  const [startedAt, setStartedAt] = useState<string>(() => new Date().toISOString());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [hasSubmitted, setHasSubmitted] = useState(false);
+
+  const modeKind: PracticeMode = useMemo(() => {
+    if (practiceModeOverride) return practiceModeOverride;
+    if (pitfall) return "bad";
+    return modeName === "Fix" ? "bad" : "good";
+  }, [modeName, pitfall, practiceModeOverride]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setSubmitError(null);
+    setQueue([]);
+    setIdx(0);
+    setAnswer("");
+    setAnswers([]);
+    setHasSubmitted(false);
+    const run = async () => {
+      try {
+        const items = await fetchPractice({ mode: modeKind, beat, pitfall });
+        if (cancelled) return;
+        const trimmed = (items ?? []).slice(0, ITEMS_PER_ROUND);
+        setQueue(trimmed);
+        setStartedAt(new Date().toISOString());
+      } catch (err) {
+        if (cancelled) return;
+        setError((err as Error).message || "Failed to load practice");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [modeKind, beat, pitfall]);
+
+  const current = queue[idx];
+  const finished = idx >= queue.length && queue.length > 0;
+
+  const recordAnswer = useCallback(
+    (entry: RoundItemAnswer) => {
+      setAnswers((prev) => {
+        const next = prev.filter((item) => item.itemId !== entry.itemId);
+        return [...next, entry];
+      });
+    },
+    [],
+  );
+
+  const next = useCallback(() => {
+    setIdx((prev) => {
+      if (prev >= queue.length) return prev;
+      const nextIndex = Math.min(prev + 1, queue.length);
+      if (nextIndex !== prev) {
+        setAnswer("");
+      }
+      return nextIndex;
+    });
+  }, [queue.length]);
+
+  const onSkip = useCallback(async () => {
+    if (!current || submitting) return;
+    recordAnswer({
+      itemId: current.id,
+      mode: modeKind,
+      beat,
+      pitfall,
+      skipped: true,
+    });
+    try {
+      await sendTelemetrySkip(modeKind, {
+        beat: current.beat ?? undefined,
+        pitfall: current.pitfall ?? undefined,
+        type: current.type ?? undefined,
+      });
+    } catch (err) {
+      console.warn("Failed to send skip telemetry", err);
+    }
+    next();
+  }, [current, submitting, recordAnswer, modeKind, beat, pitfall, next]);
+
+  const onComplete = useCallback(() => {
+    if (!current || submitting) return;
+    recordAnswer({
+      itemId: current.id,
+      mode: modeKind,
+      beat,
+      pitfall,
+      skipped: false,
+      answer: answer.trim(),
+    });
+    next();
+  }, [answer, current, submitting, modeKind, beat, pitfall, next, recordAnswer]);
+
+  const onNext = useCallback(() => {
+    if (!current || submitting) return;
+    recordAnswer({
+      itemId: current.id,
+      mode: modeKind,
+      beat,
+      pitfall,
+      skipped: true,
+    });
+    next();
+  }, [current, submitting, recordAnswer, modeKind, beat, pitfall, next]);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
+      if (isEditableTarget(event.target)) return;
+      const key = event.key.toLowerCase();
+      if (key === "s") {
+        event.preventDefault();
+        onSkip();
+      } else if (key === "c") {
+        event.preventDefault();
+        onComplete();
+      } else if (key === "n") {
+        event.preventDefault();
+        onNext();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onSkip, onComplete, onNext]);
+
+  useEffect(() => {
+    if (!finished || submitting || queue.length === 0 || hasSubmitted) return;
+    let cancelled = false;
+    const run = async () => {
+      try {
+        setSubmitting(true);
+        setSubmitError(null);
+        setHasSubmitted(true);
+        const payload: SubmitPayload = {
+          mode: modeName,
+          beat,
+          pitfall,
+          items: answers,
+          startedAt,
+          finishedAt: new Date().toISOString(),
+        };
+        const response = await submitRound(payload);
+        if (cancelled) return;
+        const summary: RoundSummary = {
+          completed: answers.filter((entry) => !entry.skipped).length,
+          skipped: answers.filter((entry) => entry.skipped).length,
+        };
+        onDone({
+          score: response.score,
+          notes: response.rubric?.notes ?? [],
+          id: response.id,
+          summary,
+          payload,
+          response,
+        });
+      } catch (err) {
+        if (cancelled) return;
+        const message = (err as Error).message || "Failed to submit round";
+        setSubmitError(message);
+        onSubmitError?.(message);
+      } finally {
+        if (!cancelled) {
+          setSubmitting(false);
+        }
+      }
+    };
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [finished, submitting, queue.length, hasSubmitted, modeName, beat, pitfall, answers, startedAt, onDone, onSubmitError]);
+
+  const handleRetrySubmit = useCallback(() => {
+    if (!finished) return;
+    setSubmitError(null);
+    setHasSubmitted(false);
+  }, [finished]);
+
+  if (loading) {
+    return (
+      <div className="card" data-testid="cutgames-round-loading">
+        loading practice…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="card text-rose-200" data-testid="cutgames-round-error">
+        {error}
+      </div>
+    );
+  }
+
+  if (!queue.length) {
+    return (
+      <div className="card" data-testid="cutgames-round-empty">
+        no practice available
+      </div>
+    );
+  }
+
+  if (submitError) {
+    return (
+      <div className="card space-y-3 text-rose-200" data-testid="cutgames-round-submit-error">
+        <p>{submitError}</p>
+        <button type="button" className="btn btn-primary" onClick={handleRetrySubmit}>
+          Try submitting again
+        </button>
+      </div>
+    );
+  }
+
+  if (finished) {
+    return (
+      <div className="card" data-testid="cutgames-round-scoring">
+        scoring…
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4" data-testid="cutgames-round-engine">
+      <div className="card flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="chip is-on">{modeName}</span>
+          {beat && <span className="chip">beat: {beat}</span>}
+          {pitfall && <span className="chip">pitfall: {pitfall}</span>}
+        </div>
+        <div className="flex items-center gap-3 text-xs text-neutral-400">
+          <span>
+            <span className="kbd">S</span> Skip
+          </span>
+          <span>
+            <span className="kbd">C</span> Complete
+          </span>
+          <span>
+            <span className="kbd">N</span> Next
+          </span>
+        </div>
+      </div>
+
+      <ProgressBar total={queue.length} index={idx} />
+
+      {current && <SceneCard item={current} />}
+
+      <div className="card space-y-3">
+        <label className="block text-sm" htmlFor="cutgames-round-answer">
+          Your move
+        </label>
+        <textarea
+          id="cutgames-round-answer"
+          value={answer}
+          onChange={(event) => setAnswer(event.target.value)}
+          placeholder={
+            modeName === "Name"
+              ? "Name the beat(s) present…"
+              : modeName === "Missing"
+                ? "What’s missing and why does it matter…"
+                : modeName === "Fix"
+                  ? "Rewrite or prescribe a fix…"
+                  : modeName === "Order"
+                    ? "Describe correct order / sequence…"
+                    : modeName === "Highlight"
+                      ? "Quote/mark the beat text and label it…"
+                      : "Explain the purpose / effect of the beat…"
+          }
+          className="w-full min-h-40 rounded-xl border border-neutral-800 bg-neutral-900 px-3 py-2"
+          data-testid="cutgames-round-answer"
+        />
+        <div className="flex gap-2">
+          <button
+            type="button"
+            className="btn btn-ghost"
+            onClick={onSkip}
+            data-testid="cutgames-round-skip"
+            disabled={submitting}
+          >
+            Skip
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={onComplete}
+            data-testid="cutgames-round-complete"
+            disabled={submitting}
+          >
+            Complete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/cutgames/SceneCard.tsx
+++ b/src/components/cutgames/SceneCard.tsx
@@ -1,0 +1,15 @@
+// src/components/cutgames/SceneCard.tsx
+import { PracticeItem } from "../../lib/cutGamesClient";
+
+export default function SceneCard({ item }: { item: PracticeItem }) {
+  return (
+    <div className="card" data-testid="scene-card">
+      <div className="flex items-center gap-2 mb-3">
+        {item.beat && <span className="chip">{item.beat}</span>}
+        {item.pitfall && <span className="chip">{item.pitfall}</span>}
+        <span className="text-xs text-neutral-500 ml-auto">#{item.id}</span>
+      </div>
+      <div className="scene">{item.scene}</div>
+    </div>
+  );
+}

--- a/src/lib/cutGamesClient.ts
+++ b/src/lib/cutGamesClient.ts
@@ -1,41 +1,126 @@
-export interface PracticeQuery {
-    mode: "good" | "bad";
-    beat?: string;
-    pitfall?: string;
+export type PracticeMode = "good" | "bad";
+
+export type PracticeItem = {
+  id: number;
+  scene: string;
+  beat?: string | null;
+  pitfall?: string | null;
+  type?: string | null;
+};
+
+export type CatalogMode = { name: string; desc: string };
+
+export type CatalogBeat = {
+  beat: string;
+  total: number;
+  from_tweetrunk: number;
+  from_good: number;
+  from_bad: number;
+};
+
+export type CutGamesCatalog = {
+  tweetrunkCount: number;
+  goodCount: number;
+  badCount: number;
+  beatsIndex: CatalogBeat[];
+  lessonsByTagCount: number;
+  modes: CatalogMode[];
+};
+
+export type IntroductionsIndex = Record<string, number[]>;
+
+type TelemetryType = "lesson" | "prompt" | "mixed" | "notelesson" | (string & {});
+
+async function get<T>(url: string): Promise<T> {
+  const res = await fetch(url, { credentials: "include" });
+  if (!res.ok) throw new Error(`GET ${url} failed: ${res.status}`);
+  return res.json() as Promise<T>;
 }
 
-export async function fetchCatalog<T = unknown>(): Promise<T> {
-    const res = await fetchJson("/cut-games/catalog");
-    return res as T;
+async function post<T>(url: string, body: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`POST ${url} failed: ${res.status}`);
+  return res.json() as Promise<T>;
 }
 
-export async function fetchBeats<T = unknown>(): Promise<T> {
-    const res = await fetchJson("/cut-games/beats");
-    return res as T;
+export async function fetchCatalog(): Promise<CutGamesCatalog> {
+  return get<CutGamesCatalog>("/cut-games/catalog");
 }
 
-export async function fetchIntroductions<T = unknown>(): Promise<T> {
-    const res = await fetchJson("/cut-games/introductions");
-    return res as T;
+export async function fetchBeats(): Promise<CatalogBeat[]> {
+  return get<CatalogBeat[]>("/cut-games/beats");
 }
 
-export async function fetchPractice<T = any[]>(query: PracticeQuery): Promise<T> {
-    const params = new URLSearchParams();
-    params.set("mode", query.mode);
-    if (query.beat) params.set("beat", query.beat);
-    if (query.pitfall) params.set("pitfall", query.pitfall);
-    const res = await fetchJson(`/cut-games/practice?${params.toString()}`);
-    return res as T;
+export async function fetchIntroductions(): Promise<IntroductionsIndex> {
+  return get<IntroductionsIndex>("/cut-games/introductions");
 }
 
-async function fetchJson(url: string): Promise<unknown> {
-    const response = await fetch(url, { headers: { "accept": "application/json" }, cache: "no-store" });
-    if (!response.ok) {
-        throw new Error(`Failed to fetch ${url}: ${response.status}`);
-    }
-    const contentType = response.headers.get("content-type") || "";
-    if (contentType.includes("application/json") || contentType.includes("application/x-ndjson")) {
-        return response.json();
-    }
-    return response.json();
+export async function fetchPractice(params: {
+  mode: PracticeMode;
+  beat?: string;
+  pitfall?: string;
+}): Promise<PracticeItem[]> {
+  const qs = new URLSearchParams();
+  qs.set("mode", params.mode);
+  if (params.beat) qs.set("beat", params.beat);
+  if (params.pitfall) qs.set("pitfall", params.pitfall);
+  return get<PracticeItem[]>(`/cut-games/practice?${qs.toString()}`);
+}
+
+export async function sendTelemetrySkip(
+  mode: PracticeMode,
+  meta: { beat?: string; pitfall?: string; type?: TelemetryType } = {}
+) {
+  return post<{ ok: true }>("/cut-games/telemetry", { event: "skip", mode, meta });
+}
+
+export type RoundItemAnswer = {
+  itemId: number;
+  mode: PracticeMode;
+  beat?: string;
+  pitfall?: string;
+  answer?: string;
+  skipped: boolean;
+};
+
+export type RoundMode =
+  | "Name"
+  | "Missing"
+  | "Fix"
+  | "Order"
+  | "Highlight"
+  | "Why"
+  | (string & {});
+
+export type SubmitRoundRubric = {
+  score: number;
+  notes: string[];
+  flags: Record<string, unknown>;
+};
+
+export type SubmitRoundResponse = {
+  ok: true;
+  id?: string;
+  score: number;
+  rubric?: SubmitRoundRubric;
+  xp?: number;
+  level?: number;
+  levelUp?: { from: number; to: number } | null;
+  newBadges?: Array<{ id: string; title: string; desc: string; xp_bonus?: number }>;
+};
+
+export async function submitRound(payload: {
+  mode: RoundMode;
+  beat?: string;
+  pitfall?: string;
+  items: RoundItemAnswer[];
+  startedAt: string;
+  finishedAt: string;
+}): Promise<SubmitRoundResponse> {
+  return post<SubmitRoundResponse>("/api/submit", payload);
 }

--- a/src/pages/CutGames.tsx
+++ b/src/pages/CutGames.tsx
@@ -1,0 +1,799 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import clsx from "clsx";
+import BeatPitfallPicker from "../components/cutgames/BeatPitfallPicker";
+import {
+  CatalogBeat,
+  CatalogMode,
+  CutGamesCatalog,
+  IntroductionsIndex,
+  PracticeItem,
+  PracticeMode,
+  RoundItemAnswer,
+  RoundMode,
+  SubmitRoundResponse,
+  fetchBeats,
+  fetchCatalog,
+  fetchIntroductions,
+  fetchPractice,
+  sendTelemetrySkip,
+  submitRound,
+} from "../lib/cutGamesClient";
+import "../styles/cutgames.css";
+
+const ROUND_SIZE = 5;
+
+type RoundSelection = {
+  datasetMode: PracticeMode;
+  gameMode: RoundMode;
+  beat?: string;
+  pitfall?: string;
+};
+
+type RoundAnswerState = Record<number, { answer: string; skipped: boolean }>;
+
+type NormalizedRoundResult = {
+  id?: string;
+  score: number;
+  rubricScore?: number;
+  notes: string[];
+  flags?: Record<string, unknown>;
+  xp?: number;
+  level?: number;
+  newBadges?: SubmitRoundResponse["newBadges"];
+  raw: SubmitRoundResponse;
+};
+
+type RoundState = {
+  selection: RoundSelection;
+  items: PracticeItem[];
+  answers: RoundAnswerState;
+  currentIndex: number;
+  startedAt: string;
+  finishedAt?: string;
+  submitting: boolean;
+  submitError?: string;
+  result?: NormalizedRoundResult | null;
+};
+
+const isFormElement = (target: EventTarget | null): target is HTMLElement => {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName.toLowerCase();
+  return tag === "input" || tag === "textarea" || tag === "select" || target.isContentEditable;
+};
+
+const slugify = (value: string) => value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+
+const formatKey = (value?: string | null) => {
+  if (!value) return "";
+  return value
+    .split(/[_-]/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+};
+
+const normalizeSubmitResponse = (response: SubmitRoundResponse): NormalizedRoundResult => ({
+  id: response.id,
+  score: typeof response.score === "number" ? response.score : response.rubric?.score ?? 0,
+  rubricScore: response.rubric?.score,
+  notes: Array.isArray(response.rubric?.notes) ? response.rubric.notes : [],
+  flags: response.rubric?.flags,
+  xp: response.xp,
+  level: response.level,
+  newBadges: response.newBadges,
+  raw: response,
+});
+
+const describeBeat = (beat?: string | null) => (beat ? formatKey(beat) : "Any beat");
+const describePitfall = (pitfall?: string | null) => (pitfall ? formatKey(pitfall) : "Any pitfall");
+
+const KeyboardLegend = () => (
+  <ul className="flex flex-wrap gap-3" data-testid="cutgames-hotkeys">
+    {[
+      { key: "R", label: "Start Round" },
+      { key: "S", label: "Skip" },
+      { key: "C", label: "Complete" },
+      { key: "N", label: "Next" },
+    ].map(({ key, label }) => (
+      <li key={key} className="inline-flex items-center gap-2 text-sm text-neutral-300">
+        <span className="kbd">{key}</span>
+        <span>{label}</span>
+      </li>
+    ))}
+  </ul>
+);
+
+function useMetaBundles() {
+  const [catalog, setCatalog] = useState<CutGamesCatalog | null>(null);
+  const [beats, setBeats] = useState<CatalogBeat[]>([]);
+  const [introductions, setIntroductions] = useState<IntroductionsIndex>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    (async () => {
+      try {
+        const [cat, beatRows, introIndex] = await Promise.all([
+          fetchCatalog(),
+          fetchBeats(),
+          fetchIntroductions(),
+        ]);
+        if (cancelled) return;
+        setCatalog(cat);
+        setBeats(Array.isArray(beatRows) ? beatRows : []);
+        setIntroductions(introIndex ?? {});
+      } catch (err) {
+        if (cancelled) return;
+        setError((err as Error).message || "Failed to load Cut Games data");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { catalog, beats, introductions, loading, error } as const;
+}
+
+function buildInitialAnswers(items: PracticeItem[]): RoundAnswerState {
+  const base: RoundAnswerState = {};
+  for (const item of items) {
+    const id = Number(item.id);
+    base[id] = { answer: "", skipped: false };
+  }
+  return base;
+}
+
+function useKeyboardShortcuts(
+  round: RoundState | null,
+  onStart: () => void,
+  onSkip: () => void,
+  onComplete: () => void,
+  onNext: () => void,
+) {
+  useEffect(() => {
+    const listener = (event: KeyboardEvent) => {
+      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
+      if (isFormElement(event.target)) return;
+      const key = event.key.toLowerCase();
+
+      if (!round || round.result) {
+        if (key === "r") {
+          event.preventDefault();
+          onStart();
+        }
+        return;
+      }
+
+      if (key === "s") {
+        event.preventDefault();
+        onSkip();
+      } else if (key === "c") {
+        event.preventDefault();
+        onComplete();
+      } else if (key === "n") {
+        event.preventDefault();
+        onNext();
+      }
+    };
+
+    window.addEventListener("keydown", listener);
+    return () => window.removeEventListener("keydown", listener);
+  }, [round, onStart, onSkip, onComplete, onNext]);
+}
+
+export default function CutGames() {
+  const { catalog, beats, introductions, loading, error } = useMetaBundles();
+  const [selection, setSelection] = useState<RoundSelection>({ datasetMode: "bad", gameMode: "Name" });
+  const [round, setRound] = useState<RoundState | null>(null);
+  const [roundError, setRoundError] = useState<string | null>(null);
+  const [roundLoading, setRoundLoading] = useState(false);
+
+  useEffect(() => {
+    if (!catalog) return;
+    setSelection((prev) => {
+      const modes = catalog.modes ?? [];
+      const hasPrev = modes.some((mode) => mode.name === prev.gameMode);
+      const fallback = (modes[0]?.name as RoundMode | undefined) ?? prev.gameMode;
+      if (hasPrev) return prev;
+      return { ...prev, gameMode: fallback ?? "Name" };
+    });
+  }, [catalog]);
+
+  const activeMode: CatalogMode | undefined = useMemo(() => {
+    if (!catalog) return undefined;
+    return catalog.modes?.find((mode) => mode.name === selection.gameMode);
+  }, [catalog, selection.gameMode]);
+
+  const beatOptions = useMemo(() => {
+    if (!Array.isArray(beats)) return [] as CatalogBeat[];
+    return beats.slice().sort((a, b) => b.total - a.total);
+  }, [beats]);
+
+  const currentItem = round ? round.items[round.currentIndex] : null;
+  const currentAnswer = useMemo(() => {
+    if (!round || !currentItem) return "";
+    return round.answers[Number(currentItem.id)]?.answer ?? "";
+  }, [round, currentItem]);
+
+  const answeredCount = round
+    ? round.items.filter((item) => {
+        const entry = round.answers[Number(item.id)];
+        if (!entry) return false;
+        return entry.skipped || entry.answer.trim().length > 0;
+      }).length
+    : 0;
+
+  const skipCount = round
+    ? round.items.filter((item) => round.answers[Number(item.id)]?.skipped).length
+    : 0;
+
+  const handleStartRound = useCallback(async () => {
+    if (roundLoading) return;
+    setRoundError(null);
+    setRoundLoading(true);
+    try {
+      const payloadBeat = selection.beat?.trim() || undefined;
+      const payloadPitfall = selection.datasetMode === "bad" ? selection.pitfall?.trim() || undefined : undefined;
+      const items = await fetchPractice({
+        mode: selection.datasetMode,
+        beat: payloadBeat,
+        pitfall: payloadPitfall,
+      });
+      const trimmed = (items ?? []).slice(0, ROUND_SIZE);
+      if (!trimmed.length) {
+        throw new Error("No practice scenes available for this selection.");
+      }
+      const startedAt = new Date().toISOString();
+      setRound({
+        selection: { ...selection, beat: payloadBeat, pitfall: payloadPitfall },
+        items: trimmed,
+        answers: buildInitialAnswers(trimmed),
+        currentIndex: 0,
+        startedAt,
+        submitting: false,
+        result: null,
+      });
+    } catch (err) {
+      setRound(null);
+      setRoundError((err as Error).message || "Unable to start round");
+    } finally {
+      setRoundLoading(false);
+    }
+  }, [roundLoading, selection]);
+
+  const handleAnswerChange = useCallback(
+    (value: string) => {
+      if (!round || !currentItem || round.result) return;
+      const itemId = Number(currentItem.id);
+      setRound((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          answers: {
+            ...prev.answers,
+            [itemId]: { answer: value, skipped: false },
+          },
+        };
+      });
+    },
+    [round, currentItem]
+  );
+
+  const advanceIndex = useCallback(
+    (offset: number) => {
+      setRound((prev) => {
+        if (!prev) return prev;
+        const nextIndex = Math.max(0, Math.min(prev.items.length - 1, prev.currentIndex + offset));
+        return { ...prev, currentIndex: nextIndex };
+      });
+    },
+    []
+  );
+
+  const handleSkip = useCallback(async () => {
+    if (!round || !currentItem || round.result) return;
+    const itemId = Number(currentItem.id);
+    const selectionMode = round.selection.datasetMode;
+    setRound((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        answers: {
+          ...prev.answers,
+          [itemId]: { answer: "", skipped: true },
+        },
+      };
+    });
+    try {
+      await sendTelemetrySkip(selectionMode, {
+        beat: currentItem.beat ?? undefined,
+        pitfall: currentItem.pitfall ?? undefined,
+        type: currentItem.type ?? undefined,
+      });
+    } catch (err) {
+      console.warn("Failed to record skip", err);
+    }
+    if (round.currentIndex < round.items.length - 1) {
+      advanceIndex(1);
+    }
+  }, [round, currentItem, advanceIndex]);
+
+  const handleComplete = useCallback(() => {
+    if (!round || !currentItem || round.result) return;
+    if (!round.answers[Number(currentItem.id)]?.answer.trim()) return;
+    if (round.currentIndex < round.items.length - 1) {
+      advanceIndex(1);
+    }
+  }, [round, currentItem, advanceIndex]);
+
+  const handleNext = useCallback(() => {
+    if (!round) return;
+    if (round.currentIndex < round.items.length - 1) {
+      advanceIndex(1);
+    }
+  }, [round, advanceIndex]);
+
+  const handlePrev = useCallback(() => {
+    if (!round) return;
+    if (round.currentIndex > 0) {
+      advanceIndex(-1);
+    }
+  }, [round, advanceIndex]);
+
+  const handleSubmitRound = useCallback(async () => {
+    if (!round || round.result) return;
+    setRound((prev) => (prev ? { ...prev, submitting: true, submitError: undefined } : prev));
+    const finishedAt = new Date().toISOString();
+    try {
+      const itemsPayload: RoundItemAnswer[] = round.items.map((item) => {
+        const entry = round.answers[Number(item.id)] ?? { answer: "", skipped: false };
+        return {
+          itemId: Number(item.id),
+          mode: round.selection.datasetMode,
+          beat: item.beat ?? undefined,
+          pitfall: item.pitfall ?? undefined,
+          answer: entry.answer || undefined,
+          skipped: entry.skipped,
+        };
+      });
+      const response = await submitRound({
+        mode: round.selection.gameMode,
+        beat: round.selection.beat,
+        pitfall: round.selection.pitfall,
+        items: itemsPayload,
+        startedAt: round.startedAt,
+        finishedAt,
+      });
+      setRound((prev) =>
+        prev
+          ? {
+              ...prev,
+              finishedAt,
+              submitting: false,
+              result: normalizeSubmitResponse(response),
+            }
+          : prev
+      );
+    } catch (err) {
+      setRound((prev) =>
+        prev
+          ? {
+              ...prev,
+              submitting: false,
+              submitError: (err as Error).message || "Failed to submit round",
+            }
+          : prev
+      );
+    }
+  }, [round]);
+
+  const resetRound = useCallback(() => {
+    setRound(null);
+    setRoundError(null);
+  }, []);
+
+  useKeyboardShortcuts(round, handleStartRound, handleSkip, handleComplete, handleNext);
+
+  const introductionCount = useMemo(() => {
+    if (!selection.beat) return 0;
+    return introductions[selection.beat] ? introductions[selection.beat].length : 0;
+  }, [introductions, selection.beat]);
+
+  const roundReady = Boolean(round && !round.result);
+  const showResults = Boolean(round?.result);
+  const roundLocked = Boolean(round?.result);
+  const startLabel = roundLoading
+    ? "Preparing scenes…"
+    : roundLocked
+      ? "Start new round"
+      : roundReady
+        ? "Restart round"
+        : "Start round";
+
+  return (
+    <div className="cut-shell" data-testid="cutgames-shell">
+      <div className="cut-container space-y-6">
+        <header className="card space-y-4" data-testid="cutgames-header-card">
+          <div className="flex flex-col gap-2">
+            <p className="text-sm uppercase tracking-[0.4em] text-neutral-400">Precision Story Lab</p>
+            <h1 className="text-3xl font-semibold text-neutral-50">Cut Games Arena</h1>
+            <p className="text-neutral-300">
+              Draft, diagnose, and remix story beats. Choose a deck, play a round, and study the style report to sharpen your cut instincts.
+            </p>
+          </div>
+          <KeyboardLegend />
+        </header>
+
+        {loading ? (
+          <div className="card" data-testid="cutgames-loading">
+            <p className="text-neutral-300">Loading cut game bundles…</p>
+          </div>
+        ) : error ? (
+          <div className="card border-rose-500/60" data-testid="cutgames-error">
+            <p className="text-rose-200">{error}</p>
+          </div>
+        ) : (
+          <div className="grid gap-6 lg:grid-cols-[320px_1fr]">
+            <div className="space-y-6">
+              <aside className="card space-y-5" data-testid="cutgames-setup">
+                <section>
+                  <h2 className="flex items-center justify-between text-neutral-100">
+                    Round setup
+                    <span className="text-xs font-medium uppercase tracking-wide text-neutral-400">{ROUND_SIZE} scenes</span>
+                  </h2>
+                  <p className="mt-1 text-sm text-neutral-400">
+                    {activeMode ? activeMode.desc : "Select a deck and mode to get started."}
+                  </p>
+                </section>
+
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium text-neutral-200" htmlFor="cutgames-mode-select">
+                      Game mode
+                    </label>
+                    <div className="flex flex-wrap gap-2" id="cutgames-mode-select">
+                      {(catalog?.modes ?? []).map((mode) => {
+                        const isActive = mode.name === selection.gameMode;
+                        return (
+                          <button
+                            key={mode.name}
+                            type="button"
+                            className={clsx("chip transition", isActive && "is-on")}
+                            onClick={() => setSelection((prev) => ({ ...prev, gameMode: mode.name }))}
+                            data-testid={`cutgames-mode-${slugify(mode.name)}`}
+                          >
+                            {mode.name}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <span className="text-sm font-medium text-neutral-200">Scene quality</span>
+                    <div className="flex gap-2">
+                      {(
+                        [
+                          { value: "good", label: "Good (mentor cuts)" },
+                          { value: "bad", label: "Bad (fix-it lab)" },
+                        ] as const
+                      ).map((option) => {
+                        const isActive = selection.datasetMode === option.value;
+                        return (
+                          <button
+                            key={option.value}
+                            type="button"
+                            className={clsx("chip transition", isActive && "is-on")}
+                            onClick={() =>
+                              setSelection((prev) => ({
+                                ...prev,
+                                datasetMode: option.value,
+                                pitfall: option.value === "bad" ? prev.pitfall : undefined,
+                              }))
+                            }
+                            data-testid={`cutgames-quality-${option.value}`}
+                          >
+                            {option.label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="space-y-3">
+                  <button
+                    type="button"
+                    className={clsx("btn w-full justify-center", "btn-primary", roundLoading && "opacity-70")}
+                    onClick={handleStartRound}
+                    disabled={roundLoading}
+                    data-testid="cutgames-start-round"
+                  >
+                    {startLabel}
+                  </button>
+                  {round && !round.result && (
+                    <button
+                      type="button"
+                      className="btn btn-ghost w-full justify-center text-neutral-300"
+                      onClick={resetRound}
+                      data-testid="cutgames-reset-round"
+                    >
+                      Cancel round
+                    </button>
+                  )}
+                  {roundError && <p className="text-sm text-rose-300" data-testid="cutgames-round-error">{roundError}</p>}
+                </div>
+
+                {catalog && (
+                  <dl className="grid grid-cols-2 gap-3 text-sm text-neutral-300" data-testid="cutgames-stats">
+                    <div>
+                      <dt className="text-neutral-500">Good scenes</dt>
+                      <dd className="text-lg font-semibold text-neutral-100">{catalog.goodCount}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-neutral-500">Bad scenes</dt>
+                      <dd className="text-lg font-semibold text-neutral-100">{catalog.badCount}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-neutral-500">Tweetrunk</dt>
+                      <dd className="text-lg font-semibold text-neutral-100">{catalog.tweetrunkCount}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-neutral-500">Lesson tags</dt>
+                      <dd className="text-lg font-semibold text-neutral-100">{catalog.lessonsByTagCount}</dd>
+                    </div>
+                  </dl>
+                )}
+              </aside>
+
+              <BeatPitfallPicker
+                beat={selection.beat}
+                pitfall={selection.datasetMode === "bad" ? selection.pitfall : undefined}
+                pitfallDisabled={selection.datasetMode !== "bad"}
+                introductionCount={introductionCount}
+                initialBeats={beatOptions}
+                onChange={({ beat: nextBeat, pitfall: nextPitfall }) =>
+                  setSelection((prev) => ({
+                    ...prev,
+                    beat: nextBeat,
+                    pitfall: prev.datasetMode === "bad" ? nextPitfall : undefined,
+                  }))
+                }
+              />
+            </div>
+
+            <main className="space-y-6" data-testid="cutgames-main-panel">
+              {round ? (
+                <section className="card space-y-4" data-testid="cutgames-round-card">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <h2 className="text-neutral-100">Round in progress</h2>
+                      <p className="text-sm text-neutral-400">
+                        {describeBeat(round.selection.beat)} · {round.selection.datasetMode === "bad" ? describePitfall(round.selection.pitfall) : "Celebrate strong cuts"}
+                      </p>
+                    </div>
+                    <div className="text-sm text-neutral-300" data-testid="cutgames-round-progress-text">
+                      {answeredCount}/{round.items.length} complete · {skipCount} skipped
+                    </div>
+                  </div>
+
+                  <div className="progress-track" data-testid="cutgames-progress">
+                    <div
+                      className="progress-bar"
+                      style={{ width: `${Math.max(1, Math.round(((round.currentIndex + 1) / round.items.length) * 100))}%` }}
+                    />
+                  </div>
+
+                  <article className="space-y-4 rounded-2xl bg-neutral-900/60 p-5" data-testid={`cutgames-scene-${currentItem?.id ?? "none"}`}>
+                    <header className="flex flex-wrap items-center justify-between gap-3">
+                      <div className="text-sm text-neutral-400">
+                        Scene #{currentItem?.id ?? "?"}
+                        {currentItem?.beat && (
+                          <span className="ml-2 inline-flex items-center rounded-full border border-neutral-700 px-2 py-1 text-xs uppercase tracking-wide text-neutral-300">
+                            {formatKey(currentItem.beat)}
+                          </span>
+                        )}
+                        {currentItem?.pitfall && (
+                          <span className="ml-2 inline-flex items-center rounded-full border border-rose-700/60 px-2 py-1 text-xs uppercase tracking-wide text-rose-200">
+                            {formatKey(currentItem.pitfall)}
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-2 text-xs text-neutral-500">
+                        <button type="button" className="btn btn-ghost px-3 py-1 text-xs" onClick={handlePrev} disabled={round.currentIndex === 0} data-testid="cutgames-prev-button">
+                          Prev
+                        </button>
+                        <span>
+                          {round.currentIndex + 1} / {round.items.length}
+                        </span>
+                        <button
+                          type="button"
+                          className="btn btn-ghost px-3 py-1 text-xs"
+                          onClick={handleNext}
+                          disabled={round.currentIndex >= round.items.length - 1}
+                          data-testid="cutgames-next-button"
+                        >
+                          Next
+                        </button>
+                      </div>
+                    </header>
+                    <div className="scene text-neutral-100" data-testid="cutgames-scene-text">
+                      {currentItem?.scene ?? "Pick a round to see practice scenes."}
+                    </div>
+                  </article>
+
+                  <div className="space-y-2" data-testid="cutgames-response-block">
+                    <label htmlFor="cutgames-response" className="text-sm font-medium text-neutral-200">
+                      Your response
+                    </label>
+                  <textarea
+                    id="cutgames-response"
+                    value={currentAnswer}
+                    onChange={(event) => handleAnswerChange(event.target.value)}
+                    rows={5}
+                    className="w-full rounded-2xl border border-neutral-700 bg-neutral-900/80 px-3 py-3 text-sm text-neutral-100 focus:border-neutral-400 focus:outline-none"
+                    placeholder={
+                      round.selection.datasetMode === "bad"
+                        ? "Diagnose the pitfall and propose a fix."
+                        : "Name the beat, praise what works, or extend the cut."
+                    }
+                    disabled={roundLocked}
+                    data-testid="cutgames-response"
+                  />
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-3" data-testid="cutgames-round-actions">
+                    <button
+                      type="button"
+                      className="btn btn-ghost"
+                      onClick={handleSkip}
+                      disabled={roundLocked}
+                      data-testid="cutgames-skip-button"
+                    >
+                      Skip
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-primary"
+                      onClick={handleComplete}
+                      disabled={roundLocked || !currentAnswer.trim()}
+                      data-testid="cutgames-complete-button"
+                    >
+                      Complete
+                    </button>
+                    <div className="ml-auto flex flex-wrap gap-2 text-xs text-neutral-500">
+                      <span>Mode: {round.selection.gameMode}</span>
+                      <span>Deck: {round.selection.datasetMode === "bad" ? "Fix Bad" : "Celebrate Good"}</span>
+                    </div>
+                  </div>
+
+                  <footer className="flex flex-wrap items-center gap-3 pt-2" data-testid="cutgames-submit-row">
+                    <button
+                      type="button"
+                      className="btn w-full justify-center md:w-auto"
+                      onClick={handleSubmitRound}
+                      disabled={round.submitting || roundLocked}
+                      data-testid="cutgames-submit-button"
+                    >
+                      {round.submitting ? "Scoring…" : "Submit round"}
+                    </button>
+                    {round.submitError && <span className="text-sm text-rose-300">{round.submitError}</span>}
+                  </footer>
+                </section>
+              ) : (
+                <section className="card space-y-4" data-testid="cutgames-placeholder">
+                  <h2 className="text-neutral-100">Ready when you are</h2>
+                  <p className="text-neutral-300">
+                    Build your round on the left, then press <span className="kbd">R</span> or the Start button. We'll queue up {ROUND_SIZE} scenes that match your filters.
+                  </p>
+                  <p className="text-sm text-neutral-500">
+                    Skipping a scene teaches the shadow stack what to serve next. Complete a round to see your personalized style report.
+                  </p>
+                </section>
+              )}
+
+              {showResults && round?.result && (
+                <section className="card space-y-4" data-testid="cutgames-results">
+                  <header className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <h2 className="text-neutral-100">Round results</h2>
+                      <p className="text-sm text-neutral-400">
+                        Score {round.result.score.toFixed(2)} · Rubric {round.result.rubricScore ?? "—"}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      className="btn btn-primary"
+                      onClick={() => {
+                        resetRound();
+                        void handleStartRound();
+                      }}
+                      data-testid="cutgames-play-again"
+                    >
+                      Play again
+                    </button>
+                  </header>
+
+                  <div className="rounded-2xl border border-neutral-700 bg-neutral-900/60 p-5" data-testid="cutgames-style-report">
+                    <h3 className="text-lg font-semibold text-neutral-100">Style report</h3>
+                    {round.result.notes.length ? (
+                      <ul className="mt-3 space-y-2 text-sm text-neutral-300" data-testid="cutgames-style-notes">
+                        {round.result.notes.map((note, index) => (
+                          <li key={`note-${index}`} className="rounded-xl bg-neutral-900/80 px-3 py-2">
+                            {note}
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className="mt-3 text-sm text-neutral-400">No style notes this time—clean cut!</p>
+                    )}
+                  </div>
+
+                  <dl className="grid gap-4 text-sm text-neutral-300" data-testid="cutgames-results-meta">
+                    <div>
+                      <dt className="text-neutral-500">Deck</dt>
+                      <dd>{round.selection.datasetMode === "bad" ? "Bad scenes lab" : "Good scenes celebration"}</dd>
+                    </div>
+                    {round.selection.beat && (
+                      <div>
+                        <dt className="text-neutral-500">Beat focus</dt>
+                        <dd>{formatKey(round.selection.beat)}</dd>
+                      </div>
+                    )}
+                    {round.selection.pitfall && (
+                      <div>
+                        <dt className="text-neutral-500">Pitfall focus</dt>
+                        <dd>{formatKey(round.selection.pitfall)}</dd>
+                      </div>
+                    )}
+                    {round.result.level && (
+                      <div>
+                        <dt className="text-neutral-500">Level</dt>
+                        <dd>{round.result.level}</dd>
+                      </div>
+                    )}
+                    {round.result.xp && (
+                      <div>
+                        <dt className="text-neutral-500">XP total</dt>
+                        <dd>{round.result.xp}</dd>
+                      </div>
+                    )}
+                  </dl>
+
+                  <div className="rounded-2xl border border-neutral-800 bg-neutral-900/40 p-4" data-testid="cutgames-round-recap">
+                    <h3 className="text-sm font-semibold text-neutral-200">Round recap</h3>
+                    <ul className="mt-3 space-y-2 text-sm text-neutral-400">
+                      {round.items.map((item) => {
+                        const entry = round.answers[Number(item.id)];
+                        const status = entry?.skipped
+                          ? "Skipped"
+                          : entry && entry.answer.trim().length > 0
+                          ? "Completed"
+                          : "Unanswered";
+                        return (
+                          <li key={`recap-${item.id}`} className="flex flex-wrap items-center justify-between gap-2 rounded-xl bg-neutral-900/60 px-3 py-2">
+                            <div>
+                              <span className="text-neutral-200">#{item.id}</span>
+                              {item.beat && <span className="ml-2 text-neutral-400">{formatKey(item.beat)}</span>}
+                            </div>
+                            <span className={clsx("text-xs font-semibold", status === "Skipped" ? "text-rose-300" : status === "Completed" ? "text-emerald-300" : "text-neutral-500")}>{status}</span>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </div>
+                </section>
+              )}
+            </main>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/CutGamesPlay.tsx
+++ b/src/pages/CutGamesPlay.tsx
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useState } from "react";
+import "../styles/cutgames.css";
+import ModePicker from "../components/cutgames/ModePicker";
+import BeatPitfallPicker from "../components/cutgames/BeatPitfallPicker";
+import RoundEngine from "../components/cutgames/RoundEngine";
+import ResultsScreen from "../components/cutgames/ResultsScreen";
+
+type ModeName = "Name" | "Missing" | "Fix" | "Order" | "Highlight" | "Why";
+
+type RoundResult = {
+  score: number;
+  notes: string[];
+  id: string;
+  summary: { completed: number; skipped: number };
+  payload: any;
+};
+
+type Phase = "select" | "play" | "results";
+
+export default function CutGamesPlay() {
+  const [mode, setMode] = useState<ModeName>("Name");
+  const [beat, setBeat] = useState<string | undefined>();
+  const [pitfall, setPitfall] = useState<string | undefined>();
+  const [roundKey, setRoundKey] = useState(0);
+  const [phase, setPhase] = useState<Phase>("select");
+  const [results, setResults] = useState<RoundResult | null>(null);
+
+  const startRound = useCallback(() => {
+    setPhase("play");
+    setResults(null);
+    setRoundKey((key) => key + 1);
+  }, []);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (phase !== "select") return;
+      if (event.key.toLowerCase() === "r") {
+        event.preventDefault();
+        startRound();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [phase, startRound]);
+
+  const handleDone = (roundResult: RoundResult) => {
+    setResults(roundResult);
+    setPhase("results");
+  };
+
+  return (
+    <div className="cut-shell" data-testid="cut-games-root">
+      <div className="cut-container space-y-4">
+        <header className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">Cut Games</h1>
+          <div className="text-sm text-neutral-400">Projects From The Projects</div>
+        </header>
+
+        {phase === "select" && (
+          <>
+            <ModePicker value={mode} onChange={(next) => setMode(next as ModeName)} />
+            <BeatPitfallPicker
+              beat={beat}
+              pitfall={pitfall}
+              onChange={(next) => {
+                setBeat(next.beat);
+                setPitfall(next.pitfall);
+              }}
+            />
+            <div className="flex gap-2">
+              <button className="btn btn-primary" onClick={startRound} data-testid="btn-start">
+                Start Round
+              </button>
+              <button
+                className="btn btn-ghost"
+                onClick={() => {
+                  setBeat(undefined);
+                  setPitfall(undefined);
+                }}
+              >
+                Clear
+              </button>
+            </div>
+            <div className="text-xs text-neutral-400">
+              Pro-tip: press <span className="kbd">R</span> to start.
+            </div>
+          </>
+        )}
+
+        {phase === "play" && (
+          <RoundEngine
+            key={roundKey}
+            modeName={mode}
+            beat={beat}
+            pitfall={pitfall}
+            onDone={handleDone}
+          />
+        )}
+
+        {phase === "results" && results && (
+          <ResultsScreen
+            score={results.score}
+            notes={results.notes}
+            summary={results.summary}
+            payload={results.payload}
+            onRestart={() => {
+              setPhase("select");
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/styles/cutgames.css
+++ b/src/styles/cutgames.css
@@ -1,0 +1,18 @@
+:root { --card: rgba(20,20,24,0.7); --accent: #7df9ff; }
+.cut-shell { @apply min-h-screen bg-neutral-950 text-neutral-100; background-image:
+ radial-gradient(ellipse at 20% 10%, rgba(125,249,255,0.12), transparent 40%),
+ radial-gradient(ellipse at 80% 30%, rgba(255,138,76,0.08), transparent 45%); }
+.cut-container { @apply max-w-5xl mx-auto px-4 py-8; }
+.card { background: var(--card); @apply rounded-2xl p-5 border border-neutral-800 shadow-lg; backdrop-filter: blur(6px); }
+.card h2 { @apply text-xl font-semibold; }
+.btn { @apply inline-flex items-center justify-center rounded-xl px-4 py-2 border border-neutral-700 hover:border-neutral-500 transition; }
+.btn-primary { @apply bg-neutral-100 text-neutral-900 hover:bg-white; }
+.btn-ghost { @apply hover:bg-neutral-800/40; }
+.chip { @apply inline-flex items-center gap-1 rounded-full px-3 py-1 border border-neutral-700 text-sm; }
+.chip.is-on { border-color: var(--accent); color: var(--accent); }
+.kbd { @apply px-2 py-1 border border-neutral-700 rounded-md text-xs; }
+.scene { @apply whitespace-pre-wrap leading-7 selection:bg-neutral-700/60; }
+.progress-track { @apply h-2 w-full bg-neutral-800 rounded-full overflow-hidden; }
+.progress-bar { @apply h-2 bg-neutral-200 transition-all; }
+.pulse { animation: pulse 1.4s infinite; }
+@keyframes pulse { 0%{opacity:.5} 50%{opacity:1} 100%{opacity:.5} }


### PR DESCRIPTION
## Summary
- add a Cut Games play page that coordinates setup, round play, and results handling
- register the /play/cut-games route in the app router so the flow is reachable

## Testing
- npm run build *(fails: vite binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eb1a08aa6c832fb49d56e4f64f4a38