### PR TITLE
Add Cut Game and Good Word bundles and UI routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,4 +154,8 @@ game thingss/influences.json
 game thingss/reportPhrases.json
 game thingss/writer_types.json
 game thingss/reportTypes.json
+game thingss/build/bundle_cut_game.json
+game thingss/build/bundle_good_word.json
+game things/build/bundle_cut_game.json
+game things/build/bundle_good_word.json
 

--- a/app/src/lib/apiBase.js
+++ b/app/src/lib/apiBase.js
@@ -1,0 +1,20 @@
+const PROD = (import.meta.env.VITE_PROD_API || '').toString().trim()
+const DEV_BASE = (import.meta.env.VITE_API_BASE || '').toString().trim()
+
+function normalizeBase(base) {
+  return base.replace(/\/+$/, '')
+}
+
+export function api(pathname = '') {
+  const path = pathname.startsWith('/') ? pathname : `/${pathname}`
+  if (PROD && /^https?:\/\//i.test(PROD)) {
+    return `${normalizeBase(PROD)}${path}`
+  }
+  const base = DEV_BASE ? normalizeBase(DEV_BASE) : ''
+  return `${base}${path}`
+}
+
+export function apiBase() {
+  if (PROD && /^https?:\/\//i.test(PROD)) return normalizeBase(PROD)
+  return DEV_BASE ? normalizeBase(DEV_BASE) : ''
+}

--- a/app/src/lib/gameAdapters/cutGood.js
+++ b/app/src/lib/gameAdapters/cutGood.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { api } from '@/lib/apiBase.js'
+
+// normalize a server game to your GameItem spec
+export function adaptItem(it) {
+  // default to MCQ wiring; highlight/order can be added later
+  if (it.input_type === 'mcq') {
+    return {
+      mode: 'mcq',
+      id: it.id,
+      prompt: <div dangerouslySetInnerHTML={{ __html: it.prompt_html || '' }} />,
+      choices: it.choices || [],
+      correctIndex: it.correct_index ?? 0,
+      title: it.title || ''
+    }
+  }
+  // fallback to read-only
+  return {
+    mode: 'read',
+    id: it.id,
+    prompt: <div dangerouslySetInnerHTML={{ __html: it.prompt_html || '' }} />,
+    title: it.title || ''
+  }
+}
+
+export async function fetchCutItem(id) {
+  const r = await fetch(api(`/cut/game/${encodeURIComponent(id)}`))
+  if (!r.ok) throw new Error(String(r.status))
+  return adaptItem(await r.json())
+}
+
+export async function fetchGoodItem(id) {
+  const r = await fetch(api(`/goodword/game/${encodeURIComponent(id)}`))
+  if (!r.ok) throw new Error(String(r.status))
+  return adaptItem(await r.json())
+}
+
+export async function listCutIds() {
+  const r = await fetch(api('/cut/catalog')); const j = await r.json()
+  return j.games || []
+}
+export async function listGoodIds() {
+  const r = await fetch(api('/goodword/catalog')); const j = await r.json()
+  return j.games || []
+}

--- a/app/src/pages/CutGame.jsx
+++ b/app/src/pages/CutGame.jsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react'
+import GameLayout from '@sigil/GameLayout'
+import GameItem from '@sigil/GameItem'
+import { fetchCutItem } from '@/lib/gameAdapters/cutGood.js'
+import { useParams, useNavigate } from 'react-router-dom'
+
+export default function CutGame() {
+  const { id } = useParams()
+  const nav = useNavigate()
+  const [spec, setSpec] = useState(null)
+  const [err, setErr] = useState('')
+
+  useEffect(() => {
+    setSpec(null); setErr('')
+    fetchCutItem(id).then(setSpec).catch(e => setErr(String(e)))
+  }, [id])
+
+  return (
+    <GameLayout title="Cut Game" feedback={err && <span style={{color:'tomato'}}>{err}</span>} onPrev={()=>nav(-1)}>
+      {spec && <GameItem spec={spec} onResult={() => {}} />}
+    </GameLayout>
+  )
+}

--- a/app/src/pages/GoodWord.jsx
+++ b/app/src/pages/GoodWord.jsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react'
+import GameLayout from '@sigil/GameLayout'
+import GameItem from '@sigil/GameItem'
+import { fetchGoodItem } from '@/lib/gameAdapters/cutGood.js'
+import { useParams, useNavigate } from 'react-router-dom'
+
+export default function GoodWord() {
+  const { id } = useParams()
+  const nav = useNavigate()
+  const [spec, setSpec] = useState(null)
+  const [err, setErr] = useState('')
+
+  useEffect(() => {
+    setSpec(null); setErr('')
+    fetchGoodItem(id).then(setSpec).catch(e => setErr(String(e)))
+  }, [id])
+
+  return (
+    <GameLayout title="The Good Word" feedback={err && <span style={{color:'tomato'}}>{err}</span>} onPrev={()=>nav(-1)}>
+      {spec && <GameItem spec={spec} onResult={() => {}} />}
+    </GameLayout>
+  )
+}

--- a/app/src/routes.jsx
+++ b/app/src/routes.jsx
@@ -4,11 +4,15 @@ import Game from "./pages/Game.jsx";
 import NotesPanel from "./pages/NotesPanel.jsx";
 import ResultsScreen from "./pages/ResultsScreen.jsx";
 import Health from "./pages/Health.jsx";
+import CutGame from "./pages/CutGame.jsx";
+import GoodWord from "./pages/GoodWord.jsx";
 
 export default [
     { path: "/", element: <Home /> },
     { path: "/game", element: <Game /> },
     { path: "/notes", element: <NotesPanel /> },
     { path: "/results", element: <ResultsScreen /> },
-    { path: "/health", element: <Health /> }
+    { path: "/health", element: <Health /> },
+    { path: "/cut/:id", element: <CutGame /> },
+    { path: "/goodword/:id", element: <GoodWord /> }
 ];

--- a/docs/CUT_AND_GOODWORD.md
+++ b/docs/CUT_AND_GOODWORD.md
@@ -1,0 +1,20 @@
+# Cut Game & The Good Word
+
+## Build
+- `npm run emit:cut` → writes `game thingss/build/bundle_cut_game.json`
+- `npm run emit:good` → writes `game thingss/build/bundle_good_word.json`
+- `npm run emit:games` → both
+
+## Server
+- Cut Game:
+  - `GET /cut/catalog` → `{ games: string[] }`
+  - `GET /cut/game/:id` → one item
+- The Good Word:
+  - `GET /goodword/catalog` → `{ games: string[] }`
+  - `GET /goodword/game/:id` → one item
+
+## Frontend
+- Routes:
+  - `/cut/:id` → plays a Cut Game item
+  - `/goodword/:id` → plays a Good Word item
+- Adapter: `app/src/lib/gameAdapters/cutGood.js` normalizes items to the GameItem spec (MCQ/read).

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "prebuild": "node scripts/freeze-manifests.mjs",
     "build": "node scripts/vite-build.mjs",
     "build:pages": "node scripts/vite-build.mjs && node scripts/copy404.mjs",
-    "preview": "vite preview --port 4173"
+    "preview": "vite preview --port 4173",
+    "emit:cut": "node tools/build_cut_game.mjs",
+    "emit:good": "node tools/build_good_word.mjs",
+    "emit:games": "npm run emit:cut && npm run emit:good"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.14",

--- a/server/cutGood/index.js
+++ b/server/cutGood/index.js
@@ -1,0 +1,25 @@
+import fs from 'fs'
+import path from 'path'
+
+const ROOTS = ['game thingss', 'game things']
+const BASE = ROOTS.find(d => fs.existsSync(d)) || 'game thingss'
+const CUT_FILE  = path.resolve(BASE, 'build', 'bundle_cut_game.json')
+const GOOD_FILE = path.resolve(BASE, 'build', 'bundle_good_word.json')
+
+function safeRead(p, fallback = { items: [] }) {
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')) } catch { return fallback }
+}
+
+export function listCutIds() {
+  const b = safeRead(CUT_FILE); return (b.items || []).map(x => x.id)
+}
+export function getCutItem(id) {
+  const b = safeRead(CUT_FILE); return (b.items || []).find(x => x.id === id) || null
+}
+
+export function listGoodIds() {
+  const b = safeRead(GOOD_FILE); return (b.items || []).map(x => x.id)
+}
+export function getGoodItem(id) {
+  const b = safeRead(GOOD_FILE); return (b.items || []).find(x => x.id === id) || null
+}

--- a/server/index.js
+++ b/server/index.js
@@ -10,6 +10,7 @@ import path from 'path'
 import { evaluateAttempt } from './sigil-syntax/judgment.js'
 import { listWriterTypes, getWriterType, allWriterTypes } from './sigil-syntax/writerTypes.js'
 import { listReportTypes, getReportType, defaultReportType } from './sigil-syntax/reportTypes.js'
+import { listCutIds, getCutItem, listGoodIds, getGoodItem } from './cutGood/index.js'
 
 const app = express()
 app.use(express.json())
@@ -45,6 +46,22 @@ app.get('/catalog/game/:id', (req, res) => {
     const item = getItem(req.params.id)
     if (!item) return res.status(404).json({ error: 'not_found', id: req.params.id })
     res.json(item)
+})
+
+// Cut Game
+app.get('/cut/catalog', (req,res) => res.json({ games: listCutIds() }))
+app.get('/cut/game/:id', (req,res) => {
+    const it = getCutItem(req.params.id)
+    if (!it) return res.status(404).json({ error:'not_found', id:req.params.id })
+    res.json(it)
+})
+
+// The Good Word
+app.get('/goodword/catalog', (req,res) => res.json({ games: listGoodIds() }))
+app.get('/goodword/game/:id', (req,res) => {
+    const it = getGoodItem(req.params.id)
+    if (!it) return res.status(404).json({ error:'not_found', id:req.params.id })
+    res.json(it)
 })
 
 // Lessons endpoints

--- a/tools/build_cut_game.mjs
+++ b/tools/build_cut_game.mjs
@@ -1,0 +1,80 @@
+import fs from 'fs'
+import path from 'path'
+
+const ROOTS = ['game thingss', 'game things']
+const BASE = (() => {
+  for (const root of ROOTS) {
+    if (fs.existsSync(path.resolve(root, 'cut_games_items_index.csv'))) return root
+  }
+  return ROOTS.find(d => fs.existsSync(d)) || 'game thingss'
+})()
+const OUTDIR = path.resolve(BASE, 'build')
+fs.mkdirSync(OUTDIR, { recursive: true })
+
+const P_CSV = path.resolve(BASE, 'cut_games_items_index.csv')
+const P_BLUE = path.resolve(BASE, 'cut_games_game_blueprints.json')
+const P_BAD = path.resolve(BASE, 'cut_games_practice_bad.jsonl')
+const P_GOOD = path.resolve(BASE, 'cut_games_practice_good.jsonl')
+const OUT = path.join(OUTDIR, 'bundle_cut_game.json')
+
+function parseCSV(txt) {
+  const [head, ...rows] = txt.trim().split(/\r?\n/)
+  const cols = head.split(',').map(s=>s.trim())
+  return rows.map(line => {
+    const vals = line.split(',').map(s=>s.trim())
+    const obj = {}; cols.forEach((k,i)=>obj[k]=vals[i]); return obj
+  })
+}
+function parseJSONL(p) {
+  const out = []
+  const lines = fs.readFileSync(p,'utf8').split('\n')
+  for (let i=0;i<lines.length;i++){
+    const t = lines[i].trim(); if(!t) continue
+    try { out.push(JSON.parse(t)) } catch(e){ console.warn('jsonl error', p, i+1) }
+  }
+  return out
+}
+
+function main(){
+  const rawBlue = JSON.parse(fs.readFileSync(P_BLUE,'utf8'))
+  const blue = Array.isArray(rawBlue)
+    ? rawBlue
+    : (Array.isArray(rawBlue.blueprints) ? rawBlue.blueprints : (Array.isArray(rawBlue.modes) ? rawBlue.modes : []))
+  const indexRows = parseCSV(fs.readFileSync(P_CSV,'utf8')) // rows referencing items
+  const bad = parseJSONL(P_BAD)  // “bad” examples / distractors
+  const good = parseJSONL(P_GOOD) // “good” examples / references
+
+  // Normalize items to a common game spec (we’ll render MCQ for now)
+  const items = []
+  for (const row of indexRows) {
+    const id = String(row.id || row.item_id || items.length + 1)
+    const title = row.title || row.prompt || `Cut Item ${id}`
+    const blueprint = blue.find(b => (b.id === row.blueprint_id)) || null
+    const stem = row.stem || blueprint?.stem || title
+    const bads = bad.filter(x => (x.item_id || x.id) == id).map(x => x.text || x.choice || '').filter(Boolean)
+    const goods = good.filter(x => (x.item_id || x.id) == id).map(x => x.text || x.answer || '').filter(Boolean)
+
+    // Build an MCQ: one good (first), rest bads as distractors; shuffle later in UI if needed
+    const answer = goods[0] || row.answer || '—'
+    const choices = [answer, ...bads.slice(0,3)].filter(Boolean).slice(0,4)
+
+    items.push({
+      id: `cut:${id}`,
+      title: `Cut Game — ${title}`,
+      input_type: 'mcq',
+      prompt_html: `<p>${stem}</p>`,
+      choices,
+      correct_index: 0
+    })
+  }
+
+  const bundle = {
+    kind: 'cut_game',
+    version: 1,
+    count: items.length,
+    items
+  }
+  fs.writeFileSync(OUT, JSON.stringify(bundle,null,2), 'utf8')
+  console.log('✅ Wrote', OUT)
+}
+main()

--- a/tools/build_good_word.mjs
+++ b/tools/build_good_word.mjs
@@ -1,0 +1,65 @@
+import fs from 'fs'
+import path from 'path'
+
+const ROOTS = ['game thingss', 'game things']
+const BASE = (() => {
+  for (const root of ROOTS) {
+    if (fs.existsSync(path.resolve(root, 'the-good-word-core-AZ.json'))) return root
+  }
+  return ROOTS.find(d => fs.existsSync(d)) || 'game thingss'
+})()
+const OUTDIR = path.resolve(BASE, 'build')
+fs.mkdirSync(OUTDIR, { recursive: true })
+
+const PACKS = [
+  'the-good-word-core-AZ.json',
+  'the-good-word-pack-02-C-D.json',
+  'the-good-word-pack-03-uncommon-E-F.json',
+  'the-good-word-pack-04-uncommon-G-H.json',
+  'the-good-word-pack-05-uncommon-I-J.json',
+  'the-good-word-pack-06-uncommon-K-L.json',
+  'the-good-word-pack-07-uncommon-M-N.json',
+  'the-good-word-pack-08-uncommon-O-P.json',
+  'the-good-word-pack-09-uncommon-Q-R.json',
+  'the-good-word-pack-10-uncommon-S-T.json',
+  'the-good-word-pack-11-uncommon-U-Z.json'
+].map(f => path.resolve(BASE, f))
+const OUT = path.join(OUTDIR, 'bundle_good_word.json')
+
+function loadAll(){
+  const words = []
+  for (const p of PACKS) {
+    if (!fs.existsSync(p)) { console.warn('missing pack', p); continue }
+    try {
+      const obj = JSON.parse(fs.readFileSync(p,'utf8'))
+      // expect obj.words or array of {word, definition, distractors?[]}
+      const arr = Array.isArray(obj) ? obj : (obj.words || [])
+      for (const w of arr) {
+        const word = String(w.word || w.term || '').trim()
+        const def = String(w.definition || w.def || w.meaning || '').trim()
+        const distractors = (w.distractors || w.options || []).map(String)
+        if (word && def) words.push({ word, definition: def, distractors })
+      }
+    } catch(e){ console.warn('pack parse error', p) }
+  }
+  return words
+}
+
+function main(){
+  const words = loadAll()
+  const items = words.map((w, i) => {
+    const choices = [w.definition, ...w.distractors.slice(0,3)].filter(Boolean).slice(0,4)
+    return {
+      id: `good:${i+1}:${w.word}`,
+      title: `The Good Word — ${w.word}`,
+      input_type: 'mcq',
+      prompt_html: `<p>Choose the best definition for <strong>${w.word}</strong>.</p>`,
+      choices,
+      correct_index: 0
+    }
+  })
+  const bundle = { kind: 'good_word', version: 1, count: items.length, items }
+  fs.writeFileSync(OUT, JSON.stringify(bundle,null,2), 'utf8')
+  console.log('✅ Wrote', OUT)
+}
+main()


### PR DESCRIPTION
## Summary
- add Node build scripts that combine Cut Game and Good Word source files into JSON bundles and ignore the generated artifacts
- expose backend helpers and endpoints so the server can list and serve the new game items
- introduce a shared frontend adapter, dedicated routes, and docs for playing both game modes in the existing GameLayout/GameItem runner

## Testing
- npm run emit:games

------
https://chatgpt.com/codex/tasks/task_e_68eed38769e0832f84dee0c0ab8cd988