### PR TITLE
Prefer new sigil content paths and refresh Literary Deviousness UI

### DIFF
--- a/app/src/main.jsx
+++ b/app/src/main.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import routes from "./routes.jsx";
+import "@/styles/links.css";
 
 const router = createBrowserRouter(routes, {
   basename: import.meta.env.BASE_URL

--- a/app/src/pages/GameStart.jsx
+++ b/app/src/pages/GameStart.jsx
@@ -2,25 +2,53 @@ import { Link } from 'react-router-dom'
 import SceneShell from '../components/SceneShell.jsx'
 
 export default function GameStart() {
+    const entries = [
+        {
+            key: 'grammar',
+            node: (
+                <Link className="link-white" to="/game/lesson/grammar-101">
+                    New Game → Grammar 101
+                </Link>
+            )
+        },
+        {
+            key: 'devices',
+            node: (
+                <Link className="link-white" to="/game/lesson/devices-101">
+                    New Game → Literary Devices 101
+                </Link>
+            )
+        },
+        {
+            key: 'continue',
+            node: (
+                <a
+                    className="link-white"
+                    href="#"
+                    onClick={e => {
+                        e.preventDefault()
+                        alert('Continue: no saves yet.')
+                    }}
+                >
+                    Continue (coming soon)
+                </a>
+            )
+        }
+    ]
+
     return (
-        <SceneShell title="Start">
+        <SceneShell title="Literary Deviousness">
             <p style={{ marginTop: 0 }}>
                 Choose a starting lane. You can jump around later.
             </p>
 
-            <ul style={{ paddingLeft: '1.2rem', lineHeight: 1.6 }}>
-                <li>
-                    <Link className="start-link" to="/game/lesson/grammar-101">New Game → Grammar 101</Link>
-                </li>
-                <li style={{ marginTop: '.75rem' }}>
-                    <Link className="start-link" to="/game/lesson/devices-101">New Game → Literary Devices 101</Link>
-                </li>
-                <li style={{ marginTop: '.75rem' }}>
-                    <a className="start-link" href="#" onClick={e => { e.preventDefault(); alert('Continue: no saves yet.'); }}>
-                        Continue (coming soon)
-                    </a>
-                </li>
-            </ul>
+            <div className="games-grid">
+                {entries.map(entry => (
+                    <div key={entry.key} className="game-tile">
+                        {entry.node}
+                    </div>
+                ))}
+            </div>
         </SceneShell>
     )
 }

--- a/app/src/pages/Home.jsx
+++ b/app/src/pages/Home.jsx
@@ -49,8 +49,8 @@ export default function Home() {
                     Fiction Writing School for Broke Mutherfuckers.
                 </p>
 
-                <Link className="tile" to="/game">
-                    ▶︎ Play the game
+                <Link className="tile link-white" to="/sigil">
+                    Literary Deviousness
                 </Link>
             </main>
         </div>

--- a/app/src/styles/links.css
+++ b/app/src/styles/links.css
@@ -1,0 +1,40 @@
+/* Global white links for game entry points */
+.link-white,
+.link-white:visited {
+  color: #ffffff;
+  text-decoration: none;
+}
+.link-white:hover,
+.link-white:focus {
+  color: #ffffff;
+  text-decoration: underline;
+}
+
+/* Tile layout for games page */
+.games-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  align-items: stretch;
+}
+
+.game-tile {
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  border: 2px solid #000;
+  border-radius: 14px;
+  padding: 14px;
+  text-align: center;
+  box-shadow: 0 8px 14px rgba(0, 0, 0, 0.25);
+}
+.game-tile a,
+.game-tile a:visited {
+  color: #fff;
+  font-weight: 800;
+  letter-spacing: 0.3px;
+}
+
+/* Optional polish */
+.link-white:hover {
+  filter: brightness(1.1);
+}

--- a/server/sigil-syntax/content.js
+++ b/server/sigil-syntax/content.js
@@ -1,7 +1,19 @@
 import fs from 'fs'
 import path from 'path'
 
-const SIGIL = path.resolve('game things', 'build', 'sigil-syntax', 'bundle_sigil_syntax.json')
+// NOTE: prefers `game things/...`; falls back to legacy `game thingss/...`.
+
+function firstExisting(...paths) {
+  for (const p of paths) {
+    if (fs.existsSync(p)) return p
+  }
+  return paths[0]
+}
+
+const SIGIL = firstExisting(
+  path.resolve('game things', 'build', 'sigil-syntax', 'bundle_sigil_syntax.json'),
+  path.resolve('game thingss', 'build', 'sigil-syntax', 'bundle_sigil_syntax.json')
+)
 
 function safe(){
   try {

--- a/server/sigil-syntax/influences.js
+++ b/server/sigil-syntax/influences.js
@@ -1,7 +1,19 @@
 import fs from 'fs'
 import path from 'path'
 
-const FILE = path.resolve('game thingss', 'sigil-syntax', 'influences.json')
+// NOTE: prefers `game things/...`; falls back to legacy `game thingss/...`.
+
+function firstExisting(...paths) {
+    for (const p of paths) {
+        if (fs.existsSync(p)) return p
+    }
+    return paths[0]
+}
+
+const FILE = firstExisting(
+    path.resolve('game things', 'sigil-syntax', 'influences.json'),
+    path.resolve('game thingss', 'sigil-syntax', 'influences.json')
+)
 
 export function readInfluences() {
     try {

--- a/server/sigil-syntax/progression.js
+++ b/server/sigil-syntax/progression.js
@@ -1,12 +1,27 @@
 import fs from 'fs'
 import path from 'path'
 
+// NOTE: prefers `game things/...`; falls back to legacy `game thingss/...`.
+
+function firstExisting(...paths) {
+    for (const p of paths) {
+        if (fs.existsSync(p)) return p
+    }
+    return paths[0]
+}
+
 function readJsonOrNull(p) {
     try { return JSON.parse(fs.readFileSync(p, 'utf8')) } catch { return null }
 }
 
-const L_JSON = path.resolve('game thingss', 'sigil-syntax', 'levels.json')
-const B_JSON = path.resolve('game thingss', 'sigil-syntax', 'badges.json')
+const L_JSON = firstExisting(
+    path.resolve('game things', 'sigil-syntax', 'levels.json'),
+    path.resolve('game thingss', 'sigil-syntax', 'levels.json')
+)
+const B_JSON = firstExisting(
+    path.resolve('game things', 'sigil-syntax', 'badges.json'),
+    path.resolve('game thingss', 'sigil-syntax', 'badges.json')
+)
 
 let LEVELS = readJsonOrNull(L_JSON)
 let BADGES = readJsonOrNull(B_JSON)

--- a/server/sigil-syntax/reportPhrases.js
+++ b/server/sigil-syntax/reportPhrases.js
@@ -1,7 +1,19 @@
 import fs from 'fs'
 import path from 'path'
 
-const FILE = path.resolve('game thingss', 'sigil-syntax', 'reportPhrases.json')
+// NOTE: prefers `game things/...`; falls back to legacy `game thingss/...`.
+
+function firstExisting(...paths) {
+    for (const p of paths) {
+        if (fs.existsSync(p)) return p
+    }
+    return paths[0]
+}
+
+const FILE = firstExisting(
+    path.resolve('game things', 'sigil-syntax', 'reportPhrases.json'),
+    path.resolve('game thingss', 'sigil-syntax', 'reportPhrases.json')
+)
 
 const FALLBACK = {
     closers: {

--- a/server/sigil-syntax/reportTypes.js
+++ b/server/sigil-syntax/reportTypes.js
@@ -1,6 +1,19 @@
 import fs from 'fs'
 import path from 'path'
-const FILE = path.resolve('game thingss', 'sigil-syntax', 'reportTypes.json')
+
+// NOTE: prefers `game things/...`; falls back to legacy `game thingss/...`.
+
+function firstExisting(...paths) {
+    for (const p of paths) {
+        if (fs.existsSync(p)) return p
+    }
+    return paths[0]
+}
+
+const FILE = firstExisting(
+    path.resolve('game things', 'sigil-syntax', 'reportTypes.json'),
+    path.resolve('game thingss', 'sigil-syntax', 'reportTypes.json')
+)
 
 function readBundle() {
     try { return JSON.parse(fs.readFileSync(FILE, 'utf8')) } catch { return { version: 0, reportTypes: [] } }

--- a/server/sigil-syntax/writerTypes.js
+++ b/server/sigil-syntax/writerTypes.js
@@ -1,6 +1,19 @@
 import fs from 'fs'
 import path from 'path'
-const FILE = path.resolve('game thingss', 'sigil-syntax', 'writer_types.json')
+
+// NOTE: prefers `game things/...`; falls back to legacy `game thingss/...`.
+
+function firstExisting(...paths) {
+    for (const p of paths) {
+        if (fs.existsSync(p)) return p
+    }
+    return paths[0]
+}
+
+const FILE = firstExisting(
+    path.resolve('game things', 'sigil-syntax', 'writer_types.json'),
+    path.resolve('game thingss', 'sigil-syntax', 'writer_types.json')
+)
 function safeRead() {
     try { return JSON.parse(fs.readFileSync(FILE, 'utf8')) } catch { return { version: 0, items: [] } }
 }

--- a/tools/emit_influences.mjs
+++ b/tools/emit_influences.mjs
@@ -1,13 +1,13 @@
 // Converts a TypeScript influence catalog to JSON for the backend.
 // Default input: app/src/ai/sigil-syntax/influenceCatalog.ts
-// Output: game thingss/sigil-syntax/influences.json
+// Output: game things/sigil-syntax/influences.json
 
 import fs from 'fs'
 import path from 'path'
 
 const INPUT =
   process.env.INFLUENCES_TS || path.resolve('app/src/ai/sigil-syntax/influenceCatalog.ts')
-const OUT_DIR = path.resolve('game thingss', 'sigil-syntax')
+const OUT_DIR = path.resolve('game things', 'sigil-syntax')
 const OUT_FILE = path.join(OUT_DIR, 'influences.json')
 
 function readFileSafe(p) {

--- a/tools/emit_progression.mjs
+++ b/tools/emit_progression.mjs
@@ -34,7 +34,7 @@ const badgesPath =
 const levels = parseTSFile(levelsPath, 'levels.ts')
 const badges = parseTSFile(badgesPath, 'badges.ts')
 
-const outDir = path.resolve('game thingss', 'sigil-syntax')
+const outDir = path.resolve('game things', 'sigil-syntax')
 if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true })
 
 if (levels) {

--- a/tools/emit_report_phrases.mjs
+++ b/tools/emit_report_phrases.mjs
@@ -1,13 +1,13 @@
 // Convert a TS phrases file to JSON for the backend.
 // Input (default): app/src/ai/sigil-syntax/reportPhrases.ts
-// Output: game thingss/sigil-syntax/reportPhrases.json
+// Output: game things/sigil-syntax/reportPhrases.json
 
 import fs from 'fs'
 import path from 'path'
 
 const INPUT =
   process.env.PHRASES_TS || path.resolve('app/src/ai/sigil-syntax/reportPhrases.ts')
-const OUT_DIR = path.resolve('game thingss', 'sigil-syntax')
+const OUT_DIR = path.resolve('game things', 'sigil-syntax')
 const OUT_FILE = path.join(OUT_DIR, 'reportPhrases.json')
 
 function read(p) {

--- a/tools/emit_report_types.mjs
+++ b/tools/emit_report_types.mjs
@@ -1,12 +1,12 @@
 // Input (default): app/src/ai/sigil-syntax/reportTypes.ts
-// Output: game thingss/sigil-syntax/reportTypes.json
+// Output: game things/sigil-syntax/reportTypes.json
 
 import fs from 'fs'
 import path from 'path'
 
 const INPUT =
   process.env.REPORT_TYPES_TS || path.resolve('app/src/ai/sigil-syntax/reportTypes.ts')
-const OUTDIR = path.resolve('game thingss', 'sigil-syntax')
+const OUTDIR = path.resolve('game things', 'sigil-syntax')
 const OUT = path.join(OUTDIR, 'reportTypes.json')
 
 function read(p) {

--- a/tools/emit_writer_types.mjs
+++ b/tools/emit_writer_types.mjs
@@ -1,4 +1,4 @@
-// Read writer_type_custom_elements.jsonl → emit game thingss/sigil-syntax/writer_types.json
+// Read writer_type_custom_elements.jsonl → emit game things/sigil-syntax/writer_types.json
 
 import fs from 'fs'
 import path from 'path'
@@ -6,7 +6,7 @@ import path from 'path'
 const INPUT =
   process.env.WRITER_TYPES_JSONL ||
   path.resolve('game thingss', 'writer_type_custom_elements.jsonl')
-const OUTDIR = path.resolve('game thingss', 'sigil-syntax')
+const OUTDIR = path.resolve('game things', 'sigil-syntax')
 const OUT = path.join(OUTDIR, 'writer_types.json')
 
 function readLines(p) {


### PR DESCRIPTION
## Summary
- move the remaining sigil-syntax placeholder into `game things/sigil-syntax/` and teach the loaders to prefer the new directory while falling back to `game thingss/`
- update the emit scripts so they now write sigil artifacts into `game things/sigil-syntax/`
- add a global white-link style, retheme the home and game selection links, and lay the Literary Deviousness tiles out in a grid

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eee924fd5c832fb4c3f04bf1bd110e