### PR TITLE
Add Funhouse hub and routing for writing variants

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,8 @@ import PlayMCQ from "./pages/PlayMCQ";
 import PlaySlot from "./pages/PlaySlot";
 import NotFound from "./pages/NotFound";
 import CutGames from "./pages/CutGames";
+import FunhouseHub from "./pages/FunhouseHub";
+import FunhouseGame from "./pages/FunhouseGame";
 import { Header } from "./components/Header";
 import { ToastHost } from "./components/ToastHost";
 import { KeyOverlay } from "./components/KeyOverlay";
@@ -34,6 +36,8 @@ export default function App() {
             <Route path="/practice" element={<PracticeHub />} />
             <Route path="/practice/:id" element={<PracticePage />} />
             <Route path="/play/cut-games" element={<CutGames />} />
+            <Route path="/funhouse" element={<FunhouseHub />} />
+            <Route path="/funhouse/:id" element={<FunhouseGame />} />
             <Route path="/play/:id/see" element={<PlaySee />} />
             <Route path="/play/:id/mcq" element={<PlayMCQ />} />
             <Route path="/play/:id/slot" element={<PlaySlot />} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -32,6 +32,9 @@ export function Header() {
           <NavLink to="/play/cut-games" className={navClass}>
             Cut Games
           </NavLink>
+          <NavLink to="/funhouse" className={navClass}>
+            Funhouse
+          </NavLink>
           <NavLink to="/settings" className={navClass}>
             Settings
           </NavLink>

--- a/src/pages/FunhouseGame.tsx
+++ b/src/pages/FunhouseGame.tsx
@@ -1,0 +1,28 @@
+import type { JSX } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import { GameLoader } from "@/games/fun_house_writing";
+
+export default function FunhouseGame(): JSX.Element {
+  const { id } = useParams<{ id: string }>();
+
+  if (!id) {
+    return (
+      <div className="mx-auto flex max-w-2xl flex-col gap-4 p-6 text-center">
+        <p className="text-lg font-semibold">No Funhouse game selected.</p>
+        <Link
+          to="/funhouse"
+          className="mx-auto inline-flex items-center justify-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700"
+        >
+          Browse Funhouse variants
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-5xl p-4">
+      <GameLoader id={id} />
+    </div>
+  );
+}

--- a/src/pages/FunhouseHub.tsx
+++ b/src/pages/FunhouseHub.tsx
@@ -1,0 +1,46 @@
+import type { JSX } from "react";
+import { Link } from "react-router-dom";
+
+import { funhouseCatalog } from "@/games/fun_house_writing/funhouse_catalog";
+
+export default function FunhouseHub(): JSX.Element {
+  const routes = funhouseCatalog.map((entry) => ({
+    id: entry.id,
+    title: entry.title,
+    description: entry.description,
+  }));
+
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-6 p-6">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold">🎪 Welcome to the Funhouse</h1>
+        <p className="text-neutral-600 dark:text-neutral-400">
+          Pick a remix to see the prompt and launch its custom interface.
+        </p>
+      </header>
+      <ul className="space-y-4">
+        {routes.map((route) => (
+          <li
+            key={route.id}
+            className="rounded border border-neutral-200 p-4 shadow-sm transition hover:border-neutral-300 dark:border-neutral-700 dark:hover:border-neutral-500"
+          >
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="text-xl font-semibold">{route.title}</h2>
+                <p className="text-sm text-neutral-600 dark:text-neutral-400">
+                  {route.description}
+                </p>
+              </div>
+              <Link
+                to={`/funhouse/${route.id}`}
+                className="inline-flex items-center justify-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700"
+              >
+                Play variant
+              </Link>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/games/index.tsx
+++ b/src/pages/games/index.tsx
@@ -16,6 +16,9 @@ export default function GamesHub(): JSX.Element {
         <a className="text-blue-600 underline" href="#/cutgames">
           The Cut Games
         </a>
+        <a className="text-blue-600 underline" href="#/funhouse">
+          The Funhouse
+        </a>
       </nav>
     </section>
   );

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -15,3 +15,5 @@ export { default as Foundation } from "./Foundation";
 export { default as Games } from "./games";
 export { default as Play } from "./Play";
 export { default as SigilSyntaxRoot } from "./SigilSyntaxRoot";
+export { default as FunhouseHub } from "./FunhouseHub";
+export { default as FunhouseGame } from "./FunhouseGame";


### PR DESCRIPTION
## Summary
- add a Funhouse hub page that lists every variant from the fun_house_writing catalog
- add a Funhouse game page that loads the proper interface for a selected variant and wire both routes into the app
- update navigation exports and menu links so the new Funhouse section is discoverable

## Testing
- npm run build *(fails: vite is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed59338514832f9372f5c3d00ac835