### PR TITLE
Add seeded RNG for deterministic gameplay randomness

### DIFF
--- a/src/pages/PlayMCQ.tsx
+++ b/src/pages/PlayMCQ.tsx
@@ -6,13 +6,7 @@ import { useProgress } from "../state/useProgress";
 import type { WordEntry } from "../data/validateAndNormalize";
 import { ProgressBar } from "../components/ProgressBar";
 import { useToast } from "../state/useToast";
-
-function shuffle<T>(input: T[]): T[] {
-  return input
-    .map((value) => ({ value, sort: Math.random() }))
-    .sort((a, b) => a.sort - b.sort)
-    .map(({ value }) => value);
-}
+import { rng } from "../utils/rng";
 
 export default function PlayMCQ() {
   const { id } = useParams();
@@ -49,8 +43,13 @@ export default function PlayMCQ() {
 
   const options = useMemo(() => {
     if (!current) return [];
-    const distractors = shuffle(entries.filter((entry) => entry.word !== current.word)).slice(0, 3);
-    return shuffle([current.literal, ...distractors.map((entry) => entry.literal)]).slice(0, 4);
+    const random = rng();
+    const distractors = random
+      .shuffle(entries.filter((entry) => entry.word !== current.word))
+      .slice(0, 3);
+    return random
+      .shuffle([current.literal, ...distractors.map((entry) => entry.literal)])
+      .slice(0, 4);
   }, [current, entries]);
 
   useEffect(() => {

--- a/src/state/useToast.ts
+++ b/src/state/useToast.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { rng } from "../utils/rng";
 
 type Toast = { id: number; text: string };
 
@@ -12,7 +13,7 @@ export const useToast = create<ToastStore>((set) => ({
   toasts: [],
   push: (text) =>
     set((state) => {
-      const id = Date.now() + Math.random();
+      const id = Date.now() + rng().random();
       if (typeof window !== "undefined") {
         window.setTimeout(() => useToast.getState().remove(id), 2000);
       }

--- a/src/utils/rng.ts
+++ b/src/utils/rng.ts
@@ -1,0 +1,82 @@
+// Mulberry32 PRNG — small, fast, decent quality for UI randomness.
+function mulberry32(seed: number) {
+  let t = seed >>> 0;
+  return function () {
+    t += 0x6d2b79f5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function hashString(str: string): number {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function seedFromCrypto(): number {
+  const arr = new Uint32Array(1);
+  crypto.getRandomValues(arr);
+  return arr[0] || (Date.now() & 0xffffffff);
+}
+
+export type RNG = {
+  seed: string; // human-readable
+  random: () => number;
+  randint: (minIncl: number, maxIncl: number) => number;
+  pick: <T>(arr: T[]) => T;
+  shuffle: <T>(arr: T[]) => T[];
+};
+
+export function createRNG(seedStr: string): RNG {
+  const s = hashString(seedStr);
+  const r = mulberry32(s);
+  const api: RNG = {
+    seed: seedStr,
+    random: r,
+    randint: (min, max) => {
+      const a = Math.ceil(min);
+      const b = Math.floor(max);
+      return Math.floor(r() * (b - a + 1)) + a;
+    },
+    pick: (arr) => arr[Math.floor(r() * (arr.length || 1))],
+    shuffle: (arr) => {
+      const a = arr.slice();
+      for (let i = a.length - 1; i > 0; i--) {
+        const j = Math.floor(r() * (i + 1));
+        [a[i], a[j]] = [a[j], a[i]];
+      }
+      return a;
+    },
+  };
+  return api;
+}
+
+// Session seed management — lives for the tab/session.
+const KEY = "good-word:session-seed";
+
+export function getSessionSeed(): string {
+  const url = new URL(location.href);
+  const override = url.searchParams.get("seed");
+  if (override) {
+    sessionStorage.setItem(KEY, override);
+    return override;
+  }
+  const existing = sessionStorage.getItem(KEY);
+  if (existing) return existing;
+  const fresh = `gw-${seedFromCrypto().toString(16)}`;
+  sessionStorage.setItem(KEY, fresh);
+  return fresh;
+}
+
+// Singleton for convenience
+let _rng: RNG | null = null;
+export function rng(): RNG {
+  if (_rng) return _rng;
+  _rng = createRNG(getSessionSeed());
+  return _rng;
+}


### PR DESCRIPTION
## Summary
- add a seeded RNG utility that stores the session seed and exposes random helpers
- update the deck hook, multiple-choice options, and toast IDs to use the shared RNG

## Testing
- npm run build *(fails: existing missing dependency for "zod")*

------
https://chatgpt.com/codex/tasks/task_e_68ec98ef3714832f96061165c416bac4