### PR TITLE
Add Funhouse prompt remix loader and debug view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import NotFound from "./pages/NotFound";
 import CutGames from "./pages/CutGames";
 import FunhouseHub from "./pages/FunhouseHub";
 import FunhouseGame from "./pages/FunhouseGame";
+import FunhouseDebug from "./pages/FunhouseDebug";
 import { Header } from "./components/Header";
 import { ToastHost } from "./components/ToastHost";
 import { KeyOverlay } from "./components/KeyOverlay";
@@ -38,6 +39,7 @@ export default function App() {
             <Route path="/play/cut-games" element={<CutGames />} />
             <Route path="/funhouse" element={<FunhouseHub />} />
             <Route path="/funhouse/:id" element={<FunhouseGame />} />
+            <Route path="/funhouse-debug" element={<FunhouseDebug />} />
             <Route path="/play/:id/see" element={<PlaySee />} />
             <Route path="/play/:id/mcq" element={<PlayMCQ />} />
             <Route path="/play/:id/slot" element={<PlaySlot />} />

--- a/src/data/cut-prompts.json
+++ b/src/data/cut-prompts.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "cut-001",
+    "title": "Surgical Draft",
+    "instructions": "Take a bloated paragraph and trim it to half its length while keeping the narrative spine intact.",
+    "tags": ["editing", "precision", "clarity"]
+  },
+  {
+    "id": "cut-002",
+    "title": "Out Loud",
+    "instructions": "Rewrite a monologue so it sounds natural when spoken, cutting any line that feels stiff on the tongue.",
+    "tags": ["dialogue", "voice", "rhythm"]
+  },
+  {
+    "id": "cut-003",
+    "title": "Negative Space",
+    "instructions": "Revise a descriptive passage so that what's unsaid becomes louder than what is explained.",
+    "tags": ["revision", "subtext", "tone"]
+  }
+]

--- a/src/data/dictionary-prompts.json
+++ b/src/data/dictionary-prompts.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "dictionary-001",
+    "title": "Invented Lexicon",
+    "instructions": "Choose three obscure words and build a scene around them without explaining what they mean.",
+    "tags": ["vocabulary", "worldbuilding", "mystery"]
+  },
+  {
+    "id": "dictionary-002",
+    "title": "Synonym Riot",
+    "instructions": "Rewrite a paragraph using entirely new word choices that keep the tone but change the texture of the language.",
+    "tags": ["diction", "tone", "style"]
+  },
+  {
+    "id": "dictionary-003",
+    "title": "Definition Duel",
+    "instructions": "Write a dialogue where two characters argue over the meaning of a single word, using quotes from imaginary dictionaries.",
+    "tags": ["dialogue", "humor", "wordplay"]
+  }
+]

--- a/src/data/foundation-prompts.json
+++ b/src/data/foundation-prompts.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "foundation-001",
+    "title": "Show, Don't Tell Redux",
+    "instructions": "Write a scene where emotions are implied through actions and sensory detail without naming the feelings outright.",
+    "tags": ["emotion", "imagery", "scene"]
+  },
+  {
+    "id": "foundation-002",
+    "title": "Conflicted Voices",
+    "instructions": "Draft a conversation between two characters who want the same thing for different reasons, letting subtext carry the tension.",
+    "tags": ["dialogue", "subtext", "character"]
+  },
+  {
+    "id": "foundation-003",
+    "title": "Momentum Builder",
+    "instructions": "Write a short sequence of three escalating beats that push a reluctant protagonist toward a decision they fear.",
+    "tags": ["structure", "pacing", "stakes"]
+  }
+]

