### PR TITLE
Align Cut Games play page with provided spec

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import PlaySee from "./pages/PlaySee";
 import PlayMCQ from "./pages/PlayMCQ";
 import PlaySlot from "./pages/PlaySlot";
 import NotFound from "./pages/NotFound";
+import CutGames from "./pages/CutGames";
 import { Header } from "./components/Header";
 import { ToastHost } from "./components/ToastHost";
 import { KeyOverlay } from "./components/KeyOverlay";
@@ -32,6 +33,7 @@ export default function App() {
             <Route path="/pack/:id" element={<PackPage />} />
             <Route path="/practice" element={<PracticeHub />} />
             <Route path="/practice/:id" element={<PracticePage />} />
+            <Route path="/play/cut-games" element={<CutGames />} />
             <Route path="/play/:id/see" element={<PlaySee />} />
             <Route path="/play/:id/mcq" element={<PlayMCQ />} />
             <Route path="/play/:id/slot" element={<PlaySlot />} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -29,6 +29,9 @@ export function Header() {
           <NavLink to="/practice" className={navClass}>
             Practice
           </NavLink>
+          <NavLink to="/play/cut-games" className={navClass}>
+            Cut Games
+          </NavLink>
           <NavLink to="/settings" className={navClass}>
             Settings
           </NavLink>

--- a/src/components/cutgames/BeatPitfallPicker.tsx
+++ b/src/components/cutgames/BeatPitfallPicker.tsx
@@ -1,131 +1,42 @@
-import { useEffect, useMemo, useState } from "react";
-import clsx from "clsx";
-import { CatalogBeat, fetchBeats } from "../../lib/cutGamesClient";
-
-type BeatRow = { beat: string; total: number };
-
-type Props = {
-  beat?: string;
-  pitfall?: string;
-  pitfallDisabled?: boolean;
-  introductionCount?: number;
-  initialBeats?: CatalogBeat[];
-  onChange: (next: { beat?: string; pitfall?: string }) => void;
-};
-
-const slugify = (value: string) => value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
-
-const formatKey = (value: string) =>
-  value
-    .split(/[_-]/)
-    .filter(Boolean)
-    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
-    .join(" ");
-
-const normalizeBeats = (rows?: CatalogBeat[] | BeatRow[] | null): BeatRow[] => {
-  if (!Array.isArray(rows)) return [];
-  return rows
-    .map((row) => ({ beat: row.beat, total: row.total ?? 0 }))
-    .filter((row) => Boolean(row.beat))
-    .sort((a, b) => b.total - a.total);
-};
+import { useEffect, useState } from "react";
+import { fetchBeats } from "../../lib/cutGamesClient";
 
 export default function BeatPitfallPicker({
-  beat,
-  pitfall,
-  pitfallDisabled = false,
-  introductionCount,
-  initialBeats,
-  onChange,
-}: Props) {
-  const [beatsIndex, setBeatsIndex] = useState<BeatRow[]>(() => normalizeBeats(initialBeats));
-
-  useEffect(() => {
-    if (!initialBeats || initialBeats.length === 0) return;
-    setBeatsIndex(normalizeBeats(initialBeats));
-  }, [initialBeats]);
-
-  useEffect(() => {
-    if (initialBeats && initialBeats.length > 0) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const beatsResponse = await fetchBeats();
-        if (cancelled) return;
-        setBeatsIndex(normalizeBeats(beatsResponse));
-      } catch (error) {
-        if (!cancelled) setBeatsIndex([]);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [initialBeats]);
-
-  const topBeats = useMemo(() => beatsIndex.slice(0, 40), [beatsIndex]);
+  beat, pitfall, onChange,
+}:{ beat?:string; pitfall?:string; onChange:(v:{beat?:string; pitfall?:string})=>void }) {
+  const [beatsIndex, setBeatsIndex] = useState<{beat:string; total:number}[]>([]);
+  useEffect(()=>{ (async()=>{
+    try {
+      const raw = await fetchBeats();
+      const entries = Array.isArray(raw) ? raw : Object.entries(raw?.beats ?? raw ?? {}).map(([k,v]:any)=>({beat:k, total:Number(v)||0}));
+      entries.sort((a,b)=> b.total-a.total);
+      setBeatsIndex(entries);
+    } catch {}
+  })(); }, []);
 
   return (
-    <div className="card space-y-4" data-testid="cutgames-beat-pitfall-picker">
-      <h2 className="text-neutral-100">Optional filters</h2>
-      <div className="grid gap-4 sm:grid-cols-2">
-        <div className="space-y-2">
-          <label className="block text-sm font-medium text-neutral-200">Beat</label>
-          <div
-            className="flex max-h-40 flex-wrap gap-2 overflow-auto rounded-xl border border-neutral-800 p-1"
-            data-testid="cutgames-beat-choices"
-          >
-            <button
-              type="button"
-              className={clsx("chip transition", !beat && "is-on")}
-              onClick={() => onChange({ beat: undefined, pitfall })}
-              data-testid="cutgames-beat-any"
-            >
-              Any beat
-            </button>
-            {topBeats.map((entry) => {
-              const isActive = beat === entry.beat;
-              return (
-                <button
-                  key={entry.beat}
-                  type="button"
-                  className={clsx("chip transition", isActive && "is-on")}
-                  onClick={() =>
-                    onChange({ beat: isActive ? undefined : entry.beat, pitfall })
-                  }
-                  data-testid={`cutgames-beat-${slugify(entry.beat)}`}
-                  title={`${entry.total} scenes`}
-                >
-                  {formatKey(entry.beat)}
-                </button>
-              );
-            })}
+    <div className="card" data-testid="beat-pitfall-picker">
+      <h2 className="mb-3">Optional filters</h2>
+      <div className="grid sm:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm mb-2">Beat</label>
+          <div className="flex flex-wrap gap-2 max-h-40 overflow-auto p-1" style={{border:"1px solid #242428", borderRadius:"12px"}}>
+            {beatsIndex.slice(0,40).map(b=>(
+              <button key={b.beat}
+                className={`chip ${beat===b.beat?"is-on":""}`}
+                onClick={()=>onChange({ beat: beat===b.beat ? undefined : b.beat, pitfall })} title={`${b.total} items`}>
+                {b.beat}
+              </button>
+            ))}
           </div>
-          {beat && (
-            <p className="text-xs text-neutral-400" data-testid="cutgames-intro-count">
-              {introductionCount && introductionCount > 0
-                ? `${introductionCount} introductions available for this beat`
-                : "No introductions recorded for this beat yet"}
-            </p>
-          )}
         </div>
-        <div className="space-y-2">
-          <label className="block text-sm font-medium text-neutral-200" htmlFor="cutgames-pitfall-input">
-            Pitfall (bad mode)
-          </label>
-          <input
-            id="cutgames-pitfall-input"
-            className="w-full rounded-xl border border-neutral-800 bg-neutral-900 px-3 py-2 text-sm text-neutral-100 placeholder:text-neutral-500 focus:border-neutral-500 focus:outline-none disabled:cursor-not-allowed disabled:text-neutral-500"
+        <div>
+          <label className="block text-sm mb-2">Pitfall (bad mode)</label>
+          <input className="w-full" style={{background:"#121215", border:"1px solid #242428", borderRadius:"12px", padding:".5rem .75rem"}}
             placeholder="e.g., info_dump, floaty_dialogue"
-            value={pitfall ?? ""}
-            onChange={(event) =>
-              onChange({ beat, pitfall: event.target.value ? event.target.value.toLowerCase().replace(/\s+/g, "_") : undefined })
-            }
-            disabled={pitfallDisabled}
-            data-testid="cutgames-pitfall-input"
+            value={pitfall||""}
+            onChange={e=>onChange({ beat, pitfall: e.target.value || undefined })}
           />
-          {pitfallDisabled && (
-            <p className="text-xs text-neutral-500">Pitfalls apply to bad-mode drills only.</p>
-          )}
         </div>
       </div>
     </div>

--- a/src/components/cutgames/ModePicker.tsx
+++ b/src/components/cutgames/ModePicker.tsx
@@ -1,76 +1,45 @@
 import { useEffect, useState } from "react";
 import { fetchCatalog } from "../../lib/cutGamesClient";
 
-type Mode = { name: string; desc?: string };
+type Mode = { name:string; desc?:string };
 
-type ModePickerProps = {
-  value?: string;
-  onChange: (mode: string) => void;
-};
-
-const FALLBACK_MODES: Mode[] = [
-  { name: "Name", desc: "Identify beats by name" },
-  { name: "Missing", desc: "Find what's missing" },
-  { name: "Fix", desc: "Repair weak writing" },
-  { name: "Order", desc: "Arrange beats in sequence" },
-  { name: "Highlight", desc: "Mark beats in context" },
-  { name: "Why", desc: "Explain the purpose" },
-];
-
-export default function ModePicker({ value, onChange }: ModePickerProps) {
+export default function ModePicker({ value, onChange }:{ value?:string; onChange:(m:string)=>void }) {
   const [modes, setModes] = useState<Mode[]>([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    let active = true;
-    (async () => {
-      try {
-        const catalog = await fetchCatalog();
-        if (!active) return;
-        const catalogModes: Mode[] = (catalog?.modes ?? []).map((mode: any) => ({
-          name: String(mode?.name ?? ""),
-          desc: mode?.desc,
-        }));
-        const filtered = catalogModes.filter((mode) => mode.name);
-        setModes(filtered.length ? filtered : FALLBACK_MODES);
-      } catch {
-        if (!active) return;
-        setModes(FALLBACK_MODES);
-      } finally {
-        if (active) setLoading(false);
-      }
-    })();
-    return () => {
-      active = false;
-    };
-  }, []);
+  useEffect(() => { (async () => {
+    try {
+      const cat = await fetchCatalog();
+      const ms = (cat?.modes ?? []).map((m:any)=>({ name:m.name, desc:m.desc }));
+      setModes(ms.length ? ms : [
+        { name:"Name", desc:"Identify beats by name" },
+        { name:"Missing", desc:"Find what’s missing" },
+        { name:"Fix", desc:"Repair weak writing" },
+        { name:"Order", desc:"Arrange sequence" },
+        { name:"Highlight", desc:"Mark beats in context" },
+        { name:"Why", desc:"Explain purpose" },
+      ]);
+    } finally { setLoading(false); }
+  })(); }, []);
 
   const selected = value || modes[0]?.name;
-
   return (
     <div className="card" data-testid="mode-picker">
       <h2 className="mb-3">Choose a mode</h2>
-      {loading ? (
-        <div className="pulse">loading modes…</div>
-      ) : (
-        <div className="grid gap-3 sm:grid-cols-2">
-          {modes.map((mode) => (
-            <button
-              key={mode.name}
-              className={`btn btn-ghost justify-start ${selected === mode.name ? "border-white" : ""}`}
-              onClick={() => onChange(mode.name)}
-              title={mode.desc || ""}
-              data-testid={`mode-option-${mode.name.replace(/\s+/g, "-").toLowerCase()}`}
-            >
-              <span className="mr-2 font-semibold">{mode.name}</span>
-              <span className="text-neutral-400">{mode.desc}</span>
+      {loading ? <div className="pulse">loading modes…</div> : (
+        <div className="grid sm:grid-cols-2 gap-3">
+          {modes.map(m=>(
+            <button key={m.name}
+              className={`btn btn-ghost justify-start ${selected===m.name?"border-white":""}`}
+              onClick={()=>onChange(m.name)} title={m.desc||""}>
+              <span className="font-semibold mr-2">{m.name}</span>
+              <span style={{opacity:.65}}>{m.desc}</span>
             </button>
           ))}
         </div>
       )}
-      <div className="mt-3 flex items-center gap-2 text-xs text-neutral-400">
-        <span className="kbd">R</span>
-        <span>start round</span>
+      <div className="mt-3 text-xs" style={{opacity:.65}}>
+        <span className="kbd">R</span> start round
       </div>
     </div>
   );

--- a/src/components/cutgames/ProgressBar.tsx
+++ b/src/components/cutgames/ProgressBar.tsx
@@ -1,17 +1,7 @@
-import clsx from "clsx";
-
-export default function ProgressBar({ total, index, className }: { total: number; index: number; className?: string }) {
-  const pct = total <= 0 ? 0 : Math.min(100, Math.round((Math.min(total, index + 1) / total) * 100));
+export default function ProgressBar({ total, index }:{ total:number; index:number }) {
+  const pct = total ? Math.min(100, Math.round(((index+1)/total)*100)) : 0;
   return (
-    <div
-      className={clsx("progress-track", className)}
-      aria-label="round progress"
-      aria-valuemin={0}
-      aria-valuemax={total > 0 ? total : undefined}
-      aria-valuenow={total > 0 ? Math.min(total, index + 1) : undefined}
-      role="progressbar"
-      data-testid="cutgames-round-progress-bar"
-    >
+    <div className="progress-track" aria-label="round progress" data-testid="round-progress">
       <div className="progress-bar" style={{ width: `${pct}%` }} />
     </div>
   );

--- a/src/components/cutgames/ResultsScreen.tsx
+++ b/src/components/cutgames/ResultsScreen.tsx
@@ -1,45 +1,34 @@
-type ResultsScreenProps = {
-  score: number;
-  notes: string[];
-  summary: { completed: number; skipped: number };
-  payload: { mode?: string; beat?: string; pitfall?: string; [key: string]: unknown };
-  onRestart: () => void;
-};
-
 export default function ResultsScreen({
-  score,
-  notes,
-  summary,
-  payload,
-  onRestart,
-}: ResultsScreenProps) {
-  const grade = score >= 90 ? "A" : score >= 80 ? "B" : score >= 70 ? "C" : score >= 60 ? "D" : "F";
+  score, notes, summary, payload, onRestart
+}:{ score:number; notes:string[]; summary:{completed:number; skipped:number}; payload:any; onRestart:()=>void }) {
+  const grade = score>=90?"A":score>=80?"B":score>=70?"C":score>=60?"D":"F";
   return (
     <div className="space-y-4" data-testid="results-screen">
       <div className="card">
         <h2 className="mb-1">Round Results</h2>
-        <div className="text-sm text-neutral-400">Mode: {payload?.mode}{payload?.beat ? ` · beat: ${payload.beat}`:""}{payload?.pitfall ? ` · pitfall: ${payload.pitfall}`:""}</div>
-        <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-3">
-          <div className="card"><div className="text-neutral-400 text-sm">Score</div><div className="text-3xl font-bold">{score}</div></div>
-          <div className="card"><div className="text-neutral-400 text-sm">Grade</div><div className="text-3xl font-bold">{grade}</div></div>
-          <div className="card"><div className="text-neutral-400 text-sm">Done / Skipped</div><div className="text-3xl font-bold">{summary.completed} / {summary.skipped}</div></div>
+        <div className="text-sm" style={{opacity:.65}}>
+          Mode: {payload?.mode}{payload?.beat?` · beat: ${payload.beat}`:""}{payload?.pitfall?` · pitfall: ${payload.pitfall}`:""}
+        </div>
+        <div className="grid" style={{gridTemplateColumns:"repeat(3,1fr)", gap:"12px", marginTop:"12px"}}>
+          <div className="card"><div style={{opacity:.65, fontSize:12}}>Score</div><div style={{fontSize:"1.75rem", fontWeight:800}}>{score}</div></div>
+          <div className="card"><div style={{opacity:.65, fontSize:12}}>Grade</div><div style={{fontSize:"1.75rem", fontWeight:800}}>{grade}</div></div>
+          <div className="card"><div style={{opacity:.65, fontSize:12}}>Done / Skipped</div><div style={{fontSize:"1.75rem", fontWeight:800}}>{summary.completed} / {summary.skipped}</div></div>
         </div>
       </div>
 
-      {/* Professor Ray Ray letter */}
       <div className="card">
         <h2 className="mb-3">Letter from Professor Ray Ray</h2>
         <div className="space-y-2">
-          <p><em>“Surprise, scholar.”</em> You did the thing. Whether you swung like a wrecking ball or stitched like a surgeon, you kept the page alive. Points if you noticed the trap beats trying to mug your attention.</p>
+          <p><em>“Surprise, scholar.”</em> You kept the page alive. Nice. The traps tried to mug you; you kept walking.</p>
           <p>Here’s the clean breakdown:</p>
-          <ul className="list-disc pl-6">
-            {notes?.length ? notes.map((note, index) => <li key={index}>{note}</li>) : <li>No major flags this round.</li>}
+          <ul className="list-disc" style={{paddingLeft:"1.25rem"}}>
+            {notes?.length ? notes.map((n,i)=><li key={i}>{n}</li>) : <li>No major flags this round.</li>}
           </ul>
-          <p className="text-neutral-400 text-sm">Style Report appears only on this results screen. Keep cooking.</p>
+          <p style={{opacity:.65, fontSize:12}}>The Style Report only appears here, on the results screen.</p>
         </div>
       </div>
 
-      <div className="flex gap-2">
+      <div style={{display:"flex", gap:"8px"}}>
         <button className="btn btn-primary" onClick={onRestart} data-testid="btn-restart">Play another round</button>
       </div>
     </div>

--- a/src/components/cutgames/RoundEngine.tsx
+++ b/src/components/cutgames/RoundEngine.tsx
@@ -1,355 +1,119 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import {
-  PracticeItem,
-  PracticeMode,
-  RoundItemAnswer,
-  RoundMode,
-  SubmitRoundResponse,
-  fetchPractice,
-  sendTelemetrySkip,
-  submitRound,
-} from "../../lib/cutGamesClient";
-import ProgressBar from "./ProgressBar";
+import { PracticeItem, RoundItemAnswer, fetchPractice, sendTelemetrySkip, submitRound } from "../../lib/cutGamesClient";
 import SceneCard from "./SceneCard";
+import ProgressBar from "./ProgressBar";
+
+type Props = {
+  modeName: "Name"|"Missing"|"Fix"|"Order"|"Highlight"|"Why";
+  beat?: string; pitfall?: string;
+  onDone: (r:{ score:number; notes:string[]; id:string; summary:any; payload:any })=>void;
+};
 
 const ITEMS_PER_ROUND = 5;
 
-const isEditableTarget = (target: EventTarget | null) => {
-  if (!(target instanceof HTMLElement)) return false;
-  const tag = target.tagName.toLowerCase();
-  return tag === "input" || tag === "textarea" || target.isContentEditable;
-};
-
-type SubmitPayload = Parameters<typeof submitRound>[0];
-type RoundSummary = { completed: number; skipped: number };
-
-export type RoundCompletion = {
-  score: number;
-  notes: string[];
-  id?: string;
-  summary: RoundSummary;
-  payload: SubmitPayload;
-  response: SubmitRoundResponse;
-};
-
-type Props = {
-  modeName: RoundMode;
-  beat?: string;
-  pitfall?: string;
-  practiceModeOverride?: PracticeMode;
-  onDone: (result: RoundCompletion) => void;
-  onSubmitError?: (error: string) => void;
-};
-
-export default function RoundEngine({
-  modeName,
-  beat,
-  pitfall,
-  practiceModeOverride,
-  onDone,
-  onSubmitError,
-}: Props) {
+export default function RoundEngine({ modeName, beat, pitfall, onDone }:Props) {
   const [queue, setQueue] = useState<PracticeItem[]>([]);
   const [idx, setIdx] = useState(0);
   const [answer, setAnswer] = useState("");
   const [answers, setAnswers] = useState<RoundItemAnswer[]>([]);
-  const [startedAt, setStartedAt] = useState<string>(() => new Date().toISOString());
+  const [startedAt] = useState<string>(new Date().toISOString());
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
-  const [submitError, setSubmitError] = useState<string | null>(null);
-  const [hasSubmitted, setHasSubmitted] = useState(false);
+  const [error, setError] = useState<string>();
 
-  const modeKind: PracticeMode = useMemo(() => {
-    if (practiceModeOverride) return practiceModeOverride;
-    if (pitfall) return "bad";
-    return modeName === "Fix" ? "bad" : "good";
-  }, [modeName, pitfall, practiceModeOverride]);
+  const modeKind: "good"|"bad" = useMemo(()=> (pitfall ? "bad" : (["Fix"].includes(modeName) ? "bad" : "good")), [modeName, pitfall]);
 
-  useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-    setSubmitError(null);
-    setQueue([]);
-    setIdx(0);
-    setAnswer("");
-    setAnswers([]);
-    setHasSubmitted(false);
-    const run = async () => {
-      try {
-        const items = await fetchPractice({ mode: modeKind, beat, pitfall });
-        if (cancelled) return;
-        const trimmed = (items ?? []).slice(0, ITEMS_PER_ROUND);
-        setQueue(trimmed);
-        setStartedAt(new Date().toISOString());
-      } catch (err) {
-        if (cancelled) return;
-        setError((err as Error).message || "Failed to load practice");
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    };
-    void run();
-    return () => {
-      cancelled = true;
-    };
-  }, [modeKind, beat, pitfall]);
+  useEffect(()=>{ (async()=>{
+    try {
+      setLoading(true);
+      const items = await fetchPractice({ mode: modeKind, beat, pitfall });
+      setQueue(items.slice(0, ITEMS_PER_ROUND));
+      setIdx(0); setAnswers([]); setAnswer(""); setError(undefined);
+    } catch (e:any) { setError(e?.message || "Failed to load practice"); }
+    finally { setLoading(false); }
+  })(); }, [modeKind, beat, pitfall]);
 
   const current = queue[idx];
-  const finished = idx >= queue.length && queue.length > 0;
+  const next = useCallback(()=>{ setAnswer(""); setIdx(i=>Math.min(i+1, queue.length)); }, [queue.length]);
 
-  const recordAnswer = useCallback(
-    (entry: RoundItemAnswer) => {
-      setAnswers((prev) => {
-        const next = prev.filter((item) => item.itemId !== entry.itemId);
-        return [...next, entry];
-      });
-    },
-    [],
-  );
-
-  const next = useCallback(() => {
-    setIdx((prev) => {
-      if (prev >= queue.length) return prev;
-      const nextIndex = Math.min(prev + 1, queue.length);
-      if (nextIndex !== prev) {
-        setAnswer("");
-      }
-      return nextIndex;
-    });
-  }, [queue.length]);
-
-  const onSkip = useCallback(async () => {
-    if (!current || submitting) return;
-    recordAnswer({
-      itemId: current.id,
-      mode: modeKind,
-      beat,
-      pitfall,
-      skipped: true,
-    });
-    try {
-      await sendTelemetrySkip(modeKind, {
-        beat: current.beat ?? undefined,
-        pitfall: current.pitfall ?? undefined,
-        type: current.type ?? undefined,
-      });
-    } catch (err) {
-      console.warn("Failed to send skip telemetry", err);
-    }
+  const onSkip = useCallback(async ()=>{
+    if (!current) return;
+    try { await sendTelemetrySkip(modeKind, { beat, pitfall }); } catch {}
+    setAnswers(a=>[...a,{ itemId: current.id, mode: modeName, beat, pitfall, skipped:true }]);
     next();
-  }, [current, submitting, recordAnswer, modeKind, beat, pitfall, next]);
+  }, [current, next, modeName, modeKind, beat, pitfall]);
 
-  const onComplete = useCallback(() => {
-    if (!current || submitting) return;
-    recordAnswer({
-      itemId: current.id,
-      mode: modeKind,
-      beat,
-      pitfall,
-      skipped: false,
-      answer: answer.trim(),
-    });
+  const onComplete = useCallback(()=>{
+    if (!current) return;
+    setAnswers(a=>[...a,{ itemId: current.id, mode: modeName, beat, pitfall, skipped:false, answer:(answer||"").trim() }]);
     next();
-  }, [answer, current, submitting, modeKind, beat, pitfall, next, recordAnswer]);
+  }, [current, modeName, beat, pitfall, answer, next]);
 
-  const onNext = useCallback(() => {
-    if (!current || submitting) return;
-    recordAnswer({
-      itemId: current.id,
-      mode: modeKind,
-      beat,
-      pitfall,
-      skipped: true,
-    });
-    next();
-  }, [current, submitting, recordAnswer, modeKind, beat, pitfall, next]);
-
-  useEffect(() => {
-    const handler = (event: KeyboardEvent) => {
-      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
-      if (isEditableTarget(event.target)) return;
-      const key = event.key.toLowerCase();
-      if (key === "s") {
-        event.preventDefault();
-        onSkip();
-      } else if (key === "c") {
-        event.preventDefault();
-        onComplete();
-      } else if (key === "n") {
-        event.preventDefault();
-        onNext();
-      }
+  useEffect(()=>{
+    const onKey = (e:KeyboardEvent)=>{
+      const k = e.key.toLowerCase();
+      if (k==="s") onSkip();
+      if (k==="c") onComplete();
+      if (k==="n") next();
     };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [onSkip, onComplete, onNext]);
+    window.addEventListener("keydown", onKey);
+    return ()=>window.removeEventListener("keydown", onKey);
+  }, [onSkip, onComplete, next]);
 
-  useEffect(() => {
-    if (!finished || submitting || queue.length === 0 || hasSubmitted) return;
-    let cancelled = false;
-    const run = async () => {
-      try {
-        setSubmitting(true);
-        setSubmitError(null);
-        setHasSubmitted(true);
-        const payload: SubmitPayload = {
-          mode: modeName,
-          beat,
-          pitfall,
-          items: answers,
-          startedAt,
-          finishedAt: new Date().toISOString(),
-        };
-        const response = await submitRound(payload);
-        if (cancelled) return;
-        const summary: RoundSummary = {
-          completed: answers.filter((entry) => !entry.skipped).length,
-          skipped: answers.filter((entry) => entry.skipped).length,
-        };
-        onDone({
-          score: response.score,
-          notes: response.rubric?.notes ?? [],
-          id: response.id,
-          summary,
-          payload,
-          response,
-        });
-      } catch (err) {
-        if (cancelled) return;
-        const message = (err as Error).message || "Failed to submit round";
-        setSubmitError(message);
-        onSubmitError?.(message);
-      } finally {
-        if (!cancelled) {
-          setSubmitting(false);
-        }
-      }
-    };
-    void run();
-    return () => {
-      cancelled = true;
-    };
-  }, [finished, submitting, queue.length, hasSubmitted, modeName, beat, pitfall, answers, startedAt, onDone, onSubmitError]);
+  const finished = idx >= queue.length && queue.length>0;
 
-  const handleRetrySubmit = useCallback(() => {
+  useEffect(()=>{ (async()=>{
     if (!finished) return;
-    setSubmitError(null);
-    setHasSubmitted(false);
-  }, [finished]);
+    const payload = { mode: modeName, beat, pitfall, items: answers, startedAt, finishedAt: new Date().toISOString() };
+    const res = await submitRound(payload);
+    onDone({
+      score: res.score,
+      notes: res.rubric?.notes || [],
+      id: res.id,
+      summary: { completed: answers.filter(a=>!a.skipped).length, skipped: answers.filter(a=>a.skipped).length },
+      payload,
+    });
+  })(); }, [finished]); // eslint-disable-line
 
-  if (loading) {
-    return (
-      <div className="card" data-testid="cutgames-round-loading">
-        loading practice…
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="card text-rose-200" data-testid="cutgames-round-error">
-        {error}
-      </div>
-    );
-  }
-
-  if (!queue.length) {
-    return (
-      <div className="card" data-testid="cutgames-round-empty">
-        no practice available
-      </div>
-    );
-  }
-
-  if (submitError) {
-    return (
-      <div className="card space-y-3 text-rose-200" data-testid="cutgames-round-submit-error">
-        <p>{submitError}</p>
-        <button type="button" className="btn btn-primary" onClick={handleRetrySubmit}>
-          Try submitting again
-        </button>
-      </div>
-    );
-  }
-
-  if (finished) {
-    return (
-      <div className="card" data-testid="cutgames-round-scoring">
-        scoring…
-      </div>
-    );
-  }
+  if (loading) return <div className="card">loading practice…</div>;
+  if (error) return <div className="card" style={{color:"#ffb3b3"}}>{error}</div>;
+  if (!queue.length) return <div className="card">no practice available</div>;
+  if (finished) return <div className="card">scoring…</div>;
 
   return (
-    <div className="space-y-4" data-testid="cutgames-round-engine">
-      <div className="card flex flex-wrap items-center justify-between gap-3">
-        <div className="flex flex-wrap items-center gap-2">
+    <div className="space-y-4" data-testid="round-engine">
+      <div className="card" style={{display:"flex", alignItems:"center", justifyContent:"space-between"}}>
+        <div style={{display:"flex", gap:"8px", alignItems:"center"}}>
           <span className="chip is-on">{modeName}</span>
           {beat && <span className="chip">beat: {beat}</span>}
           {pitfall && <span className="chip">pitfall: {pitfall}</span>}
         </div>
-        <div className="flex items-center gap-3 text-xs text-neutral-400">
-          <span>
-            <span className="kbd">S</span> Skip
-          </span>
-          <span>
-            <span className="kbd">C</span> Complete
-          </span>
-          <span>
-            <span className="kbd">N</span> Next
-          </span>
+        <div className="text-xs" style={{opacity:.65, display:"flex", gap:"12px"}}>
+          <span><span className="kbd">S</span> Skip</span>
+          <span><span className="kbd">C</span> Complete</span>
+          <span><span className="kbd">N</span> Next</span>
         </div>
       </div>
 
       <ProgressBar total={queue.length} index={idx} />
-
       {current && <SceneCard item={current} />}
 
-      <div className="card space-y-3">
-        <label className="block text-sm" htmlFor="cutgames-round-answer">
-          Your move
-        </label>
+      <div className="card">
+        <label className="block text-sm mb-2">Your move</label>
         <textarea
-          id="cutgames-round-answer"
-          value={answer}
-          onChange={(event) => setAnswer(event.target.value)}
+          value={answer} onChange={e=>setAnswer(e.target.value)}
           placeholder={
-            modeName === "Name"
-              ? "Name the beat(s) present…"
-              : modeName === "Missing"
-                ? "What’s missing and why does it matter…"
-                : modeName === "Fix"
-                  ? "Rewrite or prescribe a fix…"
-                  : modeName === "Order"
-                    ? "Describe correct order / sequence…"
-                    : modeName === "Highlight"
-                      ? "Quote/mark the beat text and label it…"
-                      : "Explain the purpose / effect of the beat…"
+            modeName==="Name" ? "Name the beat(s) present…" :
+            modeName==="Missing" ? "What’s missing and why does it matter…" :
+            modeName==="Fix" ? "Rewrite or prescribe a fix…" :
+            modeName==="Order" ? "Describe correct order / sequence…" :
+            modeName==="Highlight" ? "Quote/mark the beat text and label it…" :
+            "Explain the purpose / effect of the beat…"
           }
-          className="w-full min-h-40 rounded-xl border border-neutral-800 bg-neutral-900 px-3 py-2"
-          data-testid="cutgames-round-answer"
+          style={{width:"100%", minHeight:"10rem", background:"#121215", border:"1px solid #242428", borderRadius:"12px", padding:".5rem .75rem"}}
         />
-        <div className="flex gap-2">
-          <button
-            type="button"
-            className="btn btn-ghost"
-            onClick={onSkip}
-            data-testid="cutgames-round-skip"
-            disabled={submitting}
-          >
-            Skip
-          </button>
-          <button
-            type="button"
-            className="btn btn-primary"
-            onClick={onComplete}
-            data-testid="cutgames-round-complete"
-            disabled={submitting}
-          >
-            Complete
-          </button>
+        <div style={{display:"flex", gap:"8px", marginTop:"10px"}}>
+          <button className="btn btn-ghost" onClick={onSkip} data-testid="btn-skip">Skip</button>
+          <button className="btn btn-primary" onClick={onComplete} data-testid="btn-complete">Complete</button>
         </div>
       </div>
     </div>

--- a/src/components/cutgames/SceneCard.tsx
+++ b/src/components/cutgames/SceneCard.tsx
@@ -1,13 +1,11 @@
-// src/components/cutgames/SceneCard.tsx
 import { PracticeItem } from "../../lib/cutGamesClient";
-
-export default function SceneCard({ item }: { item: PracticeItem }) {
+export default function SceneCard({ item }:{ item:PracticeItem }) {
   return (
     <div className="card" data-testid="scene-card">
-      <div className="flex items-center gap-2 mb-3">
+      <div style={{display:"flex", alignItems:"center", gap:"8px", marginBottom:"10px"}}>
         {item.beat && <span className="chip">{item.beat}</span>}
         {item.pitfall && <span className="chip">{item.pitfall}</span>}
-        <span className="text-xs text-neutral-500 ml-auto">#{item.id}</span>
+        <span style={{marginLeft:"auto", opacity:.6, fontSize:12}}>#{item.id}</span>
       </div>
       <div className="scene">{item.scene}</div>
     </div>

--- a/src/lib/cutGamesClient.ts
+++ b/src/lib/cutGamesClient.ts
@@ -1,43 +1,13 @@
-export type PracticeMode = "good" | "bad";
-
-export type PracticeItem = {
-  id: number;
-  scene: string;
-  beat?: string | null;
-  pitfall?: string | null;
-  type?: string | null;
-};
-
-export type CatalogMode = { name: string; desc: string };
-
-export type CatalogBeat = {
-  beat: string;
-  total: number;
-  from_tweetrunk: number;
-  from_good: number;
-  from_bad: number;
-};
-
-export type CutGamesCatalog = {
-  tweetrunkCount: number;
-  goodCount: number;
-  badCount: number;
-  beatsIndex: CatalogBeat[];
-  lessonsByTagCount: number;
-  modes: CatalogMode[];
-};
-
-export type IntroductionsIndex = Record<string, number[]>;
-
-type TelemetryType = "lesson" | "prompt" | "mixed" | "notelesson" | (string & {});
+// src/lib/cutGamesClient.ts
+export type PracticeItem = { id:number; scene:string; beat?:string; pitfall?:string };
 
 async function get<T>(url: string): Promise<T> {
   const res = await fetch(url, { credentials: "include" });
   if (!res.ok) throw new Error(`GET ${url} failed: ${res.status}`);
-  return res.json() as Promise<T>;
+  return res.json();
 }
 
-async function post<T>(url: string, body: unknown): Promise<T> {
+async function post<T>(url: string, body: any): Promise<T> {
   const res = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -45,26 +15,14 @@ async function post<T>(url: string, body: unknown): Promise<T> {
     body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error(`POST ${url} failed: ${res.status}`);
-  return res.json() as Promise<T>;
+  return res.json();
 }
 
-export async function fetchCatalog(): Promise<CutGamesCatalog> {
-  return get<CutGamesCatalog>("/cut-games/catalog");
-}
+export async function fetchCatalog() { return get<any>("/cut-games/catalog"); }
+export async function fetchBeats() { return get<any>("/cut-games/beats"); }
+export async function fetchIntroductions() { return get<any>("/cut-games/introductions"); }
 
-export async function fetchBeats(): Promise<CatalogBeat[]> {
-  return get<CatalogBeat[]>("/cut-games/beats");
-}
-
-export async function fetchIntroductions(): Promise<IntroductionsIndex> {
-  return get<IntroductionsIndex>("/cut-games/introductions");
-}
-
-export async function fetchPractice(params: {
-  mode: PracticeMode;
-  beat?: string;
-  pitfall?: string;
-}): Promise<PracticeItem[]> {
+export async function fetchPractice(params: {mode:"good"|"bad"; beat?:string; pitfall?:string;}): Promise<PracticeItem[]> {
   const qs = new URLSearchParams();
   qs.set("mode", params.mode);
   if (params.beat) qs.set("beat", params.beat);
@@ -72,55 +30,19 @@ export async function fetchPractice(params: {
   return get<PracticeItem[]>(`/cut-games/practice?${qs.toString()}`);
 }
 
-export async function sendTelemetrySkip(
-  mode: PracticeMode,
-  meta: { beat?: string; pitfall?: string; type?: TelemetryType } = {}
-) {
-  return post<{ ok: true }>("/cut-games/telemetry", { event: "skip", mode, meta });
+export async function sendTelemetrySkip(mode:"good"|"bad", meta: { beat?:string; pitfall?:string; type?: "lesson"|"prompt"|"mixed"|"notelesson" } = {}) {
+  return post<{ok:true}>("/cut-games/telemetry", { event:"skip", mode, meta });
 }
 
-export type RoundItemAnswer = {
-  itemId: number;
-  mode: PracticeMode;
-  beat?: string;
-  pitfall?: string;
-  answer?: string;
-  skipped: boolean;
-};
-
-export type RoundMode =
-  | "Name"
-  | "Missing"
-  | "Fix"
-  | "Order"
-  | "Highlight"
-  | "Why"
-  | (string & {});
-
-export type SubmitRoundRubric = {
-  score: number;
-  notes: string[];
-  flags: Record<string, unknown>;
-};
-
-export type SubmitRoundResponse = {
-  ok: true;
-  id?: string;
-  score: number;
-  rubric?: SubmitRoundRubric;
-  xp?: number;
-  level?: number;
-  levelUp?: { from: number; to: number } | null;
-  newBadges?: Array<{ id: string; title: string; desc: string; xp_bonus?: number }>;
-};
+export type RoundItemAnswer = { itemId:number; mode:string; beat?:string; pitfall?:string; answer?:string; skipped:boolean };
 
 export async function submitRound(payload: {
-  mode: RoundMode;
+  mode: "Name"|"Missing"|"Fix"|"Order"|"Highlight"|"Why";
   beat?: string;
   pitfall?: string;
   items: RoundItemAnswer[];
   startedAt: string;
   finishedAt: string;
-}): Promise<SubmitRoundResponse> {
-  return post<SubmitRoundResponse>("/api/submit", payload);
+}) {
+  return post<{ ok:true; id:string; score:number; rubric:{ score:number; notes:string[]; flags:any } }>("/api/submit", payload);
 }

--- a/src/pages/CutGames.tsx
+++ b/src/pages/CutGames.tsx
@@ -1,43 +1,5 @@
-import React, { useState } from "react";
-
-const samplePrompts = [
-  "Cut 10 words from this paragraph.",
-  "Replace every adjective with a stronger one.",
-  "Find and remove passive voice.",
-  "Edit for clarity: rewrite the sentence.",
-];
+import CutGamesPlay from "./CutGamesPlay";
 
 export default function CutGames() {
-  const [current, setCurrent] = useState(0);
-
-  function nextPrompt() {
-    setCurrent((c) => (c + 1) % samplePrompts.length);
-  }
-
-  return (
-    <div style={{ maxWidth: 600, margin: "3rem auto", padding: "2rem", background: "#fff", borderRadius: "12px", border: "2px solid #222", boxShadow: "0 2px 8px rgba(0,0,0,0.07)" }}>
-      <h1 style={{ fontSize: "2rem", fontWeight: "bold", marginBottom: "1.5rem", textAlign: "center" }}>
-        The Cut Games
-      </h1>
-      <div style={{ fontSize: "1.2rem", marginBottom: "2rem", textAlign: "center" }}>
-        {samplePrompts[current]}
-      </div>
-      <button
-        style={{
-          padding: "0.75rem 2rem",
-          fontSize: "1rem",
-          background: "#222",
-          color: "#fff",
-          border: "none",
-          borderRadius: "8px",
-          cursor: "pointer",
-          display: "block",
-          margin: "0 auto"
-        }}
-        onClick={nextPrompt}
-      >
-        Next Challenge
-      </button>
-    </div>
-  );
+  return <CutGamesPlay />;
 }

--- a/src/pages/CutGamesPlay.tsx
+++ b/src/pages/CutGamesPlay.tsx
@@ -1,104 +1,57 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import "../styles/cutgames.css";
 import ModePicker from "../components/cutgames/ModePicker";
 import BeatPitfallPicker from "../components/cutgames/BeatPitfallPicker";
-import RoundEngine, { type RoundCompletion } from "../components/cutgames/RoundEngine";
+import RoundEngine from "../components/cutgames/RoundEngine";
 import ResultsScreen from "../components/cutgames/ResultsScreen";
 
-type ModeName = "Name" | "Missing" | "Fix" | "Order" | "Highlight" | "Why";
-
-type Phase = "select" | "play" | "results";
+type ModeName = "Name"|"Missing"|"Fix"|"Order"|"Highlight"|"Why";
 
 export default function CutGamesPlay() {
   const [mode, setMode] = useState<ModeName>("Name");
-  const [beat, setBeat] = useState<string | undefined>();
-  const [pitfall, setPitfall] = useState<string | undefined>();
+  const [beat, setBeat] = useState<string|undefined>();
+  const [pitfall, setPitfall] = useState<string|undefined>();
   const [roundKey, setRoundKey] = useState(0);
-  const [phase, setPhase] = useState<Phase>("select");
-  const [results, setResults] = useState<RoundCompletion | null>(null);
+  const [phase, setPhase] = useState<"select"|"play"|"results">("select");
+  const [results, setResults] = useState<{score:number; notes:string[]; id:string; summary:any; payload:any} | null>(null);
 
-  const startRound = useCallback(() => {
-    setPhase("play");
-    setResults(null);
-    setRoundKey((key) => key + 1);
-  }, []);
+  useEffect(()=> {
+    const onKey = (e:KeyboardEvent)=>{ if (e.key.toLowerCase()==="r" && phase==="select") startRound(); };
+    window.addEventListener("keydown", onKey);
+    return ()=>window.removeEventListener("keydown", onKey);
+  }, [phase]);
 
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (phase !== "select") return;
-      if (event.key.toLowerCase() === "r") {
-        event.preventDefault();
-        startRound();
-      }
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [phase, startRound]);
-
-  const handleDone = (roundResult: RoundCompletion) => {
-    setResults(roundResult);
-    setPhase("results");
-  };
+  function startRound(){
+    setPhase("play"); setResults(null); setRoundKey(k=>k+1);
+  }
+  function onDone(r:any){ setResults(r); setPhase("results"); }
 
   return (
     <div className="cut-shell" data-testid="cut-games-root">
       <div className="cut-container space-y-4">
-        <header className="flex items-center justify-between">
+        <header style={{display:"flex", alignItems:"center", justifyContent:"space-between"}}>
           <h1 className="text-2xl font-bold">Cut Games</h1>
-          <div className="text-sm text-neutral-400">Projects From The Projects</div>
+          <div className="text-sm" style={{opacity:.65}}>Projects From The Projects</div>
         </header>
 
-        {phase === "select" && (
+        {phase==="select" && (
           <>
-            <ModePicker value={mode} onChange={(next) => setMode(next as ModeName)} />
-            <BeatPitfallPicker
-              beat={beat}
-              pitfall={pitfall}
-              onChange={(next) => {
-                setBeat(next.beat);
-                setPitfall(next.pitfall);
-              }}
-            />
-            <div className="flex gap-2">
-              <button className="btn btn-primary" onClick={startRound} data-testid="btn-start">
-                Start Round
-              </button>
-              <button
-                className="btn btn-ghost"
-                onClick={() => {
-                  setBeat(undefined);
-                  setPitfall(undefined);
-                }}
-              >
-                Clear
-              </button>
+            <ModePicker value={mode} onChange={(m)=>setMode(m as ModeName)} />
+            <BeatPitfallPicker beat={beat} pitfall={pitfall} onChange={(v)=>{ setBeat(v.beat); setPitfall(v.pitfall); }} />
+            <div style={{display:"flex", gap:"8px"}}>
+              <button className="btn btn-primary" onClick={startRound} data-testid="btn-start">Start Round</button>
+              <button className="btn btn-ghost" onClick={()=>{ setBeat(undefined); setPitfall(undefined); }}>Clear</button>
             </div>
-            <div className="text-xs text-neutral-400">
-              Pro-tip: press <span className="kbd">R</span> to start.
-            </div>
+            <div className="text-xs" style={{opacity:.65}}>Pro-tip: press <span className="kbd">R</span> to start.</div>
           </>
         )}
 
-        {phase === "play" && (
-          <RoundEngine
-            key={roundKey}
-            modeName={mode}
-            beat={beat}
-            pitfall={pitfall}
-            onDone={handleDone}
-          />
+        {phase==="play" && (
+          <RoundEngine key={roundKey} modeName={mode} beat={beat} pitfall={pitfall} onDone={onDone} />
         )}
 
-        {phase === "results" && results && (
-          <ResultsScreen
-            score={results.score}
-            notes={results.notes}
-            summary={results.summary}
-            payload={results.payload}
-            onRestart={() => {
-              setPhase("select");
-            }}
-          />
+        {phase==="results" && results && (
+          <ResultsScreen score={results.score} notes={results.notes} summary={results.summary} payload={results.payload} onRestart={()=>setPhase("select")} />
         )}
       </div>
     </div>

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -25,7 +25,7 @@ export default function Game() {
                     <span className="inline-block px-4 py-2 bg-black text-white rounded">Go to Game</span>
                 </Link>
                 <Link
-                    to="/cutgames"
+                    to="/play/cut-games"
                     className="block bg-white border-2 border-black rounded-lg shadow hover:bg-neutral-100 transition p-6 text-center"
                 >
                     <div className="font-bold text-lg mb-2">The Cut Games</div>

--- a/src/pages/GameRoot.tsx
+++ b/src/pages/GameRoot.tsx
@@ -14,7 +14,7 @@ export default function GameRoot(): JSX.Element {
     return (
         <div className="brutalist-root" style={{ padding: '1rem' }}>
             <nav style={{ marginBottom: '1rem' }}>
-                <Link to="/">Home</Link> | <Link to="/play">Play</Link> | <Link to="/cutgames">Cut Games</Link>
+                <Link to="/">Home</Link> | <Link to="/play">Play</Link> | <Link to="/play/cut-games">Cut Games</Link>
             </nav>
             <Outlet />
         </div>

--- a/src/pages/SigilSyntaxRoot.tsx
+++ b/src/pages/SigilSyntaxRoot.tsx
@@ -5,7 +5,7 @@ export default function SigilSyntaxRoot(): JSX.Element {
     return (
         <div className="brutalist-root" style={{ padding: '1rem' }}>
             <nav style={{ marginBottom: '1rem' }}>
-                <Link to="/">Home</Link> | <Link to="/play">Play</Link> | <Link to="/cutgames">Cut Games</Link>
+                <Link to="/">Home</Link> | <Link to="/play">Play</Link> | <Link to="/play/cut-games">Cut Games</Link>
             </nav>
             <Outlet />
         </div>

--- a/src/styles/cutgames.css
+++ b/src/styles/cutgames.css
@@ -1,123 +1,21 @@
-:root {
-  --card: rgba(20, 20, 24, 0.7);
-  --accent: #7df9ff;
+:root { --card: rgba(20,20,24,0.7); --accent: #7df9ff; }
+.cut-shell { min-height: 100vh; background:#0a0a0b; color:#e8e8ea;
+  background-image:
+    radial-gradient(ellipse at 20% 10%, rgba(125,249,255,0.12), transparent 40%),
+    radial-gradient(ellipse at 80% 30%, rgba(255,138,76,0.08), transparent 45%);
 }
-
-.cut-shell {
-  min-height: 100vh;
-  color: #f5f5f5;
-  background-color: #0f0f12;
-  background-image: radial-gradient(ellipse at 20% 10%, rgba(125, 249, 255, 0.12), transparent 40%),
-    radial-gradient(ellipse at 80% 30%, rgba(255, 138, 76, 0.08), transparent 45%);
-}
-
-.cut-container {
-  max-width: 64rem;
-  margin-left: auto;
-  margin-right: auto;
-  padding: 2rem 1rem;
-}
-
-.card {
-  background: var(--card);
-  border-radius: 1rem;
-  padding: 1.25rem;
-  border: 1px solid rgba(64, 64, 70, 0.9);
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.3), 0 4px 6px -4px rgba(0, 0, 0, 0.3);
-  backdrop-filter: blur(6px);
-}
-
-.card h2 {
-  font-size: 1.25rem;
-  font-weight: 600;
-}
-
-.btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 0.75rem;
-  padding: 0.5rem 1rem;
-  border: 1px solid rgba(115, 115, 115, 0.7);
-  transition: all 0.2s ease;
-}
-
-.btn:hover {
-  border-color: rgba(163, 163, 163, 0.8);
-}
-
-.btn-primary {
-  background-color: #f5f5f5;
-  color: #111827;
-}
-
-.btn-primary:hover {
-  background-color: #ffffff;
-}
-
-.btn-ghost:hover {
-  background-color: rgba(38, 38, 38, 0.4);
-}
-
-.chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  border-radius: 9999px;
-  padding: 0.25rem 0.75rem;
-  border: 1px solid rgba(115, 115, 115, 0.7);
-  font-size: 0.875rem;
-  line-height: 1.25rem;
-}
-
-.chip.is-on {
-  border-color: var(--accent);
-  color: var(--accent);
-}
-
-.kbd {
-  padding: 0.25rem 0.5rem;
-  border: 1px solid rgba(115, 115, 115, 0.7);
-  border-radius: 0.375rem;
-  font-size: 0.75rem;
-  line-height: 1rem;
-}
-
-.scene {
-  white-space: pre-wrap;
-  line-height: 1.75rem;
-}
-
-.scene::selection {
-  background-color: rgba(64, 64, 64, 0.6);
-}
-
-.progress-track {
-  height: 0.5rem;
-  width: 100%;
-  background-color: rgba(64, 64, 64, 0.9);
-  border-radius: 9999px;
-  overflow: hidden;
-}
-
-.progress-bar {
-  height: 0.5rem;
-  background-color: #e5e7eb;
-  transition: width 0.2s ease;
-}
-
-.pulse {
-  animation: pulse 1.4s infinite;
-}
-
-@keyframes pulse {
-  0% {
-    opacity: 0.5;
-  }
-  50% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0.5;
-  }
-}
+.cut-container { max-width: 72rem; margin: 0 auto; padding: 2rem 1rem; }
+.card { background: var(--card); border:1px solid #242428; border-radius: 1rem; padding: 1.25rem; box-shadow: 0 8px 24px rgba(0,0,0,.25); backdrop-filter: blur(6px); }
+.card h2 { font-size: 1.1rem; font-weight: 600; }
+.btn { display:inline-flex; align-items:center; justify-content:center; border-radius: .75rem; padding:.5rem 1rem; border:1px solid #2d2d33; transition: all .2s ease; }
+.btn:hover { border-color:#4d4d55; }
+.btn-primary { background:#f2f2f5; color:#0b0b0d; }
+.btn-ghost { background: transparent; color:#e8e8ea; }
+.chip { display:inline-flex; align-items:center; gap:.5rem; border:1px solid #2d2d33; border-radius:999px; padding:.25rem .75rem; font-size:.9rem; }
+.chip.is-on { border-color: var(--accent); color: var(--accent); }
+.kbd { padding:.15rem .4rem; border:1px solid #2d2d33; border-radius:.5rem; font-size:.75rem; }
+.scene { white-space: pre-wrap; line-height: 1.75; }
+.progress-track { height:.5rem; width:100%; background:#1a1a1f; border-radius:.5rem; overflow:hidden; }
+.progress-bar { height:.5rem; background:#f0f0f2; transition: width .2s ease; }
+.pulse { animation: pulse 1.4s infinite; }
+@keyframes pulse { 0%{opacity:.5}50%{opacity:1}100%{opacity:.5} }


### PR DESCRIPTION
## Summary
- rewrite the Cut Games play page to match the requested layout and keyboard shortcut behavior
- wire the selection, play, and results phases through the provided components and restart flow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68eca322d864832f92d10e6744a930cd