### PR TITLE
Add legal pages and routing polish for wire-up audit

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,15 +1,20 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
 
-  <head>
-    <meta charset="UTF-8" />
+<head>
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>The Good Word</title>
-  </head>
+    <title>Projects From The Projects</title>
+    <meta name="description" content="Projects From The Projects — Games that teach fiction writing." />
+    <meta property="og:title" content="Projects From The Projects" />
+    <meta property="og:description" content="Games that teach fiction writing — Literary Deviousness and more." />
+    <meta property="og:type" content="website" />
+    <link rel="canonical" href="https://<USERNAME>.github.io/<REPO>/" />
+</head>
 
-  <body class="bg-brand-soft text-brand">
+<body>
     <div id="root"></div>
-    <script type="module" src="./src/main.tsx"></script>
-  </body>
+    <script type="module" src="/src/main.tsx"></script>
+</body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,12 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Sigil & Syntax</title>
+    <title>Projects From The Projects</title>
+    <meta name="description" content="Projects From The Projects — Games that teach fiction writing." />
+    <meta property="og:title" content="Projects From The Projects" />
+    <meta property="og:description" content="Games that teach fiction writing — Literary Deviousness and more." />
+    <meta property="og:type" content="website" />
+    <link rel="canonical" href="https://<USERNAME>.github.io/<REPO>/" />
 </head>
 
 <body>

--- a/public/404.html
+++ b/public/404.html
@@ -1,15 +1,20 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
 
-  <head>
-    <meta charset="UTF-8" />
+<head>
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>The Good Word</title>
-  </head>
+    <title>Projects From The Projects</title>
+    <meta name="description" content="Projects From The Projects — Games that teach fiction writing." />
+    <meta property="og:title" content="Projects From The Projects" />
+    <meta property="og:description" content="Games that teach fiction writing — Literary Deviousness and more." />
+    <meta property="og:type" content="website" />
+    <link rel="canonical" href="https://<USERNAME>.github.io/<REPO>/" />
+</head>
 
-  <body class="bg-brand-soft text-brand">
+<body>
     <div id="root"></div>
-    <script type="module" src="./src/main.tsx"></script>
-  </body>
+    <script type="module" src="/src/main.tsx"></script>
+</body>
 
 </html>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://<USERNAME>.github.io/<REPO>/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://<USERNAME>.github.io/<REPO>/</loc>
+  </url>
+  <url>
+    <loc>https://<USERNAME>.github.io/<REPO>/privacy</loc>
+  </url>
+  <url>
+    <loc>https://<USERNAME>.github.io/<REPO>/terms</loc>
+  </url>
+  <url>
+    <loc>https://<USERNAME>.github.io/<REPO>/cookies</loc>
+  </url>
+  <url>
+    <loc>https://<USERNAME>.github.io/<REPO>/dmca</loc>
+  </url>
+  <url>
+    <loc>https://<USERNAME>.github.io/<REPO>/about</loc>
+  </url>
+  <url>
+    <loc>https://<USERNAME>.github.io/<REPO>/contact</loc>
+  </url>
+  <url>
+    <loc>https://<USERNAME>.github.io/<REPO>/login</loc>
+  </url>
+  <url>
+    <loc>https://<USERNAME>.github.io/<REPO>/signup</loc>
+  </url>
+  <url>
+    <loc>https://<USERNAME>.github.io/<REPO>/reset</loc>
+  </url>
+</urlset>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,10 +15,17 @@ import FunhouseGame from "./pages/FunhouseGame";
 import FunhousePast from "./pages/FunhousePast";
 import FunhouseReplay from "./pages/FunhouseReplay";
 import FunhouseDebug from "./pages/FunhouseDebug";
-import { Header } from "./components/Header";
-import { ToastHost } from "./components/ToastHost";
-import { KeyOverlay } from "./components/KeyOverlay";
-import { Footer } from "./components/Footer";
+import Games from "./pages/games";
+import Privacy from "./pages/Privacy";
+import Terms from "./pages/Terms";
+import Cookies from "./pages/Cookies";
+import DMCA from "./pages/DMCA";
+import About from "./pages/About";
+import Contact from "./pages/Contact";
+import Login from "./pages/Login";
+import Signup from "./pages/Signup";
+import ResetPassword from "./pages/ResetPassword";
+import SiteChrome from "./components/SiteChrome";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import Welcome from "./pages/Welcome";
 import { useFirstRun } from "./state/useFirstRun";
@@ -27,11 +34,8 @@ export default function App() {
   const seenWelcome = useFirstRun((state) => state.seenWelcome);
   return (
     <ErrorBoundary>
-      <BrowserRouter>
-        <div className="min-h-screen bg-neutral-50 text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
-          <Header />
-          <ToastHost />
-          <KeyOverlay />
+      <BrowserRouter basename={import.meta.env.BASE_URL}>
+        <SiteChrome>
           <Routes>
             <Route path="/" element={seenWelcome ? <Home /> : <Welcome />} />
             <Route path="/welcome" element={<Welcome />} />
@@ -44,14 +48,23 @@ export default function App() {
             <Route path="/funhouse/replay/:id" element={<FunhouseReplay />} />
             <Route path="/funhouse/:id" element={<FunhouseGame />} />
             <Route path="/funhouse-debug" element={<FunhouseDebug />} />
+            <Route path="/games" element={<Games />} />
             <Route path="/play/:id/see" element={<PlaySee />} />
             <Route path="/play/:id/mcq" element={<PlayMCQ />} />
             <Route path="/play/:id/slot" element={<PlaySlot />} />
             <Route path="/settings" element={<Settings />} />
+            <Route path="/privacy" element={<Privacy />} />
+            <Route path="/terms" element={<Terms />} />
+            <Route path="/cookies" element={<Cookies />} />
+            <Route path="/dmca" element={<DMCA />} />
+            <Route path="/about" element={<About />} />
+            <Route path="/contact" element={<Contact />} />
+            <Route path="/login" element={<Login />} />
+            <Route path="/signup" element={<Signup />} />
+            <Route path="/reset" element={<ResetPassword />} />
             <Route path="*" element={<NotFound />} />
           </Routes>
-          <Footer />
-        </div>
+        </SiteChrome>
       </BrowserRouter>
     </ErrorBoundary>
   );

--- a/src/components/CookieNotice.tsx
+++ b/src/components/CookieNotice.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+export default function CookieNotice() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!localStorage.getItem("cookieConsent")) setVisible(true);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-black text-white p-3 text-xs flex justify-between items-center">
+      <span>This site uses cookies to improve experience.</span>
+      <button
+        onClick={() => {
+          localStorage.setItem("cookieConsent", "v1");
+          setVisible(false);
+        }}
+        className="bg-white text-black px-2 py-1 font-bold"
+      >
+        Accept
+      </button>
+    </div>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,10 +1,31 @@
 import React from "react";
+import { Link } from "react-router-dom";
 
 export function Footer() {
   return (
     <footer className="mt-8 border-t border-neutral-200 dark:border-neutral-800">
-      <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-4 text-xs text-neutral-600 dark:text-neutral-400">
+      <div className="mx-auto flex max-w-5xl flex-col gap-2 px-4 py-4 text-xs text-neutral-600 dark:text-neutral-400 md:flex-row md:items-center md:justify-between">
         <span>The Good Word · Words, but exact.</span>
+        <nav className="flex flex-wrap items-center gap-3">
+          <Link to="/privacy" className="hover:underline">
+            Privacy
+          </Link>
+          <Link to="/terms" className="hover:underline">
+            Terms
+          </Link>
+          <Link to="/cookies" className="hover:underline">
+            Cookies
+          </Link>
+          <Link to="/dmca" className="hover:underline">
+            DMCA
+          </Link>
+          <Link to="/about" className="hover:underline">
+            About
+          </Link>
+          <Link to="/contact" className="hover:underline">
+            Contact
+          </Link>
+        </nav>
         <span>v0.1</span>
       </div>
     </footer>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,9 +22,12 @@ export function Header() {
           <span className="text-lg font-semibold">The Good Word</span>
           <span className="text-xs text-neutral-500 dark:text-neutral-400">Words, but exact.</span>
         </Link>
-        <nav className="flex items-center gap-3">
+        <nav className="flex flex-wrap items-center gap-2 md:gap-3">
           <NavLink to="/" end className={navClass}>
             Home
+          </NavLink>
+          <NavLink to="/games" className={navClass}>
+            Games
           </NavLink>
           <NavLink to="/practice" className={navClass}>
             Practice
@@ -38,6 +41,15 @@ export function Header() {
           <NavLink to="/settings" className={navClass}>
             Settings
           </NavLink>
+          <div className="flex items-center gap-1">
+            <NavLink to="/login" className={navClass}>
+              Login
+            </NavLink>
+            <span className="text-xs font-semibold uppercase text-neutral-400">/</span>
+            <NavLink to="/signup" className={navClass}>
+              Signup
+            </NavLink>
+          </div>
           <button
             type="button"
             className="text-sm underline-offset-4 transition hover:underline"

--- a/src/components/SiteChrome.tsx
+++ b/src/components/SiteChrome.tsx
@@ -1,0 +1,19 @@
+import type { PropsWithChildren } from "react";
+import { Header } from "./Header";
+import { Footer } from "./Footer";
+import { ToastHost } from "./ToastHost";
+import { KeyOverlay } from "./KeyOverlay";
+import CookieNotice from "./CookieNotice";
+
+export default function SiteChrome({ children }: PropsWithChildren) {
+  return (
+    <div className="min-h-screen bg-neutral-50 text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
+      <Header />
+      <ToastHost />
+      <KeyOverlay />
+      <main>{children}</main>
+      <Footer />
+      <CookieNotice />
+    </div>
+  );
+}

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,0 +1,8 @@
+export default function About() {
+  return (
+    <div className="p-6 font-mono text-sm border-t-4 border-black">
+      <h1>About</h1>
+      <p>TODO: replace with final policy text</p>
+    </div>
+  );
+}

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,0 +1,8 @@
+export default function Contact() {
+  return (
+    <div className="p-6 font-mono text-sm border-t-4 border-black">
+      <h1>Contact</h1>
+      <p>TODO: replace with final policy text</p>
+    </div>
+  );
+}

--- a/src/pages/Cookies.tsx
+++ b/src/pages/Cookies.tsx
@@ -1,0 +1,8 @@
+export default function Cookies() {
+  return (
+    <div className="p-6 font-mono text-sm border-t-4 border-black">
+      <h1>Cookie Policy</h1>
+      <p>TODO: replace with final policy text</p>
+    </div>
+  );
+}

--- a/src/pages/DMCA.tsx
+++ b/src/pages/DMCA.tsx
@@ -1,0 +1,8 @@
+export default function DMCA() {
+  return (
+    <div className="p-6 font-mono text-sm border-t-4 border-black">
+      <h1>DMCA Policy</h1>
+      <p>TODO: replace with final policy text</p>
+    </div>
+  );
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,8 @@
+export default function Login() {
+  return (
+    <div className="p-6 font-mono text-sm border-t-4 border-black">
+      <h1>Login</h1>
+      <p>TODO: replace with final policy text</p>
+    </div>
+  );
+}

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -1,0 +1,8 @@
+export default function Privacy() {
+  return (
+    <div className="p-6 font-mono text-sm border-t-4 border-black">
+      <h1>Privacy Policy</h1>
+      <p>TODO: replace with final policy text</p>
+    </div>
+  );
+}

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -1,0 +1,8 @@
+export default function ResetPassword() {
+  return (
+    <div className="p-6 font-mono text-sm border-t-4 border-black">
+      <h1>Reset Password</h1>
+      <p>TODO: replace with final policy text</p>
+    </div>
+  );
+}

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,0 +1,8 @@
+export default function Signup() {
+  return (
+    <div className="p-6 font-mono text-sm border-t-4 border-black">
+      <h1>Signup</h1>
+      <p>TODO: replace with final policy text</p>
+    </div>
+  );
+}

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -1,0 +1,8 @@
+export default function Terms() {
+  return (
+    <div className="p-6 font-mono text-sm border-t-4 border-black">
+      <h1>Terms of Service</h1>
+      <p>TODO: replace with final policy text</p>
+    </div>
+  );
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,8 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
-  // IMPORTANT: set to your repo name with leading/trailing slashes
-  // Example: base: "/the-good-word/"
-  base: "/ProjectsFromTheProjects/",
+  base: process.env.GITHUB_REPOSITORY
+    ? "/" + process.env.GITHUB_REPOSITORY.split("/")[1] + "/"
+    : "/",
   build: { sourcemap: true, outDir: "dist" },
 });


### PR DESCRIPTION
## Summary
- add stub legal, company, and auth pages and register their routes with a wildcard fallback
- wrap the app in a SiteChrome layout with updated header/footer navigation and a CookieNotice component
- refresh GitHub Pages settings and SEO collateral including index/404 metadata, robots.txt, and sitemap.xml

## Testing
- not run (static changes only)


------
https://chatgpt.com/codex/tasks/task_e_68ed8ef8543c832fb2be7095b5959c23