### PR TITLE
Refactor funhouse variant generator to read lesson files

### DIFF
--- a/scripts/emit_funhouse_variants.ts
+++ b/scripts/emit_funhouse_variants.ts
@@ -1,9 +1,18 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import { lessonCatalog } from "../src/lessons/lesson_catalog";
+type LessonMetadata = {
+  deprecated?: boolean;
+};
 
-type LessonCatalogEntry = (typeof lessonCatalog)[number];
+type Lesson = {
+  id: string;
+  title?: string;
+  summary?: string;
+  core_prompt?: string;
+  deprecated?: boolean;
+  metadata?: LessonMetadata;
+};
 
 type FunhouseVariant = {
   id: string;
@@ -61,57 +70,221 @@ const CONSTRAINTS: Constraint[] = [
   },
 ];
 
-const OUTPUT_PATH = path.join(
+const DEFAULT_LESSONS_DIR = "foundation_lessons";
+const DEFAULT_JSON_OUTPUT = "funhouse_variants.json";
+const DEFAULT_TS_OUTPUT = path.join(
   "src",
   "games",
   "fun_house_writing",
   "generated_funhouse_variants.ts",
 );
 
-function isDeprecated(lesson: LessonCatalogEntry): boolean {
-  const directDeprecated =
-    typeof (lesson as { deprecated?: unknown }).deprecated === "boolean"
-      ? Boolean((lesson as { deprecated?: boolean }).deprecated)
-      : false;
+type CliOptions = {
+  lessonsDir: string;
+  tsOutputPath: string;
+  jsonOutputPath: string | null;
+};
 
-  if (directDeprecated) {
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function toString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function normaliseLesson(json: unknown, source: string): Lesson | null {
+  if (!isPlainObject(json)) {
+    console.warn(`⚠️  Skipping lesson at ${source}: expected an object.`);
+    return null;
+  }
+
+  const record = json as Record<string, unknown>;
+  const idValue = toString(record.id);
+
+  if (!idValue) {
+    console.warn(`⚠️  Skipping lesson at ${source}: missing a valid "id" field.`);
+    return null;
+  }
+
+  let metadata: LessonMetadata | undefined;
+  if ("metadata" in record && isPlainObject(record.metadata)) {
+    const deprecated = toBoolean((record.metadata as Record<string, unknown>).deprecated);
+    metadata = deprecated === undefined ? undefined : { deprecated };
+  }
+
+  return {
+    id: idValue,
+    title: toString(record.title),
+    summary: toString(record.summary),
+    core_prompt: toString(record.core_prompt),
+    deprecated: toBoolean(record.deprecated),
+    metadata,
+  };
+}
+
+async function loadLessons(lessonsDir: string): Promise<Lesson[]> {
+  const directoryPath = path.resolve(process.cwd(), lessonsDir);
+  let entries;
+
+  try {
+    entries = await readdir(directoryPath, { withFileTypes: true });
+  } catch (error) {
+    throw new Error(
+      `Failed to read lessons directory at "${directoryPath}": ${(error as Error).message}`,
+    );
+  }
+
+  const lessons: Lesson[] = [];
+  const seenIds = new Set<string>();
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) {
+      continue;
+    }
+
+    const filePath = path.join(directoryPath, entry.name);
+
+    try {
+      const raw = await readFile(filePath, "utf8");
+      const parsed = JSON.parse(raw) as unknown;
+      const lesson = normaliseLesson(parsed, filePath);
+
+      if (!lesson) {
+        continue;
+      }
+
+      if (seenIds.has(lesson.id)) {
+        console.warn(
+          `⚠️  Skipping duplicate lesson id "${lesson.id}" found at ${filePath}.`,
+        );
+        continue;
+      }
+
+      seenIds.add(lesson.id);
+      lessons.push(lesson);
+    } catch (error) {
+      console.warn(`⚠️  Failed to parse lesson at ${filePath}: ${(error as Error).message}`);
+    }
+  }
+
+  lessons.sort((a, b) => a.id.localeCompare(b.id));
+
+  return lessons;
+}
+
+function resolveCliOptions(args: string[]): CliOptions {
+  let lessonsDir = process.env.FUNHOUSE_LESSONS_DIR ?? DEFAULT_LESSONS_DIR;
+  let tsOutputPath = process.env.FUNHOUSE_TS_OUTPUT ?? DEFAULT_TS_OUTPUT;
+  let jsonOutputPath: string | null;
+
+  if (process.env.FUNHOUSE_JSON_OUTPUT === "false") {
+    jsonOutputPath = null;
+  } else if (typeof process.env.FUNHOUSE_JSON_OUTPUT === "string") {
+    jsonOutputPath = process.env.FUNHOUSE_JSON_OUTPUT;
+  } else {
+    jsonOutputPath = DEFAULT_JSON_OUTPUT;
+  }
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    switch (arg) {
+      case "--lessons": {
+        const next = args[index + 1];
+        if (!next || next.startsWith("--")) {
+          throw new Error("--lessons option requires a directory path");
+        }
+
+        lessonsDir = next;
+        index += 1;
+        break;
+      }
+
+      case "--ts": {
+        const next = args[index + 1];
+        if (!next || next.startsWith("--")) {
+          throw new Error("--ts option requires a file path");
+        }
+
+        tsOutputPath = next;
+        index += 1;
+        break;
+      }
+
+      case "--json": {
+        const next = args[index + 1];
+        if (!next || next.startsWith("--")) {
+          jsonOutputPath = DEFAULT_JSON_OUTPUT;
+        } else {
+          jsonOutputPath = next;
+          index += 1;
+        }
+        break;
+      }
+
+      case "--no-json": {
+        jsonOutputPath = null;
+        break;
+      }
+
+      default:
+        throw new Error(`Unknown CLI option "${arg}".`);
+    }
+  }
+
+  const resolvedLessonsDir = path.resolve(process.cwd(), lessonsDir);
+  const resolvedTsOutput = path.resolve(process.cwd(), tsOutputPath);
+  const resolvedJsonOutput =
+    jsonOutputPath === null ? null : path.resolve(process.cwd(), jsonOutputPath);
+
+  return {
+    lessonsDir: resolvedLessonsDir,
+    tsOutputPath: resolvedTsOutput,
+    jsonOutputPath: resolvedJsonOutput,
+  };
+}
+
+function isDeprecated(lesson: Lesson): boolean {
+  if (lesson.deprecated === true) {
     return true;
   }
 
-  const metaDeprecated = Boolean(
-    (lesson as { metadata?: { deprecated?: boolean } }).metadata?.deprecated,
-  );
+  const metaDeprecated = Boolean(lesson.metadata?.deprecated);
 
   return metaDeprecated;
 }
 
