### PR TITLE
Add script to generate Funhouse lesson variants

### DIFF
--- a/scripts/generate-funhouse-lesson-variants.ts
+++ b/scripts/generate-funhouse-lesson-variants.ts
@@ -1,0 +1,259 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+interface LessonData {
+  id?: string;
+}
+
+interface FunhouseVariantDefinition {
+  name: string;
+  description: string;
+  mode: string;
+  distortion: string;
+}
+
+interface CliOptions {
+  lessonPath?: string;
+  lessonId?: string;
+  outputDir: string;
+  variantPath?: string;
+}
+
+const DEFAULT_OUTPUT_DIR = path.join(
+  "src",
+  "games",
+  "fun_house_writing",
+  "generated",
+);
+
+const DEFAULT_VARIANTS: FunhouseVariantDefinition[] = [
+  {
+    name: "Write It Wrong",
+    description: "Take the original device and butcher it. Make it fail on purpose.",
+    mode: "text",
+    distortion: "reverse purpose",
+  },
+  {
+    name: "Dumb It Down",
+    description: "Explain this concept like a himbo who thinks commas are a scam.",
+    mode: "text",
+    distortion: "tone:dumb",
+  },
+  {
+    name: "Opposite Day",
+    description:
+      "Use the exact opposite technique. If it's fast, go slow. If it's subtle, go wild.",
+    mode: "text",
+    distortion: "negate",
+  },
+  {
+    name: "Melt It",
+    description: "Write as if the entire idea is melting into soup. Make it surreal.",
+    mode: "freeform",
+    distortion: "style:meltdown",
+  },
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function escapeTemplateLiteral(raw: string): string {
+  return raw.replace(/`/g, "\\`").replace(/\$\{/g, "\\${");
+}
+
+function toKebabCase(value: string): string {
+  return value
+    .trim()
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .toLowerCase();
+}
+
+function toPascalCase(value: string): string {
+  const tokens = value.match(/[a-zA-Z0-9]+/g);
+  if (!tokens) {
+    return "FunhouseVariant";
+  }
+
+  const camel = tokens
+    .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
+    .join("");
+
+  if (/^[0-9]/.test(camel)) {
+    return `Variant${camel}`;
+  }
+
+  return camel;
+}
+
+async function loadLessonId(lessonPath: string): Promise<string | undefined> {
+  const absolutePath = path.resolve(process.cwd(), lessonPath);
+  const raw = await readFile(absolutePath, "utf8");
+  const parsed = JSON.parse(raw) as LessonData;
+
+  return typeof parsed.id === "string" && parsed.id.trim().length > 0
+    ? parsed.id.trim()
+    : undefined;
+}
+
+async function loadVariants(variantPath: string): Promise<FunhouseVariantDefinition[]> {
+  const absolutePath = path.resolve(process.cwd(), variantPath);
+  const raw = await readFile(absolutePath, "utf8");
+  const parsed = JSON.parse(raw) as unknown;
+
+  if (!Array.isArray(parsed)) {
+    throw new Error(`Expected an array at ${absolutePath}`);
+  }
+
+  const variants: FunhouseVariantDefinition[] = [];
+
+  for (const [index, item] of parsed.entries()) {
+    if (!isRecord(item)) {
+      throw new Error(`Variant at index ${index} is not an object in ${absolutePath}`);
+    }
+
+    const { name, description, mode, distortion } = item as Record<string, unknown>;
+
+    if (typeof name !== "string" || name.trim().length === 0) {
+      throw new Error(`Variant at index ${index} is missing a valid "name"`);
+    }
+
+    if (typeof description !== "string" || description.trim().length === 0) {
+      throw new Error(`Variant "${name}" is missing a valid "description"`);
+    }
+
+    if (typeof mode !== "string" || mode.trim().length === 0) {
+      throw new Error(`Variant "${name}" is missing a valid "mode"`);
+    }
+
+    if (typeof distortion !== "string" || distortion.trim().length === 0) {
+      throw new Error(`Variant "${name}" is missing a valid "distortion"`);
+    }
+
+    variants.push({
+      name: name.trim(),
+      description: description.trim(),
+      mode: mode.trim(),
+      distortion: distortion.trim(),
+    });
+  }
+
+  return variants;
+}
+
+function parseCliOptions(args: string[]): CliOptions {
+  const options: CliOptions = {
+    outputDir: DEFAULT_OUTPUT_DIR,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    switch (arg) {
+      case "--lesson": {
+        options.lessonPath = args[index + 1];
+        index += 1;
+        break;
+      }
+      case "--lesson-id": {
+        options.lessonId = args[index + 1];
+        index += 1;
+        break;
+      }
+      case "--output": {
+        options.outputDir = args[index + 1];
+        index += 1;
+        break;
+      }
+      case "--variants": {
+        options.variantPath = args[index + 1];
+        index += 1;
+        break;
+      }
+      default: {
+        break;
+      }
+    }
+  }
+
+  return options;
+}
+
+function buildComponentSource(
+  componentName: string,
+  lessonId: string,
+  variant: FunhouseVariantDefinition,
+): string {
+  const safeDescription = escapeTemplateLiteral(variant.description);
+
+  return `// GENERATED FUNHOUSE GAME\nimport FunhouseGameShell from \"@/components/FunhouseGameShell\";\n\nexport default function ${componentName}() {\n  return (\n    <FunhouseGameShell\n      title=\"${variant.name}\"\n      lessonId=\"${lessonId}\"\n      mode=\"${variant.mode}\"\n      distortion=\"${variant.distortion}\"\n      description={\`${safeDescription}\`}\n    />\n  );\n}\n`;
+}
+
+async function writeVariantFile(
+  outputDir: string,
+  baseSlug: string,
+  lessonId: string,
+  variant: FunhouseVariantDefinition,
+): Promise<void> {
+  const componentName = toPascalCase(variant.name);
+  const fileSlug = toKebabCase(variant.name);
+  const fileName = `${baseSlug}--${fileSlug}.tsx`;
+  const filePath = path.resolve(process.cwd(), outputDir, fileName);
+  const source = buildComponentSource(componentName, lessonId, variant);
+
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${source}`, "utf8");
+}
+
+async function resolveLessonId(options: CliOptions): Promise<string> {
+  if (options.lessonId && options.lessonId.trim().length > 0) {
+    return options.lessonId.trim();
+  }
+
+  if (options.lessonPath) {
+    const lessonId = await loadLessonId(options.lessonPath);
+
+    if (lessonId) {
+      return lessonId;
+    }
+  }
+
+  throw new Error(
+    "Unable to resolve a lesson id. Provide --lesson-id or a JSON file via --lesson that contains an 'id' field.",
+  );
+}
+
+async function resolveVariants(options: CliOptions): Promise<FunhouseVariantDefinition[]> {
+  if (options.variantPath) {
+    return loadVariants(options.variantPath);
+  }
+
+  return DEFAULT_VARIANTS;
+}
+
+async function main(): Promise<void> {
+  const options = parseCliOptions(process.argv.slice(2));
+  const lessonId = await resolveLessonId(options);
+  const variants = await resolveVariants(options);
+
+  const baseSlugCandidate = path.basename(lessonId);
+  const baseSlug = toKebabCase(baseSlugCandidate || lessonId || "funhouse-lesson");
+  const outputDir = path.resolve(process.cwd(), options.outputDir);
+
+  await mkdir(outputDir, { recursive: true });
+
+  await Promise.all(
+    variants.map((variant) => writeVariantFile(outputDir, baseSlug, lessonId, variant)),
+  );
+
+  console.log(
+    `✅ Generated ${variants.length} Funhouse variant component(s) for lesson "${lessonId}" in ${path.relative(process.cwd(), outputDir)}`,
+  );
+}
+
+main().catch((error) => {
+  console.error("❌ Failed to generate Funhouse variant components:", error);
+  process.exitCode = 1;
+});

--- a/src/components/FunhouseGameShell.tsx
+++ b/src/components/FunhouseGameShell.tsx
@@ -1,0 +1,51 @@
+import type { JSX } from "react";
+
+export interface FunhouseGameShellProps {
+  title: string;
+  lessonId: string;
+  mode: string;
+  distortion: string;
+  description: string;
+}
+
+export default function FunhouseGameShell({
+  title,
+  lessonId,
+  mode,
+  distortion,
+  description,
+}: FunhouseGameShellProps): JSX.Element {
+  return (
+    <article className="flex flex-col gap-4 rounded-xl border border-neutral-200 bg-white p-6 shadow-sm dark:border-neutral-700 dark:bg-neutral-900">
+      <header className="space-y-1">
+        <p className="text-sm font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+          Funhouse Variant
+        </p>
+        <h1 className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">{title}</h1>
+        <p className="text-sm text-neutral-600 dark:text-neutral-400">
+          Remixed from lesson <span className="font-mono text-xs">{lessonId}</span>
+        </p>
+      </header>
+      <section className="space-y-3">
+        <p className="text-base leading-relaxed text-neutral-700 dark:text-neutral-200">{description}</p>
+        <dl className="grid grid-cols-1 gap-2 text-sm text-neutral-600 dark:text-neutral-300 sm:grid-cols-2">
+          <div className="rounded-lg bg-neutral-100 p-3 dark:bg-neutral-800">
+            <dt className="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400">Mode</dt>
+            <dd className="text-base font-medium text-neutral-900 dark:text-neutral-100">{mode}</dd>
+          </div>
+          <div className="rounded-lg bg-neutral-100 p-3 dark:bg-neutral-800">
+            <dt className="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400">Distortion</dt>
+            <dd className="text-base font-medium text-neutral-900 dark:text-neutral-100">{distortion}</dd>
+          </div>
+        </dl>
+      </section>
+      <footer className="rounded-lg bg-blue-50 p-4 text-sm text-blue-900 dark:bg-blue-950 dark:text-blue-100">
+        <p>
+          Use this shell as a starting point for implementing the interactive experience for{" "}
+          <span className="font-semibold">{title}</span>. Wire it up to the correct funhouse game UI and have fun breaking the
+          rules.
+        </p>
+      </footer>
+    </article>
+  );
+}


### PR DESCRIPTION
## Summary
- add a CLI utility for creating Funhouse variant component shells from lesson metadata and variant definitions
- provide a reusable FunhouseGameShell component that the generated files render

## Testing
- npm run build *(fails: vite not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed5b617abc832fba92c2d572220187