### PR TITLE
Handle funhouse slug loading state

### DIFF
--- a/src/pages/funhouse/[slug].tsx
+++ b/src/pages/funhouse/[slug].tsx
@@ -37,7 +37,24 @@ export default function FunhousePromptPage() {
     return funhouseCatalog.find((entry) => entry.id === slug);
   }, [slug]);
 
-  if (!slug) return null;
+  if (!router.isReady) {
+    return (
+      <div className="p-6 text-gray-500">
+        Loading prompt…
+      </div>
+    );
+  }
+
+  if (!slug) {
+    return (
+      <div className="space-y-2 p-6">
+        <p className="text-lg font-semibold">Prompt not found 😢</p>
+        <a className="text-sm text-blue-600 underline-offset-2 hover:underline" href="/funhouse">
+          Back to Funhouse hub
+        </a>
+      </div>
+    );
+  }
 
   if (!prompt) {
     return (


### PR DESCRIPTION
## Summary
- add a loading state while the funhouse prompt slug is still resolving
- guard against missing slugs before attempting to locate the prompt

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68ed61a3a7c8832fb77f786b32d3671b