### PR TITLE
Connect funhouse slug page to catalog data

### DIFF
--- a/src/components/FunhouseGameShell.tsx
+++ b/src/components/FunhouseGameShell.tsx
@@ -9,6 +9,7 @@ export interface FunhouseGameShellProps {
   mode: string;
   distortion: string;
   description: string;
+  promptText?: string;
 }
 
 export default function FunhouseGameShell({
@@ -17,6 +18,7 @@ export default function FunhouseGameShell({
   mode,
   distortion,
   description,
+  promptText,
 }: FunhouseGameShellProps): JSX.Element {
   const [text, setText] = useState("");
 
@@ -36,6 +38,17 @@ export default function FunhouseGameShell({
           </Badge>
         </div>
       </div>
+
+      {promptText && (
+        <section className="rounded-lg border border-neutral-200 bg-neutral-50 p-4 text-sm text-neutral-700 dark:border-neutral-700 dark:bg-neutral-900/40 dark:text-neutral-300">
+          <h2 className="mb-2 font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+            Prompt
+          </h2>
+          <p className="whitespace-pre-wrap leading-relaxed text-neutral-900 dark:text-neutral-100">
+            {promptText}
+          </p>
+        </section>
+      )}
 
       {mode === "text" && (
         <div className="space-y-4">

--- a/src/pages/funhouse/[slug].tsx
+++ b/src/pages/funhouse/[slug].tsx
@@ -1,0 +1,63 @@
+import { useMemo } from "react";
+import { useRouter } from "next/router";
+
+import FunhouseGameShell from "@/components/FunhouseGameShell";
+import { funhouseCatalog } from "@/games/fun_house_writing/funhouse_catalog";
+
+function resolveMode(gameType?: string): string {
+  if (!gameType) {
+    return "text";
+  }
+
+  if (gameType === "experimental") {
+    return "freeform";
+  }
+
+  return "text";
+}
+
+function resolveDistortion(constraintLabel?: string, constraintType?: string): string {
+  if (constraintLabel && constraintType) {
+    return `${constraintLabel} (${constraintType})`;
+  }
+
+  return constraintLabel ?? constraintType ?? "Funhouse Remix";
+}
+
+export default function FunhousePromptPage() {
+  const router = useRouter();
+  const slugParam = router.query.slug;
+  const slug = Array.isArray(slugParam) ? slugParam[0] : slugParam;
+
+  const prompt = useMemo(() => {
+    if (!slug) {
+      return undefined;
+    }
+
+    return funhouseCatalog.find((entry) => entry.id === slug);
+  }, [slug]);
+
+  if (!slug) return null;
+
+  if (!prompt) {
+    return (
+      <div className="space-y-2 p-6">
+        <p className="text-lg font-semibold">Prompt not found 😢</p>
+        <a className="text-sm text-blue-600 underline-offset-2 hover:underline" href="/funhouse">
+          Back to Funhouse hub
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <FunhouseGameShell
+      title={prompt.title}
+      lessonId={prompt.mirrors_lesson_id ?? "unknown-lesson"}
+      mode={resolveMode(prompt.game_type)}
+      distortion={resolveDistortion(prompt.constraint_label, prompt.constraint_type)}
+      description={prompt.description}
+      promptText={prompt.prompt_text}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- extend the shared Funhouse game shell to optionally show the full prompt copy
- add the dynamic funhouse slug page that looks up prompts from the catalog and feeds them into the shell
- provide fallbacks for unknown twists and lesson ids so the page renders friendly error messaging

## Testing
- npm run build *(fails: vite binary is unavailable because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed5f16bd44832f9d6935fb995a9303