### PR TITLE
Add Sigil & Syntax about alias and shared menu

### DIFF
--- a/games/_cache/cut-games.cache.json
+++ b/games/_cache/cut-games.cache.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-13T18:35:36.064Z",
+  "generatedAt": "2025-10-13T18:40:01.386Z",
   "files": [
     "public/data/cut_games/beats_index.json",
     "public/data/cut_games/catalog.json",

--- a/games/_cache/good-word.cache.json
+++ b/games/_cache/good-word.cache.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-13T18:35:36.064Z",
+  "generatedAt": "2025-10-13T18:40:01.386Z",
   "files": [
     "src/components/Footer.tsx",
     "src/labeled-data/the-good-word-core-AZ.json",

--- a/games/_cache/original.cache.json
+++ b/games/_cache/original.cache.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-13T18:35:36.064Z",
+  "generatedAt": "2025-10-13T18:40:01.386Z",
   "files": [
     "public/.gitkeep",
     "public/404.html",
@@ -18,6 +18,7 @@
     "src/components/ToastHost.tsx",
     "src/components/WordCard.tsx",
     "src/games/asset.ts",
+    "src/games/menu.tsx",
     "src/games/original.resolve.ts",
     "src/index.css",
     "src/index.ts",
@@ -33,6 +34,7 @@
     "src/pages/brutalist.css",
     "src/pages/literary-deviousness/index.tsx",
     "src/pages/original/index.tsx",
+    "src/pages/sigil-syntax/about.tsx",
     "src/pages/sigil-syntax/index.tsx",
     "src/pages/sigil-syntax/play.tsx",
     "src/pages/sigil-syntax/rules.tsx",
@@ -52,22 +54,24 @@
     "home": [
       "sigil",
       "syntax",
+      "src/games/menu.tsx",
       "src/index.css",
       "src/index.ts",
       "src/pages/Home.css",
       "src/pages/Home.incoming.tsx",
       "src/pages/Home.ours.merge.tsx",
       "src/pages/Home.tsx",
-      "src/pages/literary-deviousness/index.tsx",
-      "src/pages/original/index.tsx"
+      "src/pages/literary-deviousness/index.tsx"
     ],
     "play": [
       "public/games/original/.gitkeep",
       "src/games/asset.ts",
+      "src/games/menu.tsx",
       "src/games/original.resolve.ts",
       "src/pages/sigil-syntax/play.tsx"
     ],
     "rules": [
+      "src/pages/sigil-syntax/about.tsx",
       "src/pages/sigil-syntax/rules.tsx"
     ]
   }

--- a/src/games/menu.tsx
+++ b/src/games/menu.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+export function GameMenu(props: { base: string; showRules?: boolean }) {
+  const { base, showRules = true } = props;
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 12,
+        flexWrap: "wrap",
+        padding: "10px 16px",
+        borderBottom: "1px solid #eee",
+        fontFamily: "system-ui, sans-serif",
+      }}
+    >
+      <Link to={`${base}`} style={{ textDecoration: "none" }}>
+        Home
+      </Link>
+      <Link to={`${base}/play`} style={{ textDecoration: "none" }}>
+        Play
+      </Link>
+      {showRules && (
+        <Link to={`${base}/rules`} style={{ textDecoration: "none" }}>
+          Rules
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/src/games/original.resolve.ts
+++ b/src/games/original.resolve.ts
@@ -128,6 +128,14 @@ export function resolveOriginalScreens(): Resolved {
   if (!selected.get("rules")) {
     selected.set("rules", findByPattern(rulesPattern, "rules", debug));
   }
+  if (!selected.get("rules")) {
+    const aboutLike = manifestFiles.find((file) =>
+      /(about|info|overview|readme|guide)/i.test(file),
+    );
+    if (aboutLike && isComponentCandidate(aboutLike)) {
+      selected.set("rules", aboutLike);
+    }
+  }
 
   const used = new Set(
     Array.from(selected.values()).filter((value): value is string => Boolean(value)),

--- a/src/pages/sigil-syntax/about.tsx
+++ b/src/pages/sigil-syntax/about.tsx
@@ -3,16 +3,16 @@ import { loadComponent, resolveOriginalScreens } from "@/games/original.resolve"
 import { Guard } from "@/games/guard";
 import { GameMenu } from "@/games/menu";
 
-export default function SigilSyntaxHome() {
+export default function SigilSyntaxAbout() {
   const [Comp, setComp] = useState<React.ComponentType<any> | null>(null);
   const screens = useMemo(() => resolveOriginalScreens(), []);
 
   useEffect(() => {
     let cancelled = false;
     if (typeof window !== "undefined") {
-      console.info("[sigil&syntax] launching ORIGINAL");
+      console.info("[sigil&syntax] launching ORIGINAL about");
     }
-    const path = screens.home || screens.play || screens.fallbacks[0];
+    const path = screens.rules || screens.play || screens.home || screens.fallbacks[0];
     if (path) {
       loadComponent(path)
         .then((component) => {
@@ -22,7 +22,7 @@ export default function SigilSyntaxHome() {
         })
         .catch((error) => {
           if (!cancelled) {
-            console.error("[sigil&syntax] failed to load home", path, error);
+            console.error("[sigil&syntax] failed to load about", path, error);
           }
         });
     }

--- a/src/pages/sigil-syntax/play.tsx
+++ b/src/pages/sigil-syntax/play.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense, useEffect, useMemo, useState } from "react";
 import { loadComponent, resolveOriginalScreens } from "@/games/original.resolve";
 import { Guard } from "@/games/guard";
+import { GameMenu } from "@/games/menu";
 
 export default function SigilSyntaxPlay() {
   const [Comp, setComp] = useState<React.ComponentType<any> | null>(null);
@@ -36,6 +37,7 @@ export default function SigilSyntaxPlay() {
 
   return (
     <Guard gameId="original">
+      <GameMenu base="/sigil-syntax" />
       <Suspense fallback={<div style={{ padding: 20 }}>Loading…</div>}>
         <Comp />
       </Suspense>

--- a/src/pages/sigil-syntax/rules.tsx
+++ b/src/pages/sigil-syntax/rules.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense, useEffect, useMemo, useState } from "react";
 import { loadComponent, resolveOriginalScreens } from "@/games/original.resolve";
 import { Guard } from "@/games/guard";
+import { GameMenu } from "@/games/menu";
 
 export default function SigilSyntaxRules() {
   const [Comp, setComp] = useState<React.ComponentType<any> | null>(null);
@@ -36,6 +37,7 @@ export default function SigilSyntaxRules() {
 
   return (
     <Guard gameId="original">
+      <GameMenu base="/sigil-syntax" />
       <Suspense fallback={<div style={{ padding: 20 }}>Loading…</div>}>
         <Comp />
       </Suspense>


### PR DESCRIPTION
## Summary
- add an "about" fallback to the ORIGINAL resolver so rules screens can point to about/guide style files when needed
- create a reusable GameMenu helper and use it across the Sigil & Syntax wrappers, including a new about alias page
- refresh ORIGINAL caches to register the new wrappers and helper

## Testing
- npm run prebuild
- npm run build *(fails: `vite` command not found in environment)*
- npm run dev -- --host 0.0.0.0 --port 4173 *(fails: `vite` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed472153d0832f8a5796f7e3c9c3df