### PR TITLE
Add funhouse variant generator and supporting UI components

### DIFF
--- a/src/games/fun_house_writing/components/GenreMangleMachine.tsx
+++ b/src/games/fun_house_writing/components/GenreMangleMachine.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { FunhousePrompt } from "../types";
+
+interface GenreMangleMachineProps {
+  prompt: FunhousePrompt;
+}
+
+const GenreMangleMachine: React.FC<GenreMangleMachineProps> = ({ prompt }) => {
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", padding: "2rem", maxWidth: 720 }}>
+      <header style={{ marginBottom: "1.5rem" }}>
+        <h1 style={{ fontSize: "2rem", marginBottom: "0.5rem" }}>{prompt.title}</h1>
+        <p style={{ color: "#475569", lineHeight: 1.5 }}>{prompt.description}</p>
+      </header>
+      <section style={{ marginBottom: "1.5rem" }}>
+        <h2 style={{ fontSize: "1.25rem", marginBottom: "0.5rem" }}>Genre Remix Instructions</h2>
+        <p style={{ background: "#fef3c7", padding: "1rem", borderRadius: "0.75rem", lineHeight: 1.6 }}>
+          {prompt.prompt_text}
+        </p>
+      </section>
+      <ol style={{ marginLeft: "1.5rem", color: "#334155", lineHeight: 1.6 }}>
+        <li>List the hallmarks of the requested genre.</li>
+        <li>Rewrite the original scene beats to highlight those genre traits.</li>
+        <li>Keep the emotional core intact while the dressing gets weird.</li>
+      </ol>
+    </div>
+  );
+};
+
+export default GenreMangleMachine;

--- a/src/games/fun_house_writing/components/MirrorDrillUI.tsx
+++ b/src/games/fun_house_writing/components/MirrorDrillUI.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { FunhousePrompt } from "../types";
+
+interface MirrorDrillUIProps {
+  prompt: FunhousePrompt;
+}
+
+const labelStyles: React.CSSProperties = {
+  textTransform: "uppercase",
+  fontSize: "0.75rem",
+  letterSpacing: "0.08em",
+  color: "#0f172a",
+};
+
+const MirrorDrillUI: React.FC<MirrorDrillUIProps> = ({ prompt }) => {
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", padding: "2rem", maxWidth: 720 }}>
+      <header style={{ marginBottom: "1.5rem" }}>
+        <h1 style={{ fontSize: "2rem", marginBottom: "0.5rem" }}>{prompt.title}</h1>
+        <p style={{ color: "#1f2937", lineHeight: 1.6 }}>{prompt.description}</p>
+      </header>
+      <section style={{ marginBottom: "1.5rem" }}>
+        <div style={{ marginBottom: "0.5rem", ...labelStyles }}>Prompt</div>
+        <p style={{ background: "#ecfeff", padding: "1rem", borderRadius: "0.75rem", lineHeight: 1.6 }}>
+          {prompt.prompt_text}
+        </p>
+      </section>
+      <section style={{ display: "grid", gap: "1rem" }}>
+        <article style={{ background: "#cffafe", borderRadius: "0.75rem", padding: "1rem" }}>
+          <div style={labelStyles}>Step 1</div>
+          <p style={{ margin: 0 }}>Write the scene once exactly as directed. Don’t name the emotion.</p>
+        </article>
+        <article style={{ background: "#bae6fd", borderRadius: "0.75rem", padding: "1rem" }}>
+          <div style={labelStyles}>Step 2</div>
+          <p style={{ margin: 0 }}>
+            Now exaggerate or deny the feeling per the twist. Compare the drafts and note which lines make the emotion clearest
+            without naming it.
+          </p>
+        </article>
+      </section>
+    </div>
+  );
+};
+
+export default MirrorDrillUI;

--- a/src/games/fun_house_writing/components/OneParagraphChallenge.tsx
+++ b/src/games/fun_house_writing/components/OneParagraphChallenge.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { FunhousePrompt } from "../types";
+
+interface OneParagraphChallengeProps {
+  prompt: FunhousePrompt;
+}
+
+const OneParagraphChallenge: React.FC<OneParagraphChallengeProps> = ({ prompt }) => {
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", padding: "2rem", maxWidth: 720 }}>
+      <header style={{ marginBottom: "1.5rem" }}>
+        <h1 style={{ fontSize: "2rem", marginBottom: "0.5rem" }}>{prompt.title}</h1>
+        <p style={{ color: "#475569", lineHeight: 1.5 }}>{prompt.description}</p>
+      </header>
+      <section style={{ marginBottom: "1.25rem" }}>
+        <h2 style={{ fontSize: "1.25rem", marginBottom: "0.5rem" }}>Observation Log</h2>
+        <p style={{ background: "#f1f5f9", padding: "1rem", borderRadius: "0.75rem", lineHeight: 1.6 }}>
+          {prompt.prompt_text}
+        </p>
+      </section>
+      <section style={{ background: "#e2e8f0", borderRadius: "0.75rem", padding: "1rem" }}>
+        <p style={{ margin: 0, lineHeight: 1.6 }}>
+          Draft ten bullet-point observations. Each one should feel like a strange snapshot of the story. Once you have them,
+          stitch the list into a single paragraph that still reads like a catalog of oddities.
+        </p>
+      </section>
+    </div>
+  );
+};
+
+export default OneParagraphChallenge;

--- a/src/games/fun_house_writing/components/VoiceSwapGame.tsx
+++ b/src/games/fun_house_writing/components/VoiceSwapGame.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { FunhousePrompt } from "../types";
+
+interface VoiceSwapGameProps {
+  prompt: FunhousePrompt;
+}
+
+const VoiceSwapGame: React.FC<VoiceSwapGameProps> = ({ prompt }) => {
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", padding: "2rem", maxWidth: 720 }}>
+      <header style={{ marginBottom: "1.5rem" }}>
+        <h1 style={{ fontSize: "2rem", marginBottom: "0.5rem" }}>{prompt.title}</h1>
+        <p style={{ color: "#4b5563", lineHeight: 1.5 }}>{prompt.description}</p>
+      </header>
+      <section style={{ marginBottom: "1.5rem" }}>
+        <h2 style={{ fontSize: "1.25rem", marginBottom: "0.5rem" }}>Voice Swap Challenge</h2>
+        <p style={{ background: "#eef2ff", padding: "1rem", borderRadius: "0.75rem", lineHeight: 1.6 }}>
+          {prompt.prompt_text}
+        </p>
+      </section>
+      <div
+        style={{
+          background: "#1e293b",
+          color: "#f8fafc",
+          padding: "1rem 1.25rem",
+          borderRadius: "0.75rem",
+          lineHeight: 1.5,
+        }}
+      >
+        Try narrating the scene directly to the reader. Keep the twist in mind and lean into how the storyteller’s tone shifts the
+        experience.
+      </div>
+    </div>
+  );
+};
+
+export default VoiceSwapGame;

--- a/src/games/fun_house_writing/funhouse_catalog.ts
+++ b/src/games/fun_house_writing/funhouse_catalog.ts
@@ -1,4 +1,5 @@
 import { FunhouseCatalog } from "./types";
+import { generatedFunhouseVariants } from "./generated_funhouse_variants";
 
 export const funhouseCatalog: FunhouseCatalog = [
   {
@@ -12,4 +13,5 @@ export const funhouseCatalog: FunhouseCatalog = [
     game_type: "writing_prompt",
     ui_component: "FreeWriteTextBox",
   },
+  ...generatedFunhouseVariants,
 ];

--- a/src/games/fun_house_writing/generated_funhouse_variants.ts
+++ b/src/games/fun_house_writing/generated_funhouse_variants.ts
@@ -2,4 +2,135 @@
 
 import { FunhouseCatalog } from "./types";
 
-export const generatedFunhouseVariants: FunhouseCatalog = [];
+export const generatedFunhouseVariants: FunhouseCatalog = [
+  {
+    id: "foundation-014-funhouse-1",
+    title: "Show, Don’t Tell – Funhouse Variant 1",
+    description:
+      "Teaches how to evoke emotions and ideas through imagery, actions, and subtext instead of direct explanation. Funhouse twist: Make it melodramatic.",
+    mirrors_lesson_id: "foundation-014",
+    prompt_text:
+      "Original prompt: Write a short scene where the character feels something deeply, but you’re not allowed to name the feeling.\n\nRewrite the lesson prompt but with this twist: Make it melodramatic.",
+    constraint_type: "tone",
+    constraint_label: "Make it melodramatic",
+    game_type: "writing_prompt",
+    ui_component: "FreeWriteTextBox",
+  },
+  {
+    id: "foundation-014-funhouse-2",
+    title: "Show, Don’t Tell – Funhouse Variant 2",
+    description:
+      "Teaches how to evoke emotions and ideas through imagery, actions, and subtext instead of direct explanation. Funhouse twist: Make it absurd comedy.",
+    mirrors_lesson_id: "foundation-014",
+    prompt_text:
+      "Original prompt: Write a short scene where the character feels something deeply, but you’re not allowed to name the feeling.\n\nRewrite the lesson prompt but with this twist: Make it absurd comedy.",
+    constraint_type: "tone",
+    constraint_label: "Make it absurd comedy",
+    game_type: "writing_prompt",
+    ui_component: "FreeWriteTextBox",
+  },
+  {
+    id: "foundation-014-funhouse-3",
+    title: "Show, Don’t Tell – Funhouse Variant 3",
+    description:
+      "Teaches how to evoke emotions and ideas through imagery, actions, and subtext instead of direct explanation. Funhouse twist: Write in second person.",
+    mirrors_lesson_id: "foundation-014",
+    prompt_text:
+      "Original prompt: Write a short scene where the character feels something deeply, but you’re not allowed to name the feeling.\n\nRewrite the lesson prompt but with this twist: Write in second person.",
+    constraint_type: "POV",
+    constraint_label: "Write in second person",
+    game_type: "style_swap",
+    ui_component: "VoiceSwapGame",
+  },
+  {
+    id: "foundation-014-funhouse-4",
+    title: "Show, Don’t Tell – Funhouse Variant 4",
+    description:
+      "Teaches how to evoke emotions and ideas through imagery, actions, and subtext instead of direct explanation. Funhouse twist: Unreliable narrator version.",
+    mirrors_lesson_id: "foundation-014",
+    prompt_text:
+      "Original prompt: Write a short scene where the character feels something deeply, but you’re not allowed to name the feeling.\n\nRewrite the lesson prompt but with this twist: Unreliable narrator version.",
+    constraint_type: "POV",
+    constraint_label: "Unreliable narrator version",
+    game_type: "style_swap",
+    ui_component: "VoiceSwapGame",
+  },
+  {
+    id: "foundation-014-funhouse-5",
+    title: "Show, Don’t Tell – Funhouse Variant 5",
+    description:
+      "Teaches how to evoke emotions and ideas through imagery, actions, and subtext instead of direct explanation. Funhouse twist: Make it horror.",
+    mirrors_lesson_id: "foundation-014",
+    prompt_text:
+      "Original prompt: Write a short scene where the character feels something deeply, but you’re not allowed to name the feeling.\n\nRewrite the lesson prompt but with this twist: Make it horror.",
+    constraint_type: "genre",
+    constraint_label: "Make it horror",
+    game_type: "style_swap",
+    ui_component: "GenreMangleMachine",
+  },
+  {
+    id: "foundation-014-funhouse-6",
+    title: "Show, Don’t Tell – Funhouse Variant 6",
+    description:
+      "Teaches how to evoke emotions and ideas through imagery, actions, and subtext instead of direct explanation. Funhouse twist: Make it noir detective fiction.",
+    mirrors_lesson_id: "foundation-014",
+    prompt_text:
+      "Original prompt: Write a short scene where the character feels something deeply, but you’re not allowed to name the feeling.\n\nRewrite the lesson prompt but with this twist: Make it noir detective fiction.",
+    constraint_type: "genre",
+    constraint_label: "Make it noir detective fiction",
+    game_type: "style_swap",
+    ui_component: "GenreMangleMachine",
+  },
+  {
+    id: "foundation-014-funhouse-7",
+    title: "Show, Don’t Tell – Funhouse Variant 7",
+    description:
+      "Teaches how to evoke emotions and ideas through imagery, actions, and subtext instead of direct explanation. Funhouse twist: Character denies the emotion.",
+    mirrors_lesson_id: "foundation-014",
+    prompt_text:
+      "Original prompt: Write a short scene where the character feels something deeply, but you’re not allowed to name the feeling.\n\nRewrite the lesson prompt but with this twist: Character denies the emotion.",
+    constraint_type: "emotion",
+    constraint_label: "Character denies the emotion",
+    game_type: "experimental",
+    ui_component: "MirrorDrillUI",
+  },
+  {
+    id: "foundation-014-funhouse-8",
+    title: "Show, Don’t Tell – Funhouse Variant 8",
+    description:
+      "Teaches how to evoke emotions and ideas through imagery, actions, and subtext instead of direct explanation. Funhouse twist: Character explodes with the emotion.",
+    mirrors_lesson_id: "foundation-014",
+    prompt_text:
+      "Original prompt: Write a short scene where the character feels something deeply, but you’re not allowed to name the feeling.\n\nRewrite the lesson prompt but with this twist: Character explodes with the emotion.",
+    constraint_type: "emotion",
+    constraint_label: "Character explodes with the emotion",
+    game_type: "experimental",
+    ui_component: "MirrorDrillUI",
+  },
+  {
+    id: "foundation-014-funhouse-9",
+    title: "Show, Don’t Tell – Funhouse Variant 9",
+    description:
+      "Teaches how to evoke emotions and ideas through imagery, actions, and subtext instead of direct explanation. Funhouse twist: Write it backwards.",
+    mirrors_lesson_id: "foundation-014",
+    prompt_text:
+      "Original prompt: Write a short scene where the character feels something deeply, but you’re not allowed to name the feeling.\n\nRewrite the lesson prompt but with this twist: Write it backwards.",
+    constraint_type: "structure",
+    constraint_label: "Write it backwards",
+    game_type: "beat_arcade",
+    ui_component: "BeatComboMachine",
+  },
+  {
+    id: "foundation-014-funhouse-10",
+    title: "Show, Don’t Tell – Funhouse Variant 10",
+    description:
+      "Teaches how to evoke emotions and ideas through imagery, actions, and subtext instead of direct explanation. Funhouse twist: List the story as 10 weird observations.",
+    mirrors_lesson_id: "foundation-014",
+    prompt_text:
+      "Original prompt: Write a short scene where the character feels something deeply, but you’re not allowed to name the feeling.\n\nRewrite the lesson prompt but with this twist: List the story as 10 weird observations.",
+    constraint_type: "structure",
+    constraint_label: "List the story as 10 weird observations",
+    game_type: "experimental",
+    ui_component: "OneParagraphChallenge",
+  },
+];

--- a/src/games/fun_house_writing/types.ts
+++ b/src/games/fun_house_writing/types.ts
@@ -9,6 +9,10 @@ export type FunhouseComponentKey =
   | "FreeWriteTextBox"
   | "BeatComboMachine"
   | "VoiceImpersonatorChallenge"
+  | "VoiceSwapGame"
+  | "GenreMangleMachine"
+  | "MirrorDrillUI"
+  | "OneParagraphChallenge"
   | string;
 
 export interface FunhousePrompt {
@@ -19,6 +23,8 @@ export interface FunhousePrompt {
   prompt_text: string;
   game_type: FunhouseGameType;
   ui_component: FunhouseComponentKey;
+  constraint_type?: string;
+  constraint_label?: string;
 }
 
 export type FunhouseCatalog = FunhousePrompt[];


### PR DESCRIPTION
## Summary
- expand the Funhouse variant emitter to spin up constraint-based twists for each lesson
- populate the generated catalog for "Show, Don’t Tell" and expose the variants through the Funhouse menu
- add simple placeholder components for the new Funhouse UI surfaces

## Testing
- npm run build *(fails: vite binary missing because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed51da70f0832f8514aa007ab17c4b