### PR TITLE
Integrate labeled data sources for Good Word and Sigil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,4 +164,5 @@ game thingss/build/bundle_cut_game.json
 game thingss/build/bundle_good_word.json
 game things/build/bundle_cut_game.json
 game things/build/bundle_good_word.json
+game things/build/sigil-syntax/bundle_sigil_syntax.json
 

--- a/app/src/lib/gameAdapters/sources.js
+++ b/app/src/lib/gameAdapters/sources.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import { api } from '@/lib/apiBase.js'
+
+export function adaptToSpec(it){
+  if (!it) return null
+  if (it.input_type === 'mcq') {
+    return {
+      mode:'mcq',
+      id: it.id,
+      title: it.title || '',
+      prompt: <div dangerouslySetInnerHTML={{__html: it.prompt_html || ''}} />,
+      choices: it.choices || [],
+      correctIndex: it.correct_index ?? 0
+    }
+  }
+  // default to write/read
+  return {
+    mode: it.input_type === 'write' ? 'write' : 'read',
+    id: it.id,
+    title: it.title || '',
+    prompt: <div dangerouslySetInnerHTML={{__html: it.prompt_html || ''}} />,
+    minWords: it.min_words ?? 30
+  }
+}
+
+// Good Word
+export async function fetchGoodItem(id){
+  const r = await fetch(api(`/goodword/game/${encodeURIComponent(id)}`))
+  if (!r.ok) throw new Error(String(r.status))
+  return adaptToSpec(await r.json())
+}
+export async function listGoodIds(){
+  const r = await fetch(api('/goodword/catalog')); const j = await r.json()
+  return j.games || []
+}
+
+// Sigil_&_Syntax
+export async function fetchSigilItem(id){
+  const r = await fetch(api(`/sigil/game/${encodeURIComponent(id)}`))
+  if (!r.ok) throw new Error(String(r.status))
+  return adaptToSpec(await r.json())
+}
+export async function firstSigilId(){
+  const r = await fetch(api('/sigil/catalog')); const j = await r.json()
+  return j.first || (j.games && j.games[0]) || null
+}
+

--- a/app/src/pages/GoodWord.jsx
+++ b/app/src/pages/GoodWord.jsx
@@ -1,23 +1,18 @@
 import { useEffect, useState } from 'react'
 import GameLayout from '@sigil/GameLayout'
 import GameItem from '@sigil/GameItem'
-import { fetchGoodItem } from '@/lib/gameAdapters/cutGood.js'
+import { fetchGoodItem } from '@/lib/gameAdapters/sources.js'
 import { useParams, useNavigate } from 'react-router-dom'
 