--- a/src/data/funhouse-prompts.ts
+++ b/src/data/funhouse-prompts.ts
@@ -1,0 +1,258 @@
+import foundationPromptsJson from "@/data/foundation-prompts.json";
+import cutPromptsJson from "@/data/cut-prompts.json";
+import dictionaryPromptsJson from "@/data/dictionary-prompts.json";
+
+export type PromptSource = "foundation" | "cut" | "dictionary";
+
+export interface BasePrompt {
+  id: string;
+  title: string;
+  instructions: string;
+  tags: string[];
+  source: PromptSource;
+}
+
+export interface FunhouseVariant {
+  id: string;
+  mode: string;
+  instructions: string;
+}
+
+export interface FunhousePrompt extends BasePrompt {
+  variants: FunhouseVariant[];
+}
+
+type PromptRecord = {
+  id?: unknown;
+  title?: unknown;
+  instructions?: unknown;
+  tags?: unknown;
+};
+
+type RemixBlueprint = {
+  key: string;
+  mode: string;
+  tone: string;
+  genre: string;
+  badWriting: string;
+  randomConstraint: string;
+};
+
+function normaliseString(value: unknown, fallback: string): string {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
+  }
+
+  return fallback;
+}
+
+function normaliseTags(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const tags: string[] = [];
+  for (const entry of value) {
+    if (typeof entry === "string") {
+      const trimmed = entry.trim();
+      if (trimmed.length > 0) {
+        tags.push(trimmed.toLowerCase());
+      }
+    }
+  }
+
+  return tags;
+}
+
+function normalisePrompt(record: PromptRecord, source: PromptSource, fallbackIndex: number): BasePrompt {
+  const id = normaliseString(record.id, `${source}-${String(fallbackIndex).padStart(3, "0")}`);
+  const title = normaliseString(record.title, "Untitled Prompt");
+  const instructions = normaliseString(
+    record.instructions,
+    "Write something gloriously chaotic."
+  );
+  const tags = normaliseTags(record.tags);
+
+  return {
+    id,
+    title,
+    instructions,
+    tags,
+    source,
+  };
+}
+
+export function loadBasePrompts(): BasePrompt[] {
+  const sources: Array<{ source: PromptSource; data: unknown }> = [
+    { source: "foundation", data: foundationPromptsJson },
+    { source: "cut", data: cutPromptsJson },
+    { source: "dictionary", data: dictionaryPromptsJson },
+  ];
+
+  const prompts: BasePrompt[] = [];
+
+  for (const { source, data } of sources) {
+    if (!Array.isArray(data)) {
+      continue;
+    }
+
+    data.forEach((entry, index) => {
+      prompts.push(
+        normalisePrompt(
+          (entry ?? {}) as PromptRecord,
+          source,
+          index + 1,
+        ),
+      );
+    });
+  }
+
+  return prompts;
+}
+
+const remixBlueprints: RemixBlueprint[] = [
+  {
+    key: "noir-sarcasm",
+    mode: "Noir Sarcasm Spiral",
+    tone: "Narrate like a detective who has seen too much sincerity and is allergic to it.",
+    genre: "Drench the world in rain-slick noir alleys and flickering neon.",
+    badWriting: "Use every cigarette cliché you can invent and never stop with the similes.",
+    randomConstraint: "End every sentence with an accusatory 'see?' even when it hurts.",
+  },
+  {
+    key: "romantic-horror",
+    mode: "Romantic Horror Waltz",
+    tone: "Sound like a love letter written inside a haunted house with the lights off.",
+    genre: "Blend swoony gothic romance with creeping horror imagery.",
+    badWriting: "Lean into overripe metaphors that drip like doomed chandeliers.",
+    randomConstraint: "Every paragraph must include a heartbeat that may or may not be the house.",
+  },
+  {
+    key: "monotone-epic",
+    mode: "Monotone Epic Chronicle",
+    tone: "Tell the tale like a bored immortal narrating yet another prophecy.",
+    genre: "Frame the story as an epic fantasy prophecy gone stale.",
+    badWriting: "Overuse passive voice until the verbs forget what action is.",
+    randomConstraint: "Only five-word sentences are allowed; cheat with em dashes if you must.",
+  },
+  {
+    key: "sci-fi-chaos",
+    mode: "Glitchy Sci-Fi Manifesto",
+    tone: "Adopt the voice of a malfunctioning AI motivational speaker.",
+    genre: "Blast the scene into neon-drenched science fiction with broken user manuals.",
+    badWriting: "Sprinkle in technobabble buzzwords that contradict each other.",
+    randomConstraint: "Every third sentence must rhyme with 'zap'.",
+  },
+  {
+    key: "mythic-snark",
+    mode: "Mythic Snark Oracle",
+    tone: "Prophesy with smug omniscience and zero patience for mortals.",
+    genre: "Wrap the prompt in mythic high-fantasy stakes and divine bureaucracy.",
+    badWriting: "List far too many proper nouns that sound suspiciously similar.",
+    randomConstraint: "Work in at least three unhelpful footnote-style asides in parentheses.",
+  },
+  {
+    key: "camp-chaos",
+    mode: "Purple Prose Disaster",
+    tone: "Write like a soap opera villain pretending to be a poet.",
+    genre: "Slide between melodramatic ballroom drama and accidental camp.",
+    badWriting: "Every noun deserves three adjectives and a sigh.",
+    randomConstraint: "Force a full-sentence alliteration every other line.",
+  },
+  {
+    key: "deadpan-western",
+    mode: "Deadpan Cosmic Western",
+    tone: "Speak in a flat drawl that refuses to acknowledge the chaos.",
+    genre: "Set everything on a dusty planet with two moons and zero patience.",
+    badWriting: "Repeat yourself like the tumbleweeds demanded it.",
+    randomConstraint: "Mention the taste of starlight in every stanza.",
+  },
+  {
+    key: "operatic-heist",
+    mode: "Operatic Heist Catastrophe",
+    tone: "Sing every instruction as if the plan is failing spectacularly mid-aria.",
+    genre: "Treat the scene like a glittering heist musical gone wrong.",
+    badWriting: "Break into parenthetical stage directions that contradict themselves.",
+    randomConstraint: "Every line must end with an exclamation point you half-regret!",
+  },
+];
+
+function hashString(value: string): number {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+  }
+
+  return hash;
+}
+
+function rotateBlueprints(offset: number): RemixBlueprint[] {
+  const normalizedOffset = offset % remixBlueprints.length;
+  if (normalizedOffset === 0) {
+    return remixBlueprints.slice();
+  }
+
+  return [
+    ...remixBlueprints.slice(normalizedOffset),
+    ...remixBlueprints.slice(0, normalizedOffset),
+  ];
+}
+
+function buildVariantInstructions(base: BasePrompt, blueprint: RemixBlueprint): string {
+  const tagLine = base.tags.length
+    ? `Keep nodding to these craft gremlins: ${base.tags.join(", ")}.`
+    : "Invent new craft gremlins on the fly.";
+
+  return [
+    `Original directive: ${base.instructions}`,
+    `Mode switch: ${blueprint.mode}.`,
+    `Tone swap: ${blueprint.tone}`,
+    `Genre costume: ${blueprint.genre}`,
+    `Bad-writing demand: ${blueprint.badWriting}`,
+    `Random chaos rule: ${blueprint.randomConstraint}`,
+    tagLine,
+    "Make it proudly messy, celebrate failure, and write the version that would horrify your neat-freak future self.",
+  ].join("\n\n");
+}
+
+export function remixPromptToVariants(base: BasePrompt, desiredCount = 5): FunhouseVariant[] {
+  const minimumCount = Math.max(desiredCount, 5);
+  const offset = hashString(base.id + base.source);
+  const rotated = rotateBlueprints(offset);
+
+  return rotated.slice(0, minimumCount).map((blueprint, index) => ({
+    id: `${base.id}-funhouse-${index + 1}`,
+    mode: blueprint.mode,
+    instructions: buildVariantInstructions(base, blueprint),
+  }));
+}
+
+export const funhousePrompts: FunhousePrompt[] = loadBasePrompts().map((prompt) => ({
+  ...prompt,
+  variants: remixPromptToVariants(prompt),
+}));
+
+const variantIndex = (() => {
+  const index = new Map<string, { prompt: FunhousePrompt; variant: FunhouseVariant }>();
+
+  for (const prompt of funhousePrompts) {
+    for (const variant of prompt.variants) {
+      if (!index.has(variant.id)) {
+        index.set(variant.id, { prompt, variant });
+      }
+    }
+  }
+
+  return index;
+})();
+
+export function findFunhouseVariantById(id: string): { prompt: FunhousePrompt; variant: FunhouseVariant } | null {
+  return variantIndex.get(id) ?? null;
+}
+
+export function listAllFunhouseVariants(): FunhouseVariant[] {
+  return Array.from(variantIndex.values()).map((entry) => entry.variant);
+}

