### PR TITLE
Add first-run welcome onboarding flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,8 +14,11 @@ import { ToastHost } from "./components/ToastHost";
 import { KeyOverlay } from "./components/KeyOverlay";
 import { Footer } from "./components/Footer";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import Welcome from "./pages/Welcome";
+import { useFirstRun } from "./state/useFirstRun";
 
 export default function App() {
+  const seenWelcome = useFirstRun((state) => state.seenWelcome);
   return (
     <ErrorBoundary>
       <BrowserRouter>
@@ -24,7 +27,8 @@ export default function App() {
           <ToastHost />
           <KeyOverlay />
           <Routes>
-            <Route path="/" element={<Home />} />
+            <Route path="/" element={seenWelcome ? <Home /> : <Welcome />} />
+            <Route path="/welcome" element={<Welcome />} />
             <Route path="/pack/:id" element={<PackPage />} />
             <Route path="/practice" element={<PracticeHub />} />
             <Route path="/practice/:id" element={<PracticePage />} />

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { useProgress } from "../state/useProgress";
 import { useToast } from "../state/useToast";
+import { useFirstRun } from "../state/useFirstRun";
 
 export default function Settings() {
   const resetProgress = useProgress((state) => state.resetProgress);
   const push = useToast((state) => state.push);
+  const resetWelcome = useFirstRun((state) => state.resetWelcome);
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-6 space-y-4">
@@ -27,6 +29,16 @@ export default function Settings() {
           }}
         >
           Reset progress
+        </button>
+        <button
+          type="button"
+          className="mt-3 ml-2 rounded-md border border-neutral-300 px-3 py-2 text-sm transition hover:bg-neutral-100 focus:outline-none focus:ring dark:border-neutral-700 dark:hover:bg-neutral-800"
+          onClick={() => {
+            resetWelcome();
+            alert("Welcome screen will show next time.");
+          }}
+        >
+          Reset welcome
         </button>
       </section>
     </main>

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from "react";
+import { useNavigate, Link } from "react-router-dom";
+import { useFirstRun } from "../state/useFirstRun";
+import { loadAllPacksSafe, type Pack } from "../data/loadAllPacksSafe";
+
+export default function Welcome() {
+  const navigate = useNavigate();
+  const markSeen = useFirstRun((s) => s.markSeen);
+  const [packs, setPacks] = useState<Pack[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [starting, setStarting] = useState(false);
+
+  useEffect(() => {
+    loadAllPacksSafe()
+      .then(({ packs: loaded }) => setPacks(loaded))
+      .catch((e) => setError(String(e)));
+  }, []);
+
+  function pickAutoPack(available: Pack[]): Pack | null {
+    if (!available.length) return null;
+    return [...available].sort((a, b) => b.entries.length - a.entries.length)[0];
+  }
+
+  async function start() {
+    if (!packs || !packs.length) return;
+    setStarting(true);
+    const selected = pickAutoPack(packs);
+    if (!selected) {
+      setStarting(false);
+      return;
+    }
+    markSeen();
+    navigate(`/practice/${selected.id}`);
+  }
+
+  if (error) {
+    return (
+      <main className="mx-auto max-w-5xl space-y-4 px-4 py-6">
+        <h1 className="text-2xl font-semibold">Welcome</h1>
+        <p className="mt-2 text-sm text-red-700">Couldn’t load packs: {error}</p>
+        <Link className="text-sm underline" to="/">
+          Try Home
+        </Link>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl space-y-5 px-6 py-8">
+      <h1 className="text-3xl font-semibold">The Good Word</h1>
+      <p className="text-neutral-700 dark:text-neutral-300">Words, but exact.</p>
+
+      <section className="rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+        <h2 className="mb-2 text-lg font-semibold">How it works</h2>
+        <ol className="ml-5 list-decimal space-y-1 text-sm text-neutral-800 dark:text-neutral-200">
+          <li>
+            See a card: <b>WORD</b>, its origin story, and the literal meaning.
+          </li>
+          <li>
+            Choose: <b>I used it</b> (+10), <b>I learned it</b> (+5), or <b>Skip</b> (0).
+          </li>
+          <li>Clear packs. Keep what matters. No fluff.</li>
+        </ol>
+      </section>
+
+      <div className="text-sm text-neutral-600 dark:text-neutral-300">
+        {packs === null ? "Loading packs…" : `${packs.length} pack(s) detected`}
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          className="rounded-md border border-neutral-300 px-4 py-2 text-sm underline transition hover:bg-neutral-100 focus:outline-none focus:ring disabled:opacity-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+          onClick={start}
+          disabled={!packs || !packs.length || starting}
+          aria-label="Start practicing now"
+        >
+          {starting ? "Starting…" : "Start"}
+        </button>
+        <Link
+          to="/"
+          className="rounded-md border border-neutral-300 px-4 py-2 text-sm underline transition hover:bg-neutral-100 focus:outline-none focus:ring dark:border-neutral-700 dark:hover:bg-neutral-800"
+          onClick={() => useFirstRun.getState().markSeen()}
+        >
+          Skip for now
+        </Link>
+      </div>
+
+      <p className="text-xs text-neutral-600 dark:text-neutral-400">
+        Tip: You can reset this welcome screen in <Link className="underline" to="/settings">
+          Settings
+        </Link>
+        .
+      </p>
+    </main>
+  );
+}

--- a/src/state/useFirstRun.ts
+++ b/src/state/useFirstRun.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+type FirstRunState = {
+  seenWelcome: boolean;
+  markSeen: () => void;
+  resetWelcome: () => void;
+};
+
+export const useFirstRun = create<FirstRunState>()(
+  persist(
+    (set) => ({
+      seenWelcome: false,
+      markSeen: () => set({ seenWelcome: true }),
+      resetWelcome: () => set({ seenWelcome: false }),
+    }),
+    { name: "good-word:first-run:v1", storage: createJSONStorage(() => localStorage) }
+  )
+);


### PR DESCRIPTION
## Summary
- add a persisted first-run store to track whether the welcome flow has been seen
- introduce a one-screen welcome experience that auto-selects the largest pack and links to practice
- gate the root route on first-run state and expose a reset control in Settings

## Testing
- npm run build *(fails: rollup could not resolve "zod" from existing data utilities)*

------
https://chatgpt.com/codex/tasks/task_e_68ec94193190832f8882ffd25f7a83cb