-function hasValidTitle(lesson: LessonCatalogEntry): lesson is LessonCatalogEntry & {
+function hasValidTitle(lesson: Lesson): lesson is Lesson & {
   title: string;
 } {
-  const title = (lesson as { title?: unknown }).title;
-  return typeof title === "string" && title.trim().length > 0;
+  return typeof lesson.title === "string" && lesson.title.trim().length > 0;
 }
 
-function getSummary(lesson: LessonCatalogEntry): string | null {
-  const summary = (lesson as { summary?: unknown }).summary;
-  if (typeof summary === "string" && summary.trim().length > 0) {
-    return summary.trim();
+function getSummary(lesson: Lesson): string | null {
+  if (typeof lesson.summary === "string" && lesson.summary.trim().length > 0) {
+    return lesson.summary.trim();
   }
 
   return null;
 }
 
-function getCorePrompt(lesson: LessonCatalogEntry): string | null {
-  const corePrompt = (lesson as { core_prompt?: unknown }).core_prompt;
-  if (typeof corePrompt === "string" && corePrompt.trim().length > 0) {
-    return corePrompt.trim();
+function getCorePrompt(lesson: Lesson): string | null {
+  if (typeof lesson.core_prompt === "string" && lesson.core_prompt.trim().length > 0) {
+    return lesson.core_prompt.trim();
   }
 
   return null;
 }
 
 function createVariant(
-  lesson: LessonCatalogEntry & { title: string },
+  lesson: Lesson & { title: string },
   constraint: Constraint,
   index: number,
 ): FunhouseVariant {
@@ -139,10 +312,10 @@ function createVariant(
   };
 }
 
-function buildVariants(): FunhouseVariant[] {
+function buildVariants(lessons: Lesson[]): FunhouseVariant[] {
   const variants: FunhouseVariant[] = [];
 
-  for (const lesson of lessonCatalog) {
+  for (const lesson of lessons) {
     if (!hasValidTitle(lesson)) {
       continue;
     }
@@ -159,7 +332,7 @@ function buildVariants(): FunhouseVariant[] {
   return variants;
 }
 
-function formatFile(variants: FunhouseVariant[]): string {
+function formatTsFile(variants: FunhouseVariant[]): string {
   const header = "// AUTO-GENERATED FUNHOUSE PROMPTS — DO NOT EDIT BY HAND";
   const importLine = "import { FunhouseCatalog } from \"./types\";";
   const body = `export const generatedFunhouseVariants: FunhouseCatalog = ${JSON.stringify(
@@ -171,12 +344,38 @@ function formatFile(variants: FunhouseVariant[]): string {
   return `${header}\n\n${importLine}\n\n${body}\n`;
 }
 
-async function main(): Promise<void> {
-  const variants = buildVariants();
-  const fileContents = formatFile(variants);
+function formatJsonFile(variants: FunhouseVariant[]): string {
+  return `${JSON.stringify(variants, null, 2)}\n`;
+}
 
-  await mkdir(path.dirname(OUTPUT_PATH), { recursive: true });
-  await writeFile(OUTPUT_PATH, fileContents, "utf8");
+async function main(): Promise<void> {
+  const options = resolveCliOptions(process.argv.slice(2));
+  const lessons = await loadLessons(options.lessonsDir);
+  const variants = buildVariants(lessons);
+  const tsFileContents = formatTsFile(variants);
+
+  await mkdir(path.dirname(options.tsOutputPath), { recursive: true });
+  await writeFile(options.tsOutputPath, tsFileContents, "utf8");
+
+  console.log(
+    `✅ Wrote ${variants.length} Funhouse variants to ${path.relative(
+      process.cwd(),
+      options.tsOutputPath,
+    )}`,
+  );
+
+  if (options.jsonOutputPath) {
+    await mkdir(path.dirname(options.jsonOutputPath), { recursive: true });
+    const jsonFileContents = formatJsonFile(variants);
+    await writeFile(options.jsonOutputPath, jsonFileContents, "utf8");
+
+    console.log(
+      `✅ Wrote ${variants.length} Funhouse variants to ${path.relative(
+        process.cwd(),
+        options.jsonOutputPath,
+      )}`,
+    );
+  }
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary
- switch the funhouse variant emitter to load lesson JSON files instead of importing the TypeScript catalog
- add CLI/environment configuration for lesson sources and output destinations, and optionally emit a JSON export
- keep generating the TypeScript catalog while creating a default funhouse_variants.json for downstream tooling

## Testing
- npm run build -- --no-minify *(fails: vite binary not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed5464f340832f8a0c905019a32845