--- a/src/pages/FunhouseDebug.tsx
+++ b/src/pages/FunhouseDebug.tsx
@@ -1,0 +1,102 @@
+import type { JSX } from "react";
+import { Link } from "react-router-dom";
+
+import { funhousePrompts } from "@/data/funhouse-prompts";
+
+function ParagraphList({ text }: { text: string }): JSX.Element {
+  const lines = text.split(/\n+/).filter((line) => line.trim().length > 0);
+
+  return (
+    <ul className="space-y-2 text-sm leading-relaxed text-neutral-100">
+      {lines.map((line, index) => (
+        <li
+          key={`${index}-${line.slice(0, 12)}`}
+          className="rounded border border-neutral-800/60 bg-neutral-900/80 px-3 py-2 shadow-inner shadow-fuchsia-900/40"
+        >
+          {line}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function FunhouseDebug(): JSX.Element {
+  const preview = funhousePrompts.slice(0, 3);
+
+  return (
+    <div className="min-h-[60vh] w-full bg-gradient-to-br from-neutral-950 via-purple-950 to-orange-900">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-6 py-12">
+        <header className="space-y-4 text-neutral-100">
+          <p className="inline-flex items-center gap-2 text-xs uppercase tracking-[0.35em] text-orange-300">
+            <span className="h-1 w-8 bg-orange-400" aria-hidden />
+            Funhouse Debug Channel
+            <span className="h-1 w-8 bg-fuchsia-500" aria-hidden />
+          </p>
+          <h1 className="text-4xl font-black tracking-tight text-white drop-shadow-[0_6px_0_rgba(236,72,153,0.35)]">
+            Prompt Remix Control Room
+          </h1>
+          <p className="max-w-3xl text-base text-neutral-200">
+            Behold the first three remixed prompts. Each variant intentionally breaks something—tone, genre, grammar, or your
+            faith in coherent prose. Use this page to confirm the remix engine is awake and choosing chaos on purpose.
+          </p>
+          <div className="flex flex-wrap gap-4 text-xs font-semibold uppercase tracking-widest text-orange-200">
+            <span className="rounded-full border border-orange-400/80 bg-orange-500/20 px-3 py-1">temporary debug</span>
+            <Link
+              to="/funhouse"
+              className="rounded-full border border-fuchsia-400/70 bg-fuchsia-500/20 px-3 py-1 text-fuchsia-100 transition hover:bg-fuchsia-500/40"
+            >
+              Return to Funhouse Hub
+            </Link>
+          </div>
+        </header>
+
+        <div className="grid gap-8 lg:grid-cols-3">
+          {preview.map((prompt) => (
+            <article
+              key={prompt.id}
+              className="flex h-full flex-col gap-4 rounded-3xl border-4 border-orange-400/60 bg-neutral-950/80 p-6 shadow-[6px_6px_0_rgba(168,85,247,0.6)]"
+            >
+              <div className="space-y-1">
+                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-fuchsia-300">
+                  {prompt.source} prompt
+                </p>
+                <h2 className="text-2xl font-bold text-white">{prompt.title}</h2>
+                <p className="text-sm text-orange-100/90">{prompt.instructions}</p>
+              </div>
+
+              {prompt.tags.length > 0 ? (
+                <ul className="flex flex-wrap gap-2 text-[0.65rem] font-semibold uppercase tracking-wide text-neutral-900">
+                  {prompt.tags.map((tag) => (
+                    <li
+                      key={tag}
+                      className="rounded-full border border-neutral-100/70 bg-neutral-100 px-3 py-1 text-neutral-900 shadow shadow-orange-500/40"
+                    >
+                      #{tag}
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+
+              <div className="mt-2 flex-1 space-y-4">
+                {prompt.variants.map((variant) => (
+                  <section
+                    key={variant.id}
+                    className="rounded-2xl border border-fuchsia-500/60 bg-neutral-950/80 p-4 shadow-inner shadow-orange-500/40"
+                  >
+                    <header className="mb-3 flex items-center justify-between gap-2">
+                      <p className="text-xs font-semibold uppercase tracking-widest text-fuchsia-200">{variant.mode}</p>
+                      <span className="rounded-full bg-fuchsia-500/30 px-2 py-1 text-[0.65rem] font-bold text-fuchsia-100">
+                        {variant.id.split("-").slice(-1)[0]}
+                      </span>
+                    </header>
+                    <ParagraphList text={variant.instructions} />
+                  </section>
+                ))}
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/FunhouseGame.tsx
+++ b/src/pages/FunhouseGame.tsx
@@ -1,10 +1,13 @@
 import type { JSX } from "react";
 import { Link, useParams } from "react-router-dom";
 
+import { findFunhouseVariantById } from "@/data/funhouse-prompts";
+
 import { GameLoader } from "@/games/fun_house_writing";
 
 export default function FunhouseGame(): JSX.Element {
   const { id } = useParams<{ id: string }>();
+  const variantInfo = id ? findFunhouseVariantById(id) : null;
 
   if (!id) {
     return (
@@ -21,7 +24,37 @@ export default function FunhouseGame(): JSX.Element {
   }
 
   return (
-    <div className="mx-auto w-full max-w-5xl p-4">
+    <div className="mx-auto w-full max-w-5xl space-y-6 p-4">
+      {variantInfo ? (
+        <section className="rounded-3xl border border-purple-500/40 bg-gradient-to-br from-purple-950/70 via-neutral-950/60 to-orange-900/40 p-6 shadow-[6px_6px_0_rgba(168,85,247,0.45)]">
+          <div className="flex flex-wrap items-baseline justify-between gap-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-purple-200">
+              {variantInfo.prompt.source} funhouse remix
+            </p>
+            <span className="rounded-full border border-purple-400/60 bg-purple-500/30 px-3 py-1 text-[0.65rem] font-bold uppercase tracking-widest text-purple-100">
+              {variantInfo.variant.mode}
+            </span>
+          </div>
+          <h1 className="mt-3 text-2xl font-bold text-white">{variantInfo.prompt.title}</h1>
+          <p className="mt-2 text-sm text-purple-100/90">
+            Original instructions: {variantInfo.prompt.instructions}
+          </p>
+          <div className="mt-4 space-y-2 text-sm text-orange-100">
+            {variantInfo.variant.instructions
+              .split(/\n+/)
+              .filter((line) => line.trim().length > 0)
+              .map((line, index) => (
+                <p
+                  key={`${variantInfo.variant.id}-${index}`}
+                  className="rounded-xl border border-purple-400/30 bg-purple-950/50 px-3 py-2 text-left leading-relaxed shadow-inner shadow-orange-500/30"
+                >
+                  {line}
+                </p>
+              ))}
+          </div>
+        </section>
+      ) : null}
+
       <GameLoader id={id} />
     </div>
   );

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -17,3 +17,4 @@ export { default as Play } from "./Play";
 export { default as SigilSyntaxRoot } from "./SigilSyntaxRoot";
 export { default as FunhouseHub } from "./FunhouseHub";
 export { default as FunhouseGame } from "./FunhouseGame";
+export { default as FunhouseDebug } from "./FunhouseDebug";


### PR DESCRIPTION
## Summary
- add foundational Foundation/Cut/Dictionary prompt sources and a remix engine that generates five or more chaotic variants for each base prompt
- expose the generated funhouse prompt data with lookup helpers and surface variant context inside the FunhouseGame view
- add a temporary /funhouse-debug route that previews the first three remixed prompts with funhouse styling for visual verification

## Testing
- npm run build *(fails: sh: 1: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ed6e367b74832f999a2a209e3bb4d1