### PR TITLE
Update funhouse prompts to new lesson format

### DIFF
--- a/src/data/funhouse-prompts.json
+++ b/src/data/funhouse-prompts.json
@@ -1,42 +1,44 @@
 [
   {
-    "id": "foundation-014-funhouse-1",
-    "title": "Tell Everything, Show Nothing",
-    "description": "Over-explain every feeling, every action, and leave zero mystery.",
-    "mode": "free",
-    "targets": ["show-dont-tell", "focus"],
-    "source": "foundation"
+    "id": "fh-001",
+    "title": "Write Like You Hate It",
+    "sourceLesson": "emotion_reveal",
+    "description": "Take an emotional scene and rewrite it like you're embarrassed to feel anything. Dry it out. Wring it flat.",
+    "variants": [
+      {
+        "mode": "Flat Emotion",
+        "instructions": "Rewrite your most emotional scene using only facts. No metaphors. No feelings. Just the events."
+      },
+      {
+        "mode": "Hostile Voice",
+        "instructions": "Keep the same scene, but rewrite it with a mean, cynical voice that mocks everything heartfelt in the original."
+      },
+      {
+        "mode": "Third-Person Detachment",
+        "instructions": "Rewrite it in distant third person, like a bored narrator watching ants fight."
+      }
+    ],
+    "tags": ["emotion", "anti-style", "funhouse"],
+    "unlocksWith": ["emotion_reveal"],
+    "shadow": false
   },
   {
-    "id": "foundation-014-funhouse-5",
-    "title": "Show, Don’t Tell – Horror Remix",
-    "description": "Twist the core lesson into a creeping dread that drips from every sentence.",
-    "mode": "timed",
-    "targets": ["show-dont-tell", "pacing", "stakes"],
-    "source": "foundation"
-  },
-  {
-    "id": "foundation-014-funhouse-9",
-    "title": "Show, Don’t Tell – Backwards",
-    "description": "Structure the scene in reverse order so the emotional reveal lands first.",
-    "mode": "beat",
-    "targets": ["structure", "beats"],
-    "source": "foundation"
-  },
-  {
-    "id": "dictionary-focus-funhouse",
-    "title": "Focus Roulette",
-    "description": "Cycle through three wildly different focal points to distort the original prompt.",
-    "mode": "free",
-    "targets": ["focus", "precision"],
-    "source": "dictionary"
-  },
-  {
-    "id": "cut-repetition-funhouse",
-    "title": "Echo Chamber",
-    "description": "Lean into repetition until the beat pattern becomes hypnotic and weird.",
-    "mode": "beat",
-    "targets": ["repetition", "beats"],
-    "source": "cut"
+    "id": "fh-002",
+    "title": "Too Many Adjectives",
+    "sourceLesson": "description_basics",
+    "description": "Drown a basic scene in excessive adjectives and adverbs. Make it absolutely unreadable.",
+    "variants": [
+      {
+        "mode": "Purple Prose",
+        "instructions": "Describe a room using at least 3 adjectives per noun. Every sentence should sound like it got rejected from a Victorian novel."
+      },
+      {
+        "mode": "Simile Overdose",
+        "instructions": "Use a simile in every single sentence, whether it makes sense or not. Make them ridiculous."
+      }
+    ],
+    "tags": ["description", "style_breaker", "funhouse"],
+    "unlocksWith": ["description_basics"],
+    "shadow": true
   }
 ]


### PR DESCRIPTION
## Summary
- replace funhouse prompt definitions with the new lesson-based schema
- include detailed variant instructions, tags, and unlock metadata for two prompts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed69ce27e4832f8381334f7a21f57d