### PR TITLE
Add modular mode engine for Funhouse variants

### DIFF
--- a/src/components/CountdownTimer.tsx
+++ b/src/components/CountdownTimer.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useRef, useState, type JSX } from "react";
+
+interface CountdownTimerProps {
+  minutes: number;
+  onExpire?: () => void;
+  onTick?: (remainingSeconds: number) => void;
+}
+
+export function CountdownTimer({ minutes, onExpire, onTick }: CountdownTimerProps): JSX.Element {
+  const [time, setTime] = useState(() => Math.max(minutes, 0) * 60);
+  const hasExpiredRef = useRef(false);
+
+  useEffect(() => {
+    setTime(Math.max(minutes, 0) * 60);
+    hasExpiredRef.current = false;
+  }, [minutes]);
+
+  useEffect(() => {
+    if (time <= 0) {
+      if (!hasExpiredRef.current) {
+        hasExpiredRef.current = true;
+        onExpire?.();
+      }
+      onTick?.(0);
+      return;
+    }
+
+    onTick?.(time);
+
+    const interval = window.setInterval(() => {
+      setTime((previous) => {
+        const next = previous - 1;
+        return next >= 0 ? next : 0;
+      });
+    }, 1000);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [time, onExpire, onTick]);
+
+  const minutesRemaining = Math.floor(time / 60);
+  const secondsRemaining = time % 60;
+
+  if (time <= 0) {
+    return <p className="text-sm font-semibold text-red-500">⏰ Time’s up!</p>;
+  }
+
+  return (
+    <p className="text-sm text-gray-400">
+      ⏱ {minutesRemaining}:{secondsRemaining.toString().padStart(2, "0")}
+    </p>
+  );
+}

--- a/src/components/OneLineEditor.tsx
+++ b/src/components/OneLineEditor.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState, type ChangeEvent, type JSX } from "react";
+
+import { Button } from "@/components/ui/button";
+
+interface OneLineEditorProps {
+  onHideTextarea?: () => void;
+  onRevealTextarea?: () => void;
+}
+
+export function OneLineEditor({ onHideTextarea, onRevealTextarea }: OneLineEditorProps): JSX.Element {
+  const [lines, setLines] = useState<string[]>([""]);
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    onHideTextarea?.();
+    return () => {
+      onRevealTextarea?.();
+    };
+  }, [onHideTextarea, onRevealTextarea]);
+
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    const updated = [...lines];
+    updated[index] = event.target.value;
+    setLines(updated);
+  };
+
+  const addLine = () => {
+    setLines((previous) => [...previous, ""]);
+    setIndex((previous) => previous + 1);
+    onRevealTextarea?.();
+  };
+
+  return (
+    <div className="space-y-2 rounded-xl border border-purple-200/40 bg-purple-950/40 p-3">
+      <p className="text-xs uppercase tracking-[0.2em] text-purple-200/80">One line staging</p>
+      <textarea
+        value={lines[index] ?? ""}
+        onChange={handleChange}
+        rows={2}
+        className="w-full resize-none rounded-lg border border-purple-300/60 bg-purple-950/70 p-2 text-sm text-purple-50 focus:outline-none focus:ring-2 focus:ring-purple-400"
+      />
+      <Button onClick={addLine} className="border border-purple-300/70 bg-purple-100 text-purple-900">
+        Next Line ➕
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a mode engine to FunhouseGame so variants can inject custom UI and behaviors
- create reusable CountdownTimer and OneLineEditor components for timed and one-line modes
- disable or hide the main editor when modes require it and show a free play fallback message

## Testing
- npm run build *(fails: local environment is missing vite and npm install was blocked by registry permissions)*

------
https://chatgpt.com/codex/tasks/task_e_68ed7e5ea4d8832f875ed5fe283f3451