### PR TITLE
Add Fun House writing module scaffolding

### DIFF
--- a/src/games/fun_house_writing/README.md
+++ b/src/games/fun_house_writing/README.md
@@ -1,0 +1,17 @@
+# Fun House Writing
+
+This module collects the weirder, remix-friendly writing exercises that live in the Funhouse wing of the project. The goal is to provide a clear catalog of prompts alongside reusable UI components so that designers can ship oddball ideas without rewiring the rest of the game shell.
+
+## Directory Tour
+
+- `funhouse_catalog.ts` — canonical list of Funhouse prompt metadata. Each entry links to a UI component and describes how the game riffs on an existing lesson.
+- `types.ts` — shared type definitions for prompts, game types, and component keys.
+- `components/` — React components that actually render the gameplay experience for each Funhouse prompt.
+- `index.tsx` — lightweight entry point that selects the correct UI component at runtime.
+- `playground/` — a sandbox for experiments, prototypes, or reference implementations that are not yet player-ready.
+
+## Development Notes
+
+1. Add new prompts to `funhouse_catalog.ts` and give them a `ui_component` string.
+2. Implement the matching component inside `components/` and register it in `index.tsx`'s `componentRegistry`.
+3. Use the `playground/` folder when exploring odd mechanics or writing helpers before promoting them into production code.

--- a/src/games/fun_house_writing/components/TellEverythingShowNothing.tsx
+++ b/src/games/fun_house_writing/components/TellEverythingShowNothing.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+
+interface TellEverythingShowNothingProps {
+  promptText: string;
+}
+
+export function TellEverythingShowNothing(props: TellEverythingShowNothingProps) {
+  const { promptText } = props;
+
+  return (
+    <section
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "1.5rem",
+        maxWidth: 720,
+        margin: "0 auto",
+        padding: "2rem 1.5rem",
+        fontFamily: "'IBM Plex Sans', system-ui, sans-serif",
+      }}
+    >
+      <header>
+        <h1 style={{ fontSize: "2rem", marginBottom: "0.75rem" }}>
+          Tell Everything, Show Nothing
+        </h1>
+        <p style={{ color: "#555", lineHeight: 1.6 }}>
+          This Funhouse remix challenges writers to deliberately over-explain every
+          feeling, intention, and movement. Lean into exposition. Spell out every
+          motivation. The more literal the better.
+        </p>
+      </header>
+      <article
+        style={{
+          background: "#f8f5ff",
+          border: "1px solid #d9cff9",
+          borderRadius: "12px",
+          padding: "1.5rem",
+          lineHeight: 1.7,
+          color: "#2c2452",
+          boxShadow: "0 12px 32px -24px rgba(61, 35, 125, 0.6)",
+        }}
+      >
+        <strong style={{ display: "block", marginBottom: "0.75rem" }}>
+          Prompt
+        </strong>
+        <p>{promptText}</p>
+      </article>
+      <footer style={{ fontSize: "0.95rem", color: "#666", lineHeight: 1.6 }}>
+        Try drafting the most literal, on-the-nose version of your scene. Once
+        you have exhausted the approach, compare it to the original "Show, Don't
+        Tell" lesson to understand how clarity and subtext trade places.
+      </footer>
+    </section>
+  );
+}

--- a/src/games/fun_house_writing/funhouse_catalog.ts
+++ b/src/games/fun_house_writing/funhouse_catalog.ts
@@ -1,0 +1,15 @@
+import { FunhouseCatalog } from "./types";
+
+export const funhouseCatalog: FunhouseCatalog = [
+  {
+    id: "tell-everything-show-nothing",
+    title: "Show, Don't Tell",
+    description:
+      "Flip the classic writing advice on its head by over-explaining every feeling and action in exhausting detail.",
+    mirrors_lesson_id: "show-dont-tell",
+    prompt_text:
+      "Rewrite a short scene so that every emotion, motivation, and action is explicitly explained. Do not rely on imagery—spell out every intention, feeling, and transition.",
+    game_type: "writing_prompt",
+    ui_component: "TellEverythingShowNothing",
+  },
+];

--- a/src/games/fun_house_writing/index.tsx
+++ b/src/games/fun_house_writing/index.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { funhouseCatalog } from "./funhouse_catalog";
+import { FunhousePrompt } from "./types";
+import { TellEverythingShowNothing } from "./components/TellEverythingShowNothing";
+
+const componentRegistry: Record<string, React.ComponentType<{ prompt: FunhousePrompt }>> = {
+  TellEverythingShowNothing: ({ prompt }) => (
+    <TellEverythingShowNothing promptText={prompt.prompt_text} />
+  ),
+};
+
+export interface FunHouseWritingProps {
+  promptId?: string;
+}
+
+export function FunHouseWriting(props: FunHouseWritingProps) {
+  const { promptId } = props;
+  const prompt = resolvePrompt(promptId);
+
+  if (!prompt) {
+    return (
+      <div style={{ padding: "2rem", fontFamily: "system-ui, sans-serif" }}>
+        <h2 style={{ marginBottom: "0.5rem" }}>Funhouse prompt not found</h2>
+        <p style={{ color: "#555" }}>
+          The requested Funhouse prompt either does not exist yet or is still being
+          prototyped in the Funhouse lab.
+        </p>
+      </div>
+    );
+  }
+
+  const Component = componentRegistry[prompt.ui_component];
+
+  if (!Component) {
+    return (
+      <div style={{ padding: "2rem", fontFamily: "system-ui, sans-serif" }}>
+        <h2 style={{ marginBottom: "0.5rem" }}>UI component missing</h2>
+        <p style={{ color: "#555" }}>
+          We have a prompt definition for this game, but the UI component
+          <code style={{ marginLeft: 4 }}>{prompt.ui_component}</code> has not been
+          wired up yet.
+        </p>
+      </div>
+    );
+  }
+
+  return <Component prompt={prompt} />;
+}
+
+function resolvePrompt(promptId?: string): FunhousePrompt | undefined {
+  if (promptId) {
+    return funhouseCatalog.find((entry) => entry.id === promptId);
+  }
+
+  return funhouseCatalog[0];
+}

--- a/src/games/fun_house_writing/playground/README.md
+++ b/src/games/fun_house_writing/playground/README.md
@@ -1,0 +1,3 @@
+# Funhouse Playground
+
+This folder is intentionally loose. Use it to spike strange mechanics, build quick prototypes, or jot down reference utilities before they are ready for the main `components/` directory.

--- a/src/games/fun_house_writing/types.ts
+++ b/src/games/fun_house_writing/types.ts
@@ -1,0 +1,20 @@
+export type FunhouseGameType =
+  | "writing_prompt"
+  | "beat_arcade"
+  | "style_swap"
+  | "experimental"
+  | string;
+
+export type FunhouseComponentKey = "TellEverythingShowNothing" | string;
+
+export interface FunhousePrompt {
+  id: string;
+  title: string;
+  description: string;
+  mirrors_lesson_id?: string;
+  prompt_text: string;
+  game_type: FunhouseGameType;
+  ui_component: FunhouseComponentKey;
+}
+
+export type FunhouseCatalog = FunhousePrompt[];


### PR DESCRIPTION
## Summary
- add a Fun House writing directory with catalog, types, and entry point
- implement the Tell Everything, Show Nothing gameplay component
- document the module layout and create a playground for experiments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed4a6b168c832faea6ebdce97dc97e