### PR TITLE
Wire Sigil & Syntax game route and loader

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ import Game from "@/pages/Game";
 import SiteChrome from "@/components/SiteChrome";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import GoodWord from "@/games/goodword";
-import SigilSyntaxGame from "@/games/sigil-syntax/SigilSyntaxGame";
+import SigilSyntaxGame from "@/pages/SigilSyntaxGame";
 
 export default function App() {
   return (
@@ -40,7 +40,7 @@ export default function App() {
             <Route path="/" element={<Home />} />
             <Route path="/games" element={<Games />} />
             <Route path="/games/goodword" element={<GoodWord />} />
-            <Route path="/games/sigil-syntax" element={<SigilSyntaxGame />} />
+            <Route path="/games/sigil-syntax/*" element={<SigilSyntaxGame />} />
 
             <Route path="/pack/:id" element={<PackPage />} />
             <Route path="/practice" element={<PracticeHub />} />

--- a/src/data/loadAllPacksSafe.ts
+++ b/src/data/loadAllPacksSafe.ts
@@ -1,4 +1,4 @@
-import validateAndNormalize, { type WordEntry } from "@/utils/validateAndNormalize";
+import validateAndNormalize, { type ValidationResult, type WordEntry } from "@/utils/validateAndNormalize";
 import { ensurePackObject } from "@/utils/ensurePackObject";
 import { collectRawPacks } from "./packSources";
 
@@ -37,7 +37,7 @@ export async function loadAllPacksSafe(): Promise<{ packs: Pack[]; report: strin
   for (const { path, content } of rawEntries) {
     const asObj = ensurePackObject(content);
 
-    let normalized: { entries: WordEntry[]; issues: string[] };
+    let normalized: ValidationResult;
     try {
       normalized = validateAndNormalize(asObj);
     } catch (e: any) {

--- a/src/games/sigilSyntaxData.ts
+++ b/src/games/sigilSyntaxData.ts
@@ -1,0 +1,60 @@
+import validateAndNormalize from "@/utils/validateAndNormalize";
+
+type AnyObj = Record<string, any>;
+
+// Try .json first, then .ts export fallback.
+const jsonMods = import.meta.glob("/src/data/sigilSyntaxItems.json", { eager: true }) as Record<string, any>;
+const tsMods = import.meta.glob("/src/games/sigilSyntaxItems.{ts,tsx}", { eager: true }) as Record<string, any>;
+
+function pickRaw(): unknown {
+  const json = Object.values(jsonMods)[0];
+  if (json !== undefined) return json;
+  const ts = Object.values(tsMods)[0];
+  if (ts && ("default" in ts || "items" in ts)) {
+    return (ts as any).default ?? (ts as any).items;
+  }
+  return undefined;
+}
+
+// Coerce strings/arrays → object the validator accepts.
+function ensureObject(raw: unknown): AnyObj {
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) return raw as AnyObj;
+  if (Array.isArray(raw)) return { items: raw };
+  if (typeof raw === "string") {
+    const s = raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
+    try {
+      const p = JSON.parse(s);
+      if (p && typeof p === "object" && !Array.isArray(p)) return p as AnyObj;
+      if (Array.isArray(p)) return { items: p };
+      return { value: p };
+    } catch {
+      return { value: s.trim() };
+    }
+  }
+  return { value: raw as any };
+}
+
+export type SigilItem = { term?: string; definition?: string; [k: string]: any };
+export type SigilPack = { items: SigilItem[]; [k: string]: any };
+
+export function loadSigilPackSafe(): SigilPack | null {
+  const raw = pickRaw();
+  if (raw === undefined) {
+    console.warn(
+      "[Sigil&Syntax] No data found (looked for src/data/sigilSyntaxItems.json and src/games/sigilSyntaxItems.ts)."
+    );
+    return null;
+  }
+  const obj = ensureObject(raw);
+  try {
+    const normalized = validateAndNormalize(obj) as SigilPack;
+    if (!normalized || !Array.isArray(normalized.items)) {
+      console.error("[Sigil&Syntax] Normalized pack missing .items array.", normalized);
+      return null;
+    }
+    return normalized;
+  } catch (e: any) {
+    console.error("[Sigil&Syntax] Validation failed.", obj, e?.message || e);
+    return null;
+  }
+}

--- a/src/pages/SigilSyntaxGame.tsx
+++ b/src/pages/SigilSyntaxGame.tsx
@@ -1,0 +1,93 @@
+import React, { useMemo, useState } from "react";
+import { Routes, Route, Link, useNavigate } from "react-router-dom";
+import { loadSigilPackSafe } from "@/games/sigilSyntaxData";
+import "@/styles/brutalist.css";
+import "@/styles/theme/theme.css";
+
+function Menu() {
+  const nav = useNavigate();
+  return (
+    <main className="p-6 font-mono text-sm border-t-4 border-black" data-testid="sigil-menu">
+      <h1>Sigil &amp; Syntax</h1>
+      <p className="mb-3">Grammar drills &amp; literary devices.</p>
+      <button className="border-2 border-black px-3 py-1" onClick={() => nav("play")}>
+        Play
+      </button>
+    </main>
+  );
+}
+
+function Play() {
+  const pack = useMemo(() => loadSigilPackSafe(), []);
+  const [index, setIndex] = useState(0);
+
+  if (!pack) {
+    return (
+      <main className="p-6 font-mono text-sm border-t-4 border-black">
+        <h2>Data not available</h2>
+        <p>
+          Put items in <code>src/data/sigilSyntaxItems.json</code> or export <code>items</code> from{" "}
+          <code>src/games/sigilSyntaxItems.ts</code>.
+        </p>
+        <Link className="underline" to="..">
+          Back
+        </Link>
+      </main>
+    );
+  }
+
+  const items = pack.items;
+  const cur = items[index] ?? null;
+
+  return (
+    <main className="p-6 font-mono text-sm border-t-4 border-black" data-testid="sigil-play">
+      <h2 className="mb-2">Round {index + 1}</h2>
+      {cur ? (
+        <>
+          <div className="mb-3">
+            <div className="font-bold">Term:</div>
+            <div>{cur.term ?? cur.prompt ?? "—"}</div>
+          </div>
+          <div className="mb-3">
+            <div className="font-bold">Definition / Target:</div>
+            <div>{cur.definition ?? cur.target ?? "—"}</div>
+          </div>
+          <div className="flex gap-2">
+            <button
+              className="border-2 border-black px-3 py-1"
+              onClick={() => setIndex((i) => Math.max(0, i - 1))}
+            >
+              Prev
+            </button>
+            <button
+              className="border-2 border-black px-3 py-1"
+              onClick={() => setIndex((i) => Math.min(items.length - 1, i + 1))}
+            >
+              Next
+            </button>
+            <Link className="underline ml-4" to="..">
+              Menu
+            </Link>
+          </div>
+        </>
+      ) : (
+        <>
+          <p>No item at index {index}.</p>
+          <Link className="underline" to="..">
+            Menu
+          </Link>
+        </>
+      )}
+    </main>
+  );
+}
+
+/** Router-less shell (nested under /games/sigil-syntax/*) */
+export default function SigilSyntaxGame() {
+  return (
+    <Routes>
+      <Route path="" element={<Menu />} />
+      <Route path="play" element={<Play />} />
+    </Routes>
+  );
+}

--- a/src/pages/literary-deviousness/index.tsx
+++ b/src/pages/literary-deviousness/index.tsx
@@ -2,5 +2,5 @@ import type { JSX } from "react";
 import { Navigate } from "react-router-dom";
 
 export default function LiteraryDeviousnessAlias(): JSX.Element {
-  return <Navigate to="/sigil-syntax" replace />;
+  return <Navigate to="/games/sigil-syntax" replace />;
 }

--- a/src/pages/original/index.tsx
+++ b/src/pages/original/index.tsx
@@ -2,5 +2,5 @@ import type { JSX } from "react";
 import { Navigate } from "react-router-dom";
 
 export default function OriginalAlias(): JSX.Element {
-  return <Navigate to="/sigil-syntax" replace />;
+  return <Navigate to="/games/sigil-syntax" replace />;
 }

--- a/src/utils/validateAndNormalize.ts
+++ b/src/utils/validateAndNormalize.ts
@@ -10,6 +10,7 @@ export type ValidationIssue = string;
 
 export type ValidationResult = {
   entries: WordEntry[];
+  items: WordEntry[];
   issues: ValidationIssue[];
 };
 
@@ -195,7 +196,7 @@ export default function validateAndNormalize(raw: unknown): ValidationResult {
     if (normalized) entries.push(normalized);
   });
 
-  return { entries, issues };
+  return { entries, items: entries, issues };
 }
 
 export { WordEntrySchema };


### PR DESCRIPTION
## Summary
- add a dedicated Sigil & Syntax page with nested menu/play routes and shared styles
- introduce a safe data loader that normalizes JSON/TS packs through the validator
- mount the game at `/games/sigil-syntax/*`, guard legacy redirects, and expose `items` from the validator

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68eeb63f9410832fa29051068ab3ef6b