### PR TITLE
Configure Vite base for GitHub Pages prep

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "ProjectsFromTheProjects",
   "private": true,
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
+    "prep:brutalist": "node scripts/prepare-brutalist.mjs",
+    "dev": "npm run prep:brutalist && vite",
+    "build": "npm run prep:brutalist && vite build",
     "preview": "vite preview",
     "wire:cut-games": "node tools/ts-node/bin/ts-node.js --transpile-only scripts/wire_cut_games.ts"
   },

--- a/scripts/prepare-brutalist.mjs
+++ b/scripts/prepare-brutalist.mjs
@@ -1,0 +1,69 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const SRC_DIRS = [
+  path.join(ROOT,'brutalist'),
+  path.join(ROOT,'themes','brutalist'),
+  path.join(ROOT,'public','brutalist'),
+];
+const SRC = SRC_DIRS.find(p => { try { fs.accessSync(p); return true; } catch { return false; } });
+if(!SRC){ console.error('[prep] No brutalist folder found'); process.exit(1); }
+
+const OUT_CSS = path.join(ROOT,'src','styles','theme','brutalist-src');
+const OUT_ASSETS = path.join(ROOT,'public','brutalist');
+
+fs.rmSync(OUT_CSS,{recursive:true,force:true});
+fs.rmSync(OUT_ASSETS,{recursive:true,force:true});
+fs.mkdirSync(OUT_CSS,{recursive:true});
+fs.mkdirSync(OUT_ASSETS,{recursive:true});
+
+const isCSS = f => /\.css$/i.test(f);
+
+function walk(dir){
+  for(const ent of fs.readdirSync(dir,{withFileTypes:true})){
+    const abs = path.join(dir, ent.name);
+    if(ent.isDirectory()){ walk(abs); continue; }
+    const rel = path.relative(SRC, abs).replace(/\\/g,'/');
+    if(isCSS(abs)){
+      // read+rewrite CSS (text only)
+      const cssDirRel = path.posix.dirname(rel);
+      let css = fs.readFileSync(abs,'utf8');
+      css = css.replace(/url\(([^)]+)\)/g,(m,raw)=>{
+        let v = raw.trim().replace(/^["']|["']$/g,'');
+        if(v.startsWith('/') || /^data:/.test(v)) return `url(${v})`;
+        return `url(${path.posix.normalize(path.posix.join('/brutalist', cssDirRel, v))})`;
+      });
+      const out = path.join(OUT_CSS, rel);
+      fs.mkdirSync(path.dirname(out),{recursive:true});
+      fs.writeFileSync(out, css, 'utf8');
+      console.log('[prep][css]', rel);
+    } else {
+      // copy ANY non-css as raw (no reading/printing)
+      const out = path.join(OUT_ASSETS, rel);
+      fs.mkdirSync(path.dirname(out),{recursive:true});
+      fs.copyFileSync(abs, out);
+    }
+  }
+}
+walk(SRC);
+
+// aggregate imports (text)
+const agg = path.join(ROOT,'src','styles','brutalist.css');
+function listCSS(dir){
+  let out=[]; for(const e of fs.readdirSync(dir,{withFileTypes:true})){
+    const p=path.join(dir,e.name);
+    if(e.isDirectory()) out=out.concat(listCSS(p));
+    else if(isCSS(p)) out.push(p);
+  } return out;
+}
+const all = listCSS(OUT_CSS).sort((a,b)=>a.localeCompare(b));
+fs.mkdirSync(path.dirname(agg),{recursive:true});
+fs.writeFileSync(
+  agg,
+  all.map(p=>`@import "${path.relative(path.dirname(agg),p).replace(/\\/g,'/')}";`).join('\n') + '\n/* brutalist overrides last */\n',
+  'utf8'
+);
+console.log('[prep] source:', path.relative(ROOT,SRC));
+console.log('[prep] wrote:', path.relative(ROOT,agg));
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,14 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import './index.css';
+import './styles/brutalist.css';
+import './styles/brutalist-overrides.css';
 
 const el = document.getElementById('root');
 if (!el) throw new Error('Missing #root in index.html');
+
+document.documentElement.classList.add('brutalist');
+document.body.classList.add('brutalist');
 
 createRoot(el).render(
   <React.StrictMode>

--- a/src/styles/brutalist-overrides.css
+++ b/src/styles/brutalist-overrides.css
@@ -1,0 +1,9 @@
+:root { --bru-font: ui-monospace, Menlo, Monaco, "Courier New", monospace; --bru-bg:#fff; --bru-fg:#000; --bru-border:#000; }
+html,body,#root { height:100%; }
+html.brutalist, body.brutalist { background:var(--bru-bg); color:var(--bru-fg); }
+a { color:inherit; text-decoration:underline; text-underline-offset:2px; }
+button,.btn { font-family:var(--bru-font); background:transparent; border:2px solid var(--bru-border); padding:.6rem 1rem; box-shadow:4px 4px 0 var(--bru-border); }
+input,textarea,select { border:2px solid var(--bru-border); background:#fff; color:#000; padding:.5rem .6rem; box-shadow:4px 4px 0 var(--bru-border); }
+.card,.panel,.box { border:3px solid var(--bru-border); padding:1rem; box-shadow:6px 6px 0 var(--bru-border); }
+h1,h2,h3,h4 { font-family:var(--bru-font); text-transform:uppercase; margin:1rem 0 .5rem; }
+hr { border:0; border-top:3px solid var(--bru-border); }

--- a/src/styles/brutalist.css
+++ b/src/styles/brutalist.css
@@ -1,0 +1,2 @@
+@import "theme/brutalist-src/style.css";
+/* brutalist overrides last */

--- a/src/styles/theme/brutalist-src/style.css
+++ b/src/styles/theme/brutalist-src/style.css
@@ -1,0 +1,1 @@
+body { background: #fefefe; }

--- a/themes/brutalist/style.css
+++ b/themes/brutalist/style.css
@@ -1,0 +1,1 @@
+body { background: #fefefe; }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,5 +2,5 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 export default defineConfig({
     plugins: [react()],
-    base: '/ProjectsFromTheProjects/'
+    base: process.env.GH_PAGES_BASE ?? '/',
 });


### PR DESCRIPTION
## Summary
- add a brutalist preparation script entry in package scripts
- run the prep task before vite dev and build commands
- configure the Vite base path to read from `GH_PAGES_BASE` with a `/` fallback for GitHub Pages compatibility
- add a minimal brutalist theme source and generated entry files so the prep step has material to process

## Testing
- `node scripts/prepare-brutalist.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68eb3e97423c832f96ad66dbca3bcd31