-export default function GoodWord() {
+export default function GoodWord(){
   const { id } = useParams()
   const nav = useNavigate()
   const [spec, setSpec] = useState(null)
   const [err, setErr] = useState('')
-
-  useEffect(() => {
-    setSpec(null); setErr('')
-    fetchGoodItem(id).then(setSpec).catch(e => setErr(String(e)))
-  }, [id])
-
+  useEffect(()=>{ setSpec(null); setErr(''); fetchGoodItem(id).then(setSpec).catch(e=>setErr(String(e))) }, [id])
   return (
     <GameLayout title="The Good Word" feedback={err && <span style={{color:'tomato'}}>{err}</span>} onPrev={()=>nav(-1)}>
-      {spec && <GameItem spec={spec} onResult={() => {}} />}
+      {spec && <GameItem spec={spec} />}
     </GameLayout>
   )
 }

--- a/app/src/pages/SigilSyntax.jsx
+++ b/app/src/pages/SigilSyntax.jsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react'
+import GameLayout from '@sigil/GameLayout'
+import GameItem from '@sigil/GameItem'
+import { useParams, useNavigate } from 'react-router-dom'
+import { fetchSigilItem, firstSigilId } from '@/lib/gameAdapters/sources.js'
+
+export default function SigilSyntax(){
+  const { id } = useParams()
+  const nav = useNavigate()
+  const [spec, setSpec] = useState(null)
+  const [err, setErr] = useState('')
+
+  // If no :id, jump to first lesson from tweetrunk_renumbered
+  useEffect(() => {
+    if (!id) firstSigilId().then(fid => { if (fid) nav(`/sigil/${encodeURIComponent(fid)}`, { replace:true }) })
+  }, [id, nav])
+
+  useEffect(()=>{ if(!id) return; setSpec(null); setErr(''); fetchSigilItem(id).then(setSpec).catch(e=>setErr(String(e))) }, [id])
+
+  return (
+    <GameLayout title="Sigil_&_Syntax" feedback={err && <span style={{color:'tomato'}}>{err}</span>} onPrev={()=>nav(-1)}>
+      {spec && <GameItem spec={spec} />}
+    </GameLayout>
+  )
+}
+

--- a/app/src/routes.jsx
+++ b/app/src/routes.jsx
@@ -6,6 +6,7 @@ import ResultsScreen from "./pages/ResultsScreen.jsx";
 import Health from "./pages/Health.jsx";
 import CutGame from "./pages/CutGame.jsx";
 import GoodWord from "./pages/GoodWord.jsx";
+import SigilSyntax from "./pages/SigilSyntax.jsx";
 
 export default [
     { path: "/", element: <Home /> },
@@ -14,5 +15,7 @@ export default [
     { path: "/results", element: <ResultsScreen /> },
     { path: "/health", element: <Health /> },
     { path: "/cut/:id", element: <CutGame /> },
-    { path: "/goodword/:id", element: <GoodWord /> }
+    { path: "/goodword/:id", element: <GoodWord /> },
+    { path: "/sigil", element: <SigilSyntax /> },
+    { path: "/sigil/:id", element: <SigilSyntax /> }
 ];

--- a/docs/DATA_SOURCES.md
+++ b/docs/DATA_SOURCES.md
@@ -1,0 +1,13 @@
+# Data sources
+
+## The Good Word
+
+* Reads every `the-good-word-*.json` under `labeled data/`.
+* Emits a normalized bundle at `game things/build/bundle_good_word.json`.
+
+## Sigil_&_Syntax
+
+* Composes write/read lessons from `labeled data/tweetrunk_renumbered/`, ordering files by their leading number (lowest first).
+* Outputs the combined lessons to `game things/build/sigil-syntax/bundle_sigil_syntax.json`.
+* If `game things/cut_games_items_index.csv` and `game things/cut_games_game_blueprints.json` both exist, the CSV data takes priority; the JSON is a fallback when CSV is missing.
+

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "preview": "vite preview --port 4173",
     "emit:cut": "node tools/build_cut_game.mjs",
     "emit:good": "node tools/build_good_word.mjs",
-    "emit:games": "npm run emit:cut && npm run emit:good"
+    "emit:games": "npm run emit:cut && npm run emit:good",
+    "emit:good:labeled": "node tools/build_good_word_from_labeled.mjs",
+    "emit:sigil:labeled": "node tools/build_sigil_from_labeled.mjs",
+    "emit:content": "npm run emit:good:labeled && npm run emit:sigil:labeled"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.14",

--- a/server/goodword/index.js
+++ b/server/goodword/index.js
@@ -1,0 +1,21 @@
+import fs from 'fs'
+import path from 'path'
+
+const GOOD = path.resolve('game things', 'build', 'bundle_good_word.json')
+
+function safe(p){
+  try {
+    return JSON.parse(fs.readFileSync(p,'utf8'))
+  } catch {
+    return { items:[] }
+  }
+}
+
+export function listGoodIds(){
+  return (safe(GOOD).items || []).map(x=>x.id)
+}
+
+export function getGoodItem(id){
+  return (safe(GOOD).items || []).find(x=>x.id === id) || null
+}
+

--- a/server/index.js
+++ b/server/index.js
@@ -13,7 +13,9 @@ import { evaluateAttempt } from './sigil-syntax/judgment.js'
 import { listWriterTypes, getWriterType, allWriterTypes } from './sigil-syntax/writerTypes.js'
 import { listReportTypes, getReportType, defaultReportType } from './sigil-syntax/reportTypes.js'
 import { analyzeText } from './sigil-syntax/styleReport.js'
-import { listCutIds, getCutItem, listGoodIds, getGoodItem } from './cutGood/index.js'
+import { listCutIds, getCutItem } from './cutGood/index.js'
+import { listGoodIds, getGoodItem } from './goodword/index.js'
+import { listSigilIds, getSigilItem, firstSigilId } from './sigil-syntax/content.js'
 
 const app = express()
 app.use(express.json())
@@ -63,6 +65,14 @@ app.get('/cut/game/:id', (req,res) => {
 app.get('/goodword/catalog', (req,res) => res.json({ games: listGoodIds() }))
 app.get('/goodword/game/:id', (req,res) => {
     const it = getGoodItem(req.params.id)
+    if (!it) return res.status(404).json({ error:'not_found', id:req.params.id })
+    res.json(it)
+})
+
+// Sigil_&_Syntax lessons
+app.get('/sigil/catalog', (req,res) => res.json({ games: listSigilIds(), first: firstSigilId() }))
+app.get('/sigil/game/:id', (req,res) => {
+    const it = getSigilItem(req.params.id)
     if (!it) return res.status(404).json({ error:'not_found', id:req.params.id })
     res.json(it)
 })

--- a/server/sigil-syntax/content.js
+++ b/server/sigil-syntax/content.js
@@ -1,0 +1,25 @@
+import fs from 'fs'
+import path from 'path'
+
+const SIGIL = path.resolve('game things', 'build', 'sigil-syntax', 'bundle_sigil_syntax.json')
+
+function safe(){
+  try {
+    return JSON.parse(fs.readFileSync(SIGIL,'utf8'))
+  } catch {
+    return { items:[], first:null }
+  }
+}
+
+export function listSigilIds(){
+  return (safe().items || []).map(x=>x.id)
+}
+
+export function getSigilItem(id){
+  return (safe().items || []).find(x=>x.id === id) || null
+}
+
+export function firstSigilId(){
+  return safe().first || null
+}
+

--- a/tools/build_good_word_from_labeled.mjs
+++ b/tools/build_good_word_from_labeled.mjs
@@ -1,0 +1,55 @@
+import fs from 'fs'
+import path from 'path'
+
+const LAB = 'labeled data'
+const OUTDIR = path.resolve('game things', 'build')
+fs.mkdirSync(OUTDIR, { recursive: true })
+
+// Gather every “the-good-word-*.json” under labeled data
+function listPacks(dir) {
+  if (!fs.existsSync(dir)) return []
+  const all = fs.readdirSync(dir).filter(f => f.endsWith('.json'))
+  return all
+    .filter(f => f.startsWith('the-good-word-')) // core + packs
+    .map(f => path.join(dir, f))
+}
+
+const PACKS = listPacks(LAB)
+const OUT = path.join(OUTDIR, 'bundle_good_word.json')
+
+function loadAll(packs){
+  const words = []
+  for (const p of packs) {
+    try {
+      const obj = JSON.parse(fs.readFileSync(p,'utf8'))
+      const arr = Array.isArray(obj) ? obj : (obj.words || [])
+      for (const w of arr) {
+        const word = String(w.word || w.term || '').trim()
+        const def = String(w.definition || w.def || w.meaning || '').trim()
+        const distractors = (w.distractors || w.options || []).map(String)
+        if (word && def) words.push({ word, definition: def, distractors })
+      }
+    } catch(e){ console.warn('pack parse error', p) }
+  }
+  return words
+}
+
+function main(){
+  const words = loadAll(PACKS)
+  const items = words.map((w, i) => {
+    const choices = [w.definition, ...w.distractors.slice(0,3)].filter(Boolean).slice(0,4)
+    return {
+      id: `good:${i+1}:${w.word}`,
+      title: `The Good Word — ${w.word}`,
+      input_type: 'mcq',
+      prompt_html: `<p>Choose the best definition for <strong>${w.word}</strong>.</p>`,
+      choices,
+      correct_index: 0
+    }
+  })
+  const bundle = { kind: 'good_word', version: 1, count: items.length, items }
+  fs.writeFileSync(OUT, JSON.stringify(bundle,null,2), 'utf8')
+  console.log('✅ Wrote', OUT)
+}
+main()
+

--- a/tools/build_sigil_from_labeled.mjs
+++ b/tools/build_sigil_from_labeled.mjs
@@ -1,0 +1,88 @@
+import fs from 'fs'
+import path from 'path'
+
+const GT = 'game things'
+const LAB = 'labeled data'
+const TWEET = path.join(LAB, 'tweetrunk_renumbered')
+const OUTDIR = path.resolve(GT, 'build', 'sigil-syntax')
+fs.mkdirSync(OUTDIR, { recursive: true })
+
+// Optional CSV/JSON “same data” reconciliation in game things/
+// We take CSV if present, else JSON; if both, prefer CSV.
+function readMaybe(p){ try { return fs.readFileSync(p,'utf8') } catch { return null } }
+function parseCSV(txt){
+  if (!txt) return []
+  const [head, ...rows] = txt.trim().split(/\r?\n/)
+  const cols = head.split(',').map(s=>s.trim())
+  return rows.map(line => {
+    const vals = line.split(',').map(s=>s.trim())
+    const o = {}; cols.forEach((k,i)=>o[k]=vals[i]); return o
+  })
+}
+
+// Load lessons from tweetrunk_renumbered: sort numerically by leading digits
+function listTweetLessons(dir){
+  if (!fs.existsSync(dir)) return []
+  const files = fs.readdirSync(dir).filter(f => /\.(jsonl|json)$/i.test(f))
+  const withOrder = files.map(f => {
+    const m = f.match(/^(\d+)/); const n = m ? parseInt(m[1],10) : Number.MAX_SAFE_INTEGER
+    return { f, n }
+  }).sort((a,b)=>a.n - b.n)
+  return withOrder.map(x => path.join(dir, x.f))
+}
+
+function readJSONL(p) {
+  const items = []
+  const lines = readMaybe(p)?.split('\n') || []
+  for (let i=0;i<lines.length;i++){
+    const t = lines[i].trim(); if (!t) continue
+    try { items.push(JSON.parse(t)) } catch { /* skip */ }
+  }
+  return items
+}
+
+function normalizeWriteItem(obj, idx){
+  // Expect an object with at least prompt or text; fallback sane defaults
+  const id = obj.id || `w:${idx+1}`
+  const prompt = obj.prompt_html || obj.prompt || obj.text || ''
+  const minWords = Number(obj.min_words ?? 30)
+  return {
+    id: `sigil:${id}`,
+    title: obj.title || `Sigil_&_Syntax — Lesson ${idx+1}`,
+    input_type: obj.input_type || 'write',
+    prompt_html: typeof prompt === 'string' ? prompt : String(prompt),
+    min_words: minWords
+  }
+}
+
+function main(){
+  // 1) Optional index data from game things/ if you need it later (csv/json parity)
+  const csv = readMaybe(path.join(GT,'cut_games_items_index.csv'))
+  const json = readMaybe(path.join(GT,'cut_games_game_blueprints.json'))
+  const indexRows = csv ? parseCSV(csv) : (json ? JSON.parse(json) : [])
+
+  // 2) Lessons from tweetrunk_renumbered
+  const lessonFiles = listTweetLessons(TWEET)
+  let items = []
+  let order = 1
+  for (const p of lessonFiles) {
+    if (p.endsWith('.jsonl')) {
+      const arr = readJSONL(p).map((o, i) => normalizeWriteItem(o, items.length + i))
+      items.push(...arr)
+    } else {
+      try {
+        const obj = JSON.parse(fs.readFileSync(p,'utf8'))
+        const arr = Array.isArray(obj) ? obj : (obj.items || obj.lessons || [obj])
+        items.push(...arr.map((o,i)=>normalizeWriteItem(o, items.length + i)))
+      } catch { /* skip bad file */ }
+    }
+    order++
+  }
+
+  // ensure first served lesson is first item (lowest number already first)
+  const bundle = { kind: 'sigil-syntax', version: 1, count: items.length, first: items[0]?.id, items }
+  fs.writeFileSync(path.join(OUTDIR, 'bundle_sigil_syntax.json'), JSON.stringify(bundle,null,2), 'utf8')
+  console.log('✅ Wrote', path.join(OUTDIR, 'bundle_sigil_syntax.json'))
+}
+main()
+


### PR DESCRIPTION
## Summary
- add build scripts that bundle The Good Word content from the labeled data folder and Sigil_&_Syntax lessons from tweetrunk_renumbered
- expose new backend loaders and routes that serve the generated bundles for Good Word and Sigil_&_Syntax
- wire frontend adapters, pages, and routes to fetch the new endpoints and document the data sources

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eedf144c4c832f8886c89a3b64b1ce