### PR TITLE
Use funhouse catalog for prompt index

### DIFF
--- a/src/games/fun_house_writing/utils.ts
+++ b/src/games/fun_house_writing/utils.ts
@@ -1,0 +1,10 @@
+export function resolveFunhouseDistortion(
+  constraintLabel?: string,
+  constraintType?: string,
+): string {
+  if (constraintLabel && constraintType) {
+    return `${constraintLabel} (${constraintType})`;
+  }
+
+  return constraintLabel ?? constraintType ?? "Funhouse Remix";
+}

--- a/src/pages/funhouse/[slug].tsx
+++ b/src/pages/funhouse/[slug].tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 
 import FunhouseGameShell from "@/components/FunhouseGameShell";
 import { funhouseCatalog } from "@/games/fun_house_writing/funhouse_catalog";
+import { resolveFunhouseDistortion } from "@/games/fun_house_writing/utils";
 
 function resolveMode(gameType?: string): string {
   if (!gameType) {
@@ -14,14 +15,6 @@ function resolveMode(gameType?: string): string {
   }
 
   return "text";
-}
-
-function resolveDistortion(constraintLabel?: string, constraintType?: string): string {
-  if (constraintLabel && constraintType) {
-    return `${constraintLabel} (${constraintType})`;
-  }
-
-  return constraintLabel ?? constraintType ?? "Funhouse Remix";
 }
 
 export default function FunhousePromptPage() {
@@ -72,7 +65,7 @@ export default function FunhousePromptPage() {
       title={prompt.title}
       lessonId={prompt.mirrors_lesson_id ?? "unknown-lesson"}
       mode={resolveMode(prompt.game_type)}
-      distortion={resolveDistortion(prompt.constraint_label, prompt.constraint_type)}
+      distortion={resolveFunhouseDistortion(prompt.constraint_label, prompt.constraint_type)}
       description={prompt.description}
       promptText={prompt.prompt_text}
     />

--- a/src/pages/funhouse/index.tsx
+++ b/src/pages/funhouse/index.tsx
@@ -1,51 +1,15 @@
-import Link from "next/link";
 import Head from "next/head";
+import Link from "next/link";
 
-interface FunhousePrompt {
-  slug: string;
-  title: string;
-  distortion: string;
-  description: string;
-}
+import { funhouseCatalog } from "@/games/fun_house_writing/funhouse_catalog";
+import { resolveFunhouseDistortion } from "@/games/fun_house_writing/utils";
 
-const funhousePrompts: ReadonlyArray<FunhousePrompt> = [
-  {
-    slug: "bad-love-letter",
-    title: "Write a Bad Love Letter",
-    distortion: "Opposite Emotion",
-    description: "Write a love letter using only violent, inappropriate, or unromantic language.",
-  },
-  {
-    slug: "no-dialogue-drama",
-    title: "Scene With No Dialogue",
-    distortion: "Constraint Play",
-    description: "Write a dramatic argument between two characters without using dialogue.",
-  },
-  {
-    slug: "genre-swap-misery",
-    title: "Rewrite in the Wrong Genre",
-    distortion: "Genre Swap",
-    description: "Rewrite a tragic scene as if it were a comedy sketch. Think banana peels and fart jokes.",
-  },
-  {
-    slug: "wrong-pov-rescue",
-    title: "Rescue Scene in the Wrong POV",
-    distortion: "POV Inversion",
-    description: "Write a dramatic rescue scene from the point of view of an object in the room.",
-  },
-  {
-    slug: "villain-monologue-mixup",
-    title: "Villain Monologue Remix",
-    distortion: "Perspective Clash",
-    description: "Rewrite a villain's triumphant speech as though it were an anxious best friend's pep talk.",
-  },
-  {
-    slug: "metaphor-meltdown",
-    title: "Metaphor Meltdown",
-    distortion: "Overload",
-    description: "Describe a simple action using an absurd chain of clashing metaphors that never quite land.",
-  },
-];
+const funhousePrompts = funhouseCatalog.map((prompt) => ({
+  id: prompt.id,
+  title: prompt.title,
+  description: prompt.description,
+  distortion: resolveFunhouseDistortion(prompt.constraint_label, prompt.constraint_type),
+}));
 
 export default function FunhouseIndex() {
   return (
@@ -64,13 +28,16 @@ export default function FunhouseIndex() {
           Choose your distortion, embrace the chaos, and write the scene the wrong way on purpose.
           Each challenge links to a ready-to-play Funhouse prompt.
         </p>
+        <p className="text-sm text-gray-500">
+          Explore {funhousePrompts.length} remixed prompts pulled from real craft lessons.
+        </p>
       </header>
 
       <ul className="grid gap-4 sm:grid-cols-2">
         {funhousePrompts.map((prompt) => (
-          <li key={prompt.slug} className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+          <li key={prompt.id} className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
             <h2 className="text-lg font-semibold">
-              <Link href={`/funhouse/${prompt.slug}`} className="text-blue-700 hover:underline">
+              <Link href={`/funhouse/${prompt.id}`} className="text-blue-700 hover:underline">
                 {prompt.title}
               </Link>
             </h2>


### PR DESCRIPTION
## Summary
- populate the Next.js Funhouse menu from the shared funhouse catalog so the list stays in sync with available prompts
- add a reusable helper for formatting distortion labels and use it in both the index and detail pages

## Testing
- npm run build *(fails: vite executable is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed64707464832f915c8ad2971f7556