### PR TITLE
Add maintenance guard around original Sigil & Syntax routes

### DIFF
--- a/src/games/guard.tsx
+++ b/src/games/guard.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from "react";
+
+type Flags = { gameEnabled?: boolean; maintenanceMessage?: string };
+
+async function fetchFlags(): Promise<Flags> {
+  try {
+    const r = await fetch("/api/flags", { cache: "no-store" });
+    const j = await r.json();
+    return (j?.flags ?? j) as Flags;
+  } catch {
+    return { gameEnabled: true, maintenanceMessage: "" };
+  }
+}
+
+export function useFlags(pollMs = 0) {
+  const [flags, setFlags] = useState<Flags>({ gameEnabled: true, maintenanceMessage: "" });
+  useEffect(() => {
+    let timer: any;
+    (async () => setFlags(await fetchFlags()))();
+    if (pollMs > 0) {
+      timer = setInterval(async () => setFlags(await fetchFlags()), pollMs);
+    }
+    return () => clearInterval(timer);
+  }, [pollMs]);
+  return flags;
+}
+
+export function Guard(props: { gameId: string; children: React.ReactNode }) {
+  const { gameId, children } = props;
+  const { gameEnabled = true, maintenanceMessage = "" } = useFlags(0);
+  if (!gameEnabled) {
+    return (
+      <div style={{ padding: 20, fontFamily: "system-ui, sans-serif", lineHeight: 1.4 }}>
+        <h1>Temporarily Unavailable</h1>
+        <p style={{ opacity: 0.8 }}>
+          The game <strong>{gameId}</strong> is currently under maintenance.
+        </p>
+        {maintenanceMessage ? <p>{maintenanceMessage}</p> : null}
+      </div>
+    );
+  }
+  return <>{children}</>;
+}

--- a/src/pages/sigil-syntax/index.tsx
+++ b/src/pages/sigil-syntax/index.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense, useEffect, useMemo, useState } from "react";
 import { loadComponent, resolveOriginalScreens } from "@/games/original.resolve";
+import { Guard } from "@/games/guard";
 
 export default function SigilSyntaxHome() {
   const [Comp, setComp] = useState<React.ComponentType<any> | null>(null);
@@ -34,8 +35,10 @@ export default function SigilSyntaxHome() {
   }
 
   return (
-    <Suspense fallback={<div style={{ padding: 20 }}>Loading…</div>}>
-      <Comp />
-    </Suspense>
+    <Guard gameId="original">
+      <Suspense fallback={<div style={{ padding: 20 }}>Loading…</div>}>
+        <Comp />
+      </Suspense>
+    </Guard>
   );
 }

--- a/src/pages/sigil-syntax/play.tsx
+++ b/src/pages/sigil-syntax/play.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense, useEffect, useMemo, useState } from "react";
 import { loadComponent, resolveOriginalScreens } from "@/games/original.resolve";
+import { Guard } from "@/games/guard";
 
 export default function SigilSyntaxPlay() {
   const [Comp, setComp] = useState<React.ComponentType<any> | null>(null);
@@ -34,8 +35,10 @@ export default function SigilSyntaxPlay() {
   }
 
   return (
-    <Suspense fallback={<div style={{ padding: 20 }}>Loading…</div>}>
-      <Comp />
-    </Suspense>
+    <Guard gameId="original">
+      <Suspense fallback={<div style={{ padding: 20 }}>Loading…</div>}>
+        <Comp />
+      </Suspense>
+    </Guard>
   );
 }

--- a/src/pages/sigil-syntax/rules.tsx
+++ b/src/pages/sigil-syntax/rules.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense, useEffect, useMemo, useState } from "react";
 import { loadComponent, resolveOriginalScreens } from "@/games/original.resolve";
+import { Guard } from "@/games/guard";
 
 export default function SigilSyntaxRules() {
   const [Comp, setComp] = useState<React.ComponentType<any> | null>(null);
@@ -34,8 +35,10 @@ export default function SigilSyntaxRules() {
   }
 
   return (
-    <Suspense fallback={<div style={{ padding: 20 }}>Loading…</div>}>
-      <Comp />
-    </Suspense>
+    <Guard gameId="original">
+      <Suspense fallback={<div style={{ padding: 20 }}>Loading…</div>}>
+        <Comp />
+      </Suspense>
+    </Guard>
   );
 }


### PR DESCRIPTION
## Summary
- add a reusable game Guard component that polls /api/flags for maintenance mode
- wrap the original Sigil & Syntax entry points with the Guard to block access during maintenance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed457436dc832f910d51d6be452b28