### PR TITLE
Restore Sigil & Syntax wiring without renaming files

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import Game from "@/pages/Game";
 import SiteChrome from "@/components/SiteChrome";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import GoodWord from "@/games/goodword";
+import SigilSyntaxGame from "@/games/sigil-syntax/SigilSyntaxGame";
 
 export default function App() {
   return (
@@ -39,6 +40,7 @@ export default function App() {
             <Route path="/" element={<Home />} />
             <Route path="/games" element={<Games />} />
             <Route path="/games/goodword" element={<GoodWord />} />
+            <Route path="/games/sigil-syntax" element={<SigilSyntaxGame />} />
 
             <Route path="/pack/:id" element={<PackPage />} />
             <Route path="/practice" element={<PracticeHub />} />

--- a/src/games/sigil-syntax/SigilSyntaxGame.tsx
+++ b/src/games/sigil-syntax/SigilSyntaxGame.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { getSigilSyntaxComponent } from "./resolve";
+
+export default function SigilSyntaxGame() {
+  const C = getSigilSyntaxComponent();
+  if (!C) {
+    return (
+      <main className="p-6 font-mono text-sm border-t-4 border-black">
+        <h1>Sigil &amp; Syntax</h1>
+        <p>
+          Could not locate the original game entry. Check generically named files like
+          <code>app.tsx</code> or <code>page.tsx</code> and ensure they export a default React component.
+        </p>
+      </main>
+    );
+  }
+  // Render the discovered game
+  return <C />;
+}

--- a/src/games/sigil-syntax/dataProbe.ts
+++ b/src/games/sigil-syntax/dataProbe.ts
@@ -1,0 +1,11 @@
+// For quick diagnostics & optional usage by the game.
+// You can import this into your generic app if needed.
+export const labeledDataRaw = import.meta.glob(
+  "/labled data/**/*.{json,jsonl,txt,md}",
+  { as: "raw", eager: true }
+) as Record<string, string>;
+
+export const labeledDataJson = import.meta.glob(
+  "/labled data/**/*.json",
+  { eager: true }
+) as Record<string, any>;

--- a/src/games/sigil-syntax/resolve.tsx
+++ b/src/games/sigil-syntax/resolve.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+
+/**
+ * We scan for likely entry components (generic names like app.tsx/App.tsx/page.tsx)
+ * and choose the best candidate by scoring:
+ *  1) File path contains "sigil" or "syntax"
+ *  2) File content includes "Sigil" or "Syntax"
+ *  3) File imports from "labled data" or "game thingss"
+ *  4) Fallback: first matching "app.tsx" nearest to games/
+ *
+ * We do NOT move/rename anything. We just import the chosen module and render its default export.
+ */
+
+// Raw contents for scoring
+const rawCandidates = import.meta.glob(
+  "/src/**/*{app,App,page,Page}.{tsx,jsx,ts,js}",
+  { as: "raw", eager: true }
+) as Record<string, string>;
+
+// Modules to render
+const modCandidates = import.meta.glob(
+  "/src/**/*{app,App,page,Page}.{tsx,jsx,ts,js}",
+  { eager: true }
+) as Record<string, any>;
+
+type Scored = { path: string; score: number };
+
+function scorePath(path: string, raw: string): number {
+  let s = 0;
+  const p = path.toLowerCase();
+  if (p.includes("sigil")) s += 6;
+  if (p.includes("syntax")) s += 6;
+  if (/sigil|syntax/i.test(raw)) s += 5;
+  if (/from\s+["'][./\s]*labled data/i.test(raw)) s += 4;
+  if (/from\s+["'][./\s]*game thingss/i.test(raw)) s += 4;
+  // Prefer under games/
+  if (p.includes("/games/")) s += 3;
+  // Prefer app.tsx over page.tsx
+  if (p.match(/\/app\.(t|j)sx?$/i)) s += 2;
+  return s;
+}
+
+function pickCandidate(): string | null {
+  const scored: Scored[] = Object.entries(rawCandidates).map(([path, raw]) => ({
+    path,
+    score: scorePath(path, raw || "")
+  }));
+  scored.sort((a, b) => b.score - a.score);
+  const top = scored[0];
+  if (!top || top.score <= 0) {
+    // fallback: any app.tsx near games
+    const fall = Object.keys(rawCandidates).find(p =>
+      /\/games\/.*\/app\.(t|j)sx?$/i.test(p)
+    ) || Object.keys(rawCandidates).find(p =>
+      /\/app\.(t|j)sx?$/i.test(p)
+    );
+    return fall || null;
+  }
+  return top.path;
+}
+
+export function getSigilSyntaxComponent(): React.ComponentType | null {
+  const chosen = pickCandidate();
+  if (!chosen) {
+    console.error("[Sigil&Syntax] No candidate entry component found.");
+    return null;
+  }
+  const mod = modCandidates[chosen];
+  const C = (mod?.default ?? mod) as React.ComponentType | undefined;
+  if (!C) {
+    console.error("[Sigil&Syntax] Candidate has no default export:", chosen);
+    return null;
+  }
+  console.groupCollapsed("[Sigil&Syntax] Using entry:", chosen);
+  console.log("Scanned", Object.keys(modCandidates).length, "candidates.");
+  console.groupEnd();
+  return C;
+}

--- a/src/pages/games/index.tsx
+++ b/src/pages/games/index.tsx
@@ -8,16 +8,29 @@ export default function GamesHub(): JSX.Element {
         <h1 className="text-3xl font-semibold">Games</h1>
         <p className="text-neutral-600 dark:text-neutral-400">Jump into an adventure.</p>
       </header>
-      <nav className="flex flex-col gap-3 text-lg">
-        <Link className="text-blue-600 underline" to="/games/goodword">
-          The Good Word
-        </Link>
-        <Link className="text-blue-600 underline" to="/play/cut-games">
-          The Cut Games
-        </Link>
-        <Link className="text-blue-600 underline" to="/funhouse">
-          The Funhouse
-        </Link>
+      <nav>
+        <ul className="flex flex-col gap-3 text-lg">
+          <li>
+            <Link className="text-blue-600 underline" to="/games/goodword">
+              The Good Word
+            </Link>
+          </li>
+          <li>
+            <Link className="text-blue-600 underline" to="/play/cut-games">
+              The Cut Games
+            </Link>
+          </li>
+          <li>
+            <Link className="text-blue-600 underline" to="/funhouse">
+              The Funhouse
+            </Link>
+          </li>
+          <li className="mb-2">
+            <Link className="underline" to="/games/sigil-syntax">
+              Sigil &amp; Syntax
+            </Link>
+          </li>
+        </ul>
       </nav>
     </section>
   );


### PR DESCRIPTION
## Summary
- add a runtime resolver that discovers the existing Sigil & Syntax entry module
- mount the game at /games/sigil-syntax and surface it from the games hub
- expose the optional labled data probe for debugging without touching existing files

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eea0b900ac832f82faea0f1ed64a56