### PR TITLE
Fix: remove nested Router in Sigil & Syntax

### DIFF
--- a/src/SigilSyntaxApp.tsx
+++ b/src/SigilSyntaxApp.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { HashRouter, Routes, Route, Link } from "react-router-dom";
+import { Routes, Route, Link } from "react-router-dom";
 import {
     CutGames,
     CutGamesPlay,
@@ -14,45 +14,44 @@ import {
     SigilSyntaxRoot,
 } from "./pages";
 
-export default function SigilSyntaxApp() {
+/** Router-less shell: assumes parent router provides context. */
+export default function SigilSyntaxAppShell() {
     return (
         <div className="bg-brand-soft min-h-screen">
-            <HashRouter>
-                {/* simple top nav so everything is discoverable */}
-                <nav style={{ padding: 12, borderBottom: "2px solid #000" }}>
-                    <Link to="/">Home</Link> {" | "}
-                    <Link to="/games">Games</Link> {" | "}
-                    <Link to="/cutgames">Cut Game</Link> {" | "}
-                    <Link to="/foundation">Foundation</Link> {" | "}
-                    <Link to="/dictionary">Dictionary</Link> {" | "}
-                    <Link to="/play">Play</Link>
-                </nav>
+            {/* simple top nav so everything is discoverable */}
+            <nav style={{ padding: 12, borderBottom: "2px solid #000" }}>
+                <Link to=".">Home</Link> {" | "}
+                <Link to="games">Games</Link> {" | "}
+                <Link to="cutgames">Cut Game</Link> {" | "}
+                <Link to="foundation">Foundation</Link> {" | "}
+                <Link to="dictionary">Dictionary</Link> {" | "}
+                <Link to="play">Play</Link>
+            </nav>
 
-                <Routes>
-                    <Route path="/" element={<Home />} />
-                    {/* Cut Game */}
-                    <Route path="/games" element={<Games />} />
-                    <Route path="/cutgames" element={<CutGames />} />
-                    <Route path="/cutgames/play" element={<CutGamesPlay />} />
+            <Routes>
+                <Route index element={<Home />} />
+                {/* Cut Game */}
+                <Route path="games" element={<Games />} />
+                <Route path="cutgames" element={<CutGames />} />
+                <Route path="cutgames/play" element={<CutGamesPlay />} />
 
-                    {/* Foundation + Dictionary */}
-                    <Route path="/foundation" element={<Foundation />} />
-                    <Route path="/dictionary" element={<Dictionary />} />
+                {/* Foundation + Dictionary */}
+                <Route path="foundation" element={<Foundation />} />
+                <Route path="dictionary" element={<Dictionary />} />
 
-                    {/* Word games */}
-                    <Route path="/play" element={<Play />} />
-                    <Route path="/play/:id" element={<PlaySee />} />
-                    <Route path="/play/:id/see" element={<PlaySee />} />
-                    <Route path="/play/:id/mcq" element={<PlayMCQ />} />
-                    <Route path="/play/:id/slot" element={<PlaySlot />} />
+                {/* Word games */}
+                <Route path="play" element={<Play />} />
+                <Route path="play/:id" element={<PlaySee />} />
+                <Route path="play/:id/see" element={<PlaySee />} />
+                <Route path="play/:id/mcq" element={<PlayMCQ />} />
+                <Route path="play/:id/slot" element={<PlaySlot />} />
 
-                    {/* Generic container if you want nested stuff later */}
-                    <Route path="/game" element={<SigilSyntaxRoot />} />
+                {/* Generic container if you want nested stuff later */}
+                <Route path="game" element={<SigilSyntaxRoot />} />
 
-                    {/* Fallback */}
-                    <Route path="*" element={<Home />} />
-                </Routes>
-            </HashRouter>
+                {/* Fallback */}
+                <Route path="*" element={<Home />} />
+            </Routes>
         </div>
     );
 }

--- a/src/games/menu.tsx
+++ b/src/games/menu.tsx
@@ -1,6 +1,17 @@
 import React from "react";
 import { Link } from "react-router-dom";
 
+function join(base: string, segment?: string): string {
+  const trimmed = base.replace(/\/+$/, "");
+  if (!segment) {
+    return trimmed || ".";
+  }
+  if (!trimmed || trimmed === ".") {
+    return segment;
+  }
+  return `${trimmed}/${segment}`;
+}
+
 export function GameMenu(props: { base: string; showRules?: boolean }) {
   const { base, showRules = true } = props;
   return (
@@ -14,14 +25,14 @@ export function GameMenu(props: { base: string; showRules?: boolean }) {
         fontFamily: "system-ui, sans-serif",
       }}
     >
-      <Link to={`${base}`} style={{ textDecoration: "none" }}>
+      <Link to={join(base)} style={{ textDecoration: "none" }}>
         Home
       </Link>
-      <Link to={`${base}/play`} style={{ textDecoration: "none" }}>
+      <Link to={join(base, "play")} style={{ textDecoration: "none" }}>
         Play
       </Link>
       {showRules && (
-        <Link to={`${base}/rules`} style={{ textDecoration: "none" }}>
+        <Link to={join(base, "rules")} style={{ textDecoration: "none" }}>
           Rules
         </Link>
       )}

--- a/src/pages/SigilSyntaxRoot.tsx
+++ b/src/pages/SigilSyntaxRoot.tsx
@@ -5,7 +5,7 @@ export default function SigilSyntaxRoot(): JSX.Element {
     return (
         <div className="brutalist-root" style={{ padding: '1rem' }}>
             <nav style={{ marginBottom: '1rem' }}>
-                <Link to="/">Home</Link> | <Link to="/play">Play</Link> | <Link to="/play/cut-games">Cut Games</Link>
+                <Link to=".">Home</Link> | <Link to="play">Play</Link> | <Link to="cutgames/play">Cut Games</Link>
             </nav>
             <Outlet />
         </div>

--- a/src/pages/sigil-syntax/about.tsx
+++ b/src/pages/sigil-syntax/about.tsx
@@ -37,7 +37,7 @@ export default function SigilSyntaxAbout() {
 
   return (
     <Guard gameId="original">
-      <GameMenu base="/sigil-syntax" />
+      <GameMenu base="." />
       <Suspense fallback={<div style={{ padding: 20 }}>Loading…</div>}>
         <Comp />
       </Suspense>

--- a/src/pages/sigil-syntax/index.tsx
+++ b/src/pages/sigil-syntax/index.tsx
@@ -37,7 +37,7 @@ export default function SigilSyntaxHome() {
 
   return (
     <Guard gameId="original">
-      <GameMenu base="/sigil-syntax" />
+      <GameMenu base="." />
       <Suspense fallback={<div style={{ padding: 20 }}>Loading…</div>}>
         <Comp />
       </Suspense>

--- a/src/pages/sigil-syntax/play.tsx
+++ b/src/pages/sigil-syntax/play.tsx
@@ -37,7 +37,7 @@ export default function SigilSyntaxPlay() {
 
   return (
     <Guard gameId="original">
-      <GameMenu base="/sigil-syntax" />
+      <GameMenu base="." />
       <Suspense fallback={<div style={{ padding: 20 }}>Loading…</div>}>
         <Comp />
       </Suspense>

--- a/src/pages/sigil-syntax/rules.tsx
+++ b/src/pages/sigil-syntax/rules.tsx
@@ -37,7 +37,7 @@ export default function SigilSyntaxRules() {
 
   return (
     <Guard gameId="original">
-      <GameMenu base="/sigil-syntax" />
+      <GameMenu base="." />
       <Suspense fallback={<div style={{ padding: 20 }}>Loading…</div>}>
         <Comp />
       </Suspense>


### PR DESCRIPTION
## Summary
- remove the nested router from the Sigil & Syntax entry and keep its routes relative to the parent
- adjust the shared game menu helper to generate relative links and update Sigil & Syntax screens to use it
- convert in-game navigation links to relative paths so the game nests cleanly under /games/sigil-syntax

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eeae44ba20832fa3122215d23cce40