### PR TITLE
Replace alias imports with relative paths

### DIFF
--- a/src/components/FunhouseGameShell.tsx
+++ b/src/components/FunhouseGameShell.tsx
@@ -1,7 +1,7 @@
 import { useState, type JSX } from "react";
-import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
-import { Badge } from "@/components/ui/badge";
+import { Button } from "./ui/button";
+import { Textarea } from "./ui/textarea";
+import { Badge } from "./ui/badge";
 
 export interface FunhouseGameShellProps {
   title: string;

--- a/src/components/OneLineEditor.tsx
+++ b/src/components/OneLineEditor.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type ChangeEvent, type JSX } from "react";
 
-import { Button } from "@/components/ui/button";
+import { Button } from "./ui/button";
 
 interface OneLineEditorProps {
   onHideTextarea?: () => void;

--- a/src/data/funhouse-prompts.ts
+++ b/src/data/funhouse-prompts.ts
@@ -1,6 +1,6 @@
-import foundationPromptsJson from "@/data/foundation-prompts.json";
-import cutPromptsJson from "@/data/cut-prompts.json";
-import dictionaryPromptsJson from "@/data/dictionary-prompts.json";
+import foundationPromptsJson from "./foundation-prompts.json";
+import cutPromptsJson from "./cut-prompts.json";
+import dictionaryPromptsJson from "./dictionary-prompts.json";
 
 export type PromptSource = "foundation" | "cut" | "dictionary";
 

--- a/src/pages/FunhouseDebug.tsx
+++ b/src/pages/FunhouseDebug.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from "react";
 import { Link } from "react-router-dom";
 
-import { funhousePrompts } from "@/data/funhouse-prompts";
+import { funhousePrompts } from "../data/funhouse-prompts";
 
 function ParagraphList({ text }: { text: string }): JSX.Element {
   const lines = text.split(/\n+/).filter((line) => line.trim().length > 0);

--- a/src/pages/FunhouseGame.tsx
+++ b/src/pages/FunhouseGame.tsx
@@ -1,14 +1,14 @@
 import { useCallback, useEffect, useMemo, useState, type Dispatch, type JSX, type SetStateAction } from "react";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 
-import { CountdownTimer } from "@/components/CountdownTimer";
-import { OneLineEditor } from "@/components/OneLineEditor";
-import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
-import { findFunhouseVariantById, funhousePrompts } from "@/data/funhouse-prompts";
+import { CountdownTimer } from "../components/CountdownTimer";
+import { OneLineEditor } from "../components/OneLineEditor";
+import { Button } from "../components/ui/button";
+import { Textarea } from "../components/ui/textarea";
+import { findFunhouseVariantById, funhousePrompts } from "../data/funhouse-prompts";
 
-import { GameLoader } from "@/games/fun_house_writing";
-import { saveEntry } from "@/utils/funhouseStorage";
+import { GameLoader } from "../games/fun_house_writing";
+import { saveEntry } from "../utils/funhouseStorage";
 
 type PromptIndices = {
   promptIndex: number;

--- a/src/pages/FunhouseHub.tsx
+++ b/src/pages/FunhouseHub.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from "react";
 import { Link } from "react-router-dom";
 
-import { funhouseCatalog } from "@/games/fun_house_writing/funhouse_catalog";
+import { funhouseCatalog } from "../games/fun_house_writing/funhouse_catalog";
 
 export default function FunhouseHub(): JSX.Element {
   const routes = funhouseCatalog.map((entry) => ({

--- a/src/pages/FunhousePast.tsx
+++ b/src/pages/FunhousePast.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState, type JSX } from "react";
 import { Link } from "react-router-dom";
 
-import { loadSaves, type FunhouseSaveEntry } from "@/utils/funhouseStorage";
-import { formatTimeAgo } from "@/utils/timeAgo";
+import { loadSaves, type FunhouseSaveEntry } from "../utils/funhouseStorage";
+import { formatTimeAgo } from "../utils/timeAgo";
 
 function truncate(text: string, maxLength = 100): string {
   if (text.length <= maxLength) {

--- a/src/pages/FunhouseReplay.tsx
+++ b/src/pages/FunhouseReplay.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState, type JSX } from "react";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 
-import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
-import { getSaveById, loadSaves, type FunhouseSaveEntry } from "@/utils/funhouseStorage";
-import { formatTimeAgo } from "@/utils/timeAgo";
+import { Button } from "../components/ui/button";
+import { Textarea } from "../components/ui/textarea";
+import { getSaveById, loadSaves, type FunhouseSaveEntry } from "../utils/funhouseStorage";
+import { formatTimeAgo } from "../utils/timeAgo";
 
 export default function FunhouseReplay(): JSX.Element {
   const { id } = useParams<{ id: string }>();

--- a/src/pages/__games.tsx
+++ b/src/pages/__games.tsx
@@ -1,7 +1,7 @@
 import cutManifest from "../../games/_manifests/cut-games.manifest.json";
 import goodManifest from "../../games/_manifests/good-word.manifest.json";
 import originalManifest from "../../games/_manifests/original.manifest.json";
-import { resolveOriginalScreens } from "@/games/original.resolve";
+import { resolveOriginalScreens } from "../games/original.resolve";
 
 const MAX_FILES = 20;
 

--- a/src/pages/__smoke.tsx
+++ b/src/pages/__smoke.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useEffect, useMemo, useState } from "react";
-import { resolveOriginalScreens, loadComponent } from "@/games/original.resolve";
+import { resolveOriginalScreens, loadComponent } from "../games/original.resolve";
 
 type ScreenKey = "home" | "play" | "rules";
 

--- a/src/pages/funhouse/[slug].tsx
+++ b/src/pages/funhouse/[slug].tsx
@@ -3,9 +3,9 @@ import Link from "next/link";
 import { useMemo } from "react";
 import { useRouter } from "next/router";
 
-import FunhouseGameShell from "@/components/FunhouseGameShell";
-import { funhouseCatalog } from "@/games/fun_house_writing/funhouse_catalog";
-import { resolveFunhouseDistortion } from "@/games/fun_house_writing/utils";
+import FunhouseGameShell from "../../components/FunhouseGameShell";
+import { funhouseCatalog } from "../../games/fun_house_writing/funhouse_catalog";
+import { resolveFunhouseDistortion } from "../../games/fun_house_writing/utils";
 
 function resolveMode(gameType?: string): string {
   if (!gameType) {

--- a/src/pages/funhouse/index.tsx
+++ b/src/pages/funhouse/index.tsx
@@ -1,8 +1,8 @@
 import Head from "next/head";
 import Link from "next/link";
 
-import { funhouseCatalog } from "@/games/fun_house_writing/funhouse_catalog";
-import { resolveFunhouseDistortion } from "@/games/fun_house_writing/utils";
+import { funhouseCatalog } from "../../games/fun_house_writing/funhouse_catalog";
+import { resolveFunhouseDistortion } from "../../games/fun_house_writing/utils";
 
 const funhousePrompts = funhouseCatalog.map((prompt) => ({
   id: prompt.id,

--- a/src/pages/sigil-syntax/about.tsx
+++ b/src/pages/sigil-syntax/about.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, useEffect, useMemo, useState } from "react";
-import { loadComponent, resolveOriginalScreens } from "@/games/original.resolve";
-import { Guard } from "@/games/guard";
-import { GameMenu } from "@/games/menu";
+import { loadComponent, resolveOriginalScreens } from "../../games/original.resolve";
+import { Guard } from "../../games/guard";
+import { GameMenu } from "../../games/menu";
 
 export default function SigilSyntaxAbout() {
   const [Comp, setComp] = useState<React.ComponentType<any> | null>(null);

--- a/src/pages/sigil-syntax/index.tsx
+++ b/src/pages/sigil-syntax/index.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, useEffect, useMemo, useState } from "react";
-import { loadComponent, resolveOriginalScreens } from "@/games/original.resolve";
-import { Guard } from "@/games/guard";
-import { GameMenu } from "@/games/menu";
+import { loadComponent, resolveOriginalScreens } from "../../games/original.resolve";
+import { Guard } from "../../games/guard";
+import { GameMenu } from "../../games/menu";
 
 export default function SigilSyntaxHome() {
   const [Comp, setComp] = useState<React.ComponentType<any> | null>(null);

--- a/src/pages/sigil-syntax/play.tsx
+++ b/src/pages/sigil-syntax/play.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, useEffect, useMemo, useState } from "react";
-import { loadComponent, resolveOriginalScreens } from "@/games/original.resolve";
-import { Guard } from "@/games/guard";
-import { GameMenu } from "@/games/menu";
+import { loadComponent, resolveOriginalScreens } from "../../games/original.resolve";
+import { Guard } from "../../games/guard";
+import { GameMenu } from "../../games/menu";
 
 export default function SigilSyntaxPlay() {
   const [Comp, setComp] = useState<React.ComponentType<any> | null>(null);

--- a/src/pages/sigil-syntax/rules.tsx
+++ b/src/pages/sigil-syntax/rules.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, useEffect, useMemo, useState } from "react";
-import { loadComponent, resolveOriginalScreens } from "@/games/original.resolve";
-import { Guard } from "@/games/guard";
-import { GameMenu } from "@/games/menu";
+import { loadComponent, resolveOriginalScreens } from "../../games/original.resolve";
+import { Guard } from "../../games/guard";
+import { GameMenu } from "../../games/menu";
 
 export default function SigilSyntaxRules() {
   const [Comp, setComp] = useState<React.ComponentType<any> | null>(null);

--- a/src/utils/unlockFunhousePrompts.ts
+++ b/src/utils/unlockFunhousePrompts.ts
@@ -1,7 +1,7 @@
-import foundation from "@/data/foundation-skills.json";
-import dictionary from "@/data/dictionary-skills.json";
-import cut from "@/data/cut-skills.json";
-import funhouse from "@/data/funhouse-prompts.json";
+import foundation from "../data/foundation-skills.json";
+import dictionary from "../data/dictionary-skills.json";
+import cut from "../data/cut-skills.json";
+import funhouse from "../data/funhouse-prompts.json";
 
 type SkillRecord = { id?: unknown } | string;
 


### PR DESCRIPTION
## Summary
- replace usages of the Vite `@` alias with relative imports across Funhouse and Sigil Syntax pages
- update component and utility imports to use filesystem-relative paths for GitHub Pages compatibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed894b95e4832f92cbad8e3e07c44d