### PR TITLE
Add games hub route and update Sigil & Syntax navigation

### DIFF
--- a/src/SigilSyntaxApp.tsx
+++ b/src/SigilSyntaxApp.tsx
@@ -5,6 +5,7 @@ import {
     CutGamesPlay,
     Dictionary,
     Foundation,
+    Games,
     Home,
     Play,
     PlayMCQ,
@@ -20,6 +21,7 @@ export default function SigilSyntaxApp() {
                 {/* simple top nav so everything is discoverable */}
                 <nav style={{ padding: 12, borderBottom: "2px solid #000" }}>
                     <Link to="/">Home</Link> {" | "}
+                    <Link to="/games">Games</Link> {" | "}
                     <Link to="/cutgames">Cut Game</Link> {" | "}
                     <Link to="/foundation">Foundation</Link> {" | "}
                     <Link to="/dictionary">Dictionary</Link> {" | "}
@@ -29,6 +31,7 @@ export default function SigilSyntaxApp() {
                 <Routes>
                     <Route path="/" element={<Home />} />
                     {/* Cut Game */}
+                    <Route path="/games" element={<Games />} />
                     <Route path="/cutgames" element={<CutGames />} />
                     <Route path="/cutgames/play" element={<CutGamesPlay />} />
 

--- a/src/pages/Dictionary.tsx
+++ b/src/pages/Dictionary.tsx
@@ -8,8 +8,8 @@ export default function Dictionary() {
         <p className="text-neutral-500">Dictionary — placeholder page (wire me up later)</p>
       </header>
       <p>
-        This placeholder keeps the Sigil & Syntax navigation functioning until the interactive
-        dictionary experience is restored.
+        This placeholder keeps the <a href="#/sigil-syntax" data-game="original">Sigil &amp; Syntax</a>
+        navigation functioning until the interactive dictionary experience is restored.
       </p>
       <p>
         <Link className="text-blue-500 underline" to="/">Return home</Link>

--- a/src/pages/__games.tsx
+++ b/src/pages/__games.tsx
@@ -37,7 +37,8 @@ function ResolvedOriginalScreens() {
       <div>
         <h2 className="text-xl font-semibold">Resolved ORIGINAL screens</h2>
         <p className="text-sm text-neutral-600 dark:text-neutral-400">
-          Live routes below point to the Sigil &amp; Syntax wrappers; file paths show the selected components.
+          Live routes below point to the <a href="#/sigil-syntax">Sigil &amp; Syntax</a> wrappers; file paths show
+          the selected components.
         </p>
       </div>
       <ul className="space-y-3 text-sm">

--- a/src/pages/games/index.tsx
+++ b/src/pages/games/index.tsx
@@ -1,0 +1,22 @@
+import type { JSX } from "react";
+
+export default function GamesHub(): JSX.Element {
+  return (
+    <section className="mx-auto flex max-w-xl flex-col gap-4 p-6">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold">Games</h1>
+        <p className="text-neutral-600 dark:text-neutral-400">
+          Jump into an adventure.
+        </p>
+      </header>
+      <nav className="flex flex-col gap-3 text-lg">
+        <a className="text-blue-600 underline" href="#/sigil-syntax">
+          Sigil &amp; Syntax (Original)
+        </a>
+        <a className="text-blue-600 underline" href="#/cutgames">
+          The Cut Games
+        </a>
+      </nav>
+    </section>
+  );
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -7,3 +7,11 @@ export { default as PlaySee } from "./PlaySee";
 export { default as PlayMCQ } from "./PlayMCQ";
 export { default as PlaySlot } from "./PlaySlot";
 export { default as NotFound } from "./NotFound";
+
+export { default as CutGames } from "./CutGames";
+export { default as CutGamesPlay } from "./CutGamesPlay";
+export { default as Dictionary } from "./Dictionary";
+export { default as Foundation } from "./Foundation";
+export { default as Games } from "./games";
+export { default as Play } from "./Play";
+export { default as SigilSyntaxRoot } from "./SigilSyntaxRoot";

--- a/src/pages/sigil-syntax/index.tsx
+++ b/src/pages/sigil-syntax/index.tsx
@@ -8,7 +8,7 @@ export default function SigilSyntaxHome() {
   useEffect(() => {
     let cancelled = false;
     if (typeof window !== "undefined") {
-      console.info("[sigil&syntax] launching ORIGINAL home");
+      console.info("[sigil&syntax] launching ORIGINAL");
     }
     const path = screens.home || screens.play || screens.fallbacks[0];
     if (path) {


### PR DESCRIPTION
## Summary
- add a hash router link for the Games hub and register its route so the Sigil & Syntax tile opens the original game
- introduce a lightweight games hub page with links to the original Sigil & Syntax and Cut Games experiences
- tweak supporting copy to link the Sigil & Syntax name and align the original console marker

## Testing
- npm run build *(fails: local vite binary was not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed418cb650832faf7967f53791ad25