### PR TITLE
Add data-driven funhouse prompt unlock helper

### DIFF
--- a/src/data/cut-skills.json
+++ b/src/data/cut-skills.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "beats",
+    "label": "Beat Mastery",
+    "description": "Recognising how narrative beats stack and collide."
+  },
+  {
+    "id": "pacing",
+    "label": "Pacing",
+    "description": "Modulating tempo and momentum across a scene."
+  },
+  {
+    "id": "stakes",
+    "label": "Raise the Stakes",
+    "description": "Turning up consequences so the reader cares."
+  }
+]

--- a/src/data/dictionary-skills.json
+++ b/src/data/dictionary-skills.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "focus",
+    "label": "Focus",
+    "description": "Dialing in on the most important idea in a sentence or scene."
+  },
+  {
+    "id": "repetition",
+    "label": "Repetition",
+    "description": "Controlling repeated words and phrases for emphasis or rhythm."
+  },
+  {
+    "id": "precision",
+    "label": "Precision",
+    "description": "Choosing exact language to keep meaning sharp."
+  }
+]

--- a/src/data/foundation-skills.json
+++ b/src/data/foundation-skills.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "show-dont-tell",
+    "label": "Show, Don't Tell",
+    "description": "Understanding how to reveal emotion and story through action instead of direct explanation."
+  },
+  {
+    "id": "voice",
+    "label": "Voice Control",
+    "description": "Experimenting with tone, diction, and point of view to shape narration."
+  },
+  {
+    "id": "structure",
+    "label": "Story Structure",
+    "description": "Working with scene beats, escalation, and reversals to move a story forward."
+  }
+]

--- a/src/data/funhouse-prompts.json
+++ b/src/data/funhouse-prompts.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "foundation-014-funhouse-1",
+    "title": "Tell Everything, Show Nothing",
+    "description": "Over-explain every feeling, every action, and leave zero mystery.",
+    "mode": "free",
+    "targets": ["show-dont-tell", "focus"],
+    "source": "foundation"
+  },
+  {
+    "id": "foundation-014-funhouse-5",
+    "title": "Show, Don’t Tell – Horror Remix",
+    "description": "Twist the core lesson into a creeping dread that drips from every sentence.",
+    "mode": "timed",
+    "targets": ["show-dont-tell", "pacing", "stakes"],
+    "source": "foundation"
+  },
+  {
+    "id": "foundation-014-funhouse-9",
+    "title": "Show, Don’t Tell – Backwards",
+    "description": "Structure the scene in reverse order so the emotional reveal lands first.",
+    "mode": "beat",
+    "targets": ["structure", "beats"],
+    "source": "foundation"
+  },
+  {
+    "id": "dictionary-focus-funhouse",
+    "title": "Focus Roulette",
+    "description": "Cycle through three wildly different focal points to distort the original prompt.",
+    "mode": "free",
+    "targets": ["focus", "precision"],
+    "source": "dictionary"
+  },
+  {
+    "id": "cut-repetition-funhouse",
+    "title": "Echo Chamber",
+    "description": "Lean into repetition until the beat pattern becomes hypnotic and weird.",
+    "mode": "beat",
+    "targets": ["repetition", "beats"],
+    "source": "cut"
+  }
+]

--- a/src/utils/unlockFunhousePrompts.ts
+++ b/src/utils/unlockFunhousePrompts.ts
@@ -1,0 +1,150 @@
+import foundation from "@/data/foundation-skills.json";
+import dictionary from "@/data/dictionary-skills.json";
+import cut from "@/data/cut-skills.json";
+import funhouse from "@/data/funhouse-prompts.json";
+
+type SkillRecord = { id?: unknown } | string;
+
+type FunhousePromptRecord = {
+  id?: unknown;
+  title?: unknown;
+  description?: unknown;
+  mode?: unknown;
+  targets?: unknown;
+  source?: unknown;
+};
+
+export type FunhousePrompt = {
+  id: string;
+  title: string;
+  description: string;
+  mode: string;
+  targets: string[];
+  source: string;
+};
+
+function normaliseSkillId(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (value && typeof value === "object" && "id" in value && typeof (value as { id?: unknown }).id === "string") {
+    const trimmed = ((value as { id: string }).id ?? "").trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  return null;
+}
+
+function buildSkillSet(data: unknown): Set<string> {
+  if (!Array.isArray(data)) {
+    return new Set();
+  }
+
+  const ids = new Set<string>();
+  for (const entry of data as SkillRecord[]) {
+    const id = normaliseSkillId(entry);
+    if (id) {
+      ids.add(id);
+    }
+  }
+
+  return ids;
+}
+
+function normaliseString(value: unknown, fallback: string): string {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
+  }
+
+  return fallback;
+}
+
+function normaliseTargets(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const targets: string[] = [];
+  for (const entry of value) {
+    if (typeof entry === "string") {
+      const trimmed = entry.trim();
+      if (trimmed.length > 0) {
+        targets.push(trimmed);
+      }
+    }
+  }
+
+  return targets;
+}
+
+function normaliseFunhousePrompts(data: unknown): FunhousePrompt[] {
+  if (!Array.isArray(data)) {
+    return [];
+  }
+
+  const prompts: FunhousePrompt[] = [];
+
+  for (const entry of data as FunhousePromptRecord[]) {
+    const id = normaliseString(entry.id, "");
+    const title = normaliseString(entry.title, "Untitled Funhouse Prompt");
+    const description = normaliseString(entry.description, "");
+    const mode = normaliseString(entry.mode, "free");
+    const source = normaliseString(entry.source, "funhouse");
+    const targets = normaliseTargets(entry.targets);
+
+    if (!id) {
+      continue;
+    }
+
+    prompts.push({
+      id,
+      title,
+      description,
+      mode,
+      source,
+      targets,
+    });
+  }
+
+  return prompts;
+}
+
+const foundationSkills = buildSkillSet(foundation);
+const dictionarySkills = buildSkillSet(dictionary);
+const cutSkills = buildSkillSet(cut);
+const knownSkills = new Set<string>([...foundationSkills, ...dictionarySkills, ...cutSkills]);
+const funhousePrompts = normaliseFunhousePrompts(funhouse);
+
+// Input: array of unlocked skill IDs like ["focus", "repetition"]
+// Output: funhouse prompts that target those skills
+export function getEligibleFunhousePrompts(unlockedSkills: string[]): FunhousePrompt[] {
+  if (!Array.isArray(unlockedSkills) || unlockedSkills.length === 0) {
+    return [];
+  }
+
+  const unlockedSet = new Set<string>();
+
+  for (const skill of unlockedSkills) {
+    if (typeof skill !== "string") {
+      continue;
+    }
+
+    const trimmed = skill.trim();
+    if (trimmed.length === 0 || !knownSkills.has(trimmed)) {
+      continue;
+    }
+
+    unlockedSet.add(trimmed);
+  }
+
+  if (unlockedSet.size === 0) {
+    return [];
+  }
+
+  return funhousePrompts.filter((prompt) => prompt.targets.some((skill) => unlockedSet.has(skill)));
+}


### PR DESCRIPTION
## Summary
- add lightweight skill metadata for foundation, dictionary, and cut tracks
- add funhouse prompt metadata annotated with skill targets
- expose a utility to return funhouse prompts unlocked by the available skills

## Testing
- npm run build *(fails: vite not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ed66c9ec4c832fbb36d8f7850533a4