### PR TITLE
Hide header on home and games

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,6 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Projects From The Projects</title>
-    <meta name="description" content="Projects From The Projects — Games that teach fiction writing." />
-    <meta property="og:title" content="Projects From The Projects" />
-    <meta property="og:description" content="Games that teach fiction writing — Literary Deviousness and more." />
     <meta property="og:type" content="website" />
     <link rel="canonical" href="https://projectsfromtheprojects.github.io/ProjectsFromTheProjects/" />
 </head>

--- a/src/components/SiteChrome.tsx
+++ b/src/components/SiteChrome.tsx
@@ -1,4 +1,5 @@
 import type { PropsWithChildren } from "react";
+import { useLocation } from "react-router-dom";
 import { Header } from "./Header";
 import { Footer } from "./Footer";
 import { ToastHost } from "./ToastHost";
@@ -6,9 +7,21 @@ import { KeyOverlay } from "./KeyOverlay";
 import CookieNotice from "./CookieNotice";
 
 export default function SiteChrome({ children }: PropsWithChildren) {
+  const location = useLocation();
+  const base = (import.meta as any).env?.BASE_URL || "/";
+
+  // Resolve a base-agnostic path: turns "/<repo>/" → "/", "/<repo>/games" → "/games"
+  function rel(p: string) {
+    if (!base || base === "/") return p;
+    return p.startsWith(base) ? p.slice(base.length - 1) : p;
+  }
+
+  const path = rel(location.pathname) || "/";
+  const hideTopNav = path === "/" || path === "/games";
+
   return (
     <div className="min-h-screen bg-neutral-50 text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
-      <Header />
+      {!hideTopNav && <Header />}
       <ToastHost />
       <KeyOverlay />
       <main>{children}</main>


### PR DESCRIPTION
## Summary
- UI: Header/top nav hidden on Home (/) and Games (/games) only; persists elsewhere.
- Meta: Removed description, og:title, and og:description from index.html per request.
- No other routes or SEO tags changed.

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ed9d8ce2a8832fafecd704205335de