### PR TITLE
Add safe JSON fetching and configure dev proxy

### DIFF
--- a/app/src/components/BackendHealth.jsx
+++ b/app/src/components/BackendHealth.jsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { api, safeFetchJSON } from '@/lib/apiBase.js'
+
+function useInterval(fn, ms) {
+  const ref = useRef(fn)
+  useEffect(() => { ref.current = fn }, [fn])
+  useEffect(() => {
+    const id = setInterval(() => ref.current(), ms)
+    return () => clearInterval(id)
+  }, [ms])
+}
+
+export default function BackendHealth({ className = '', intervalMs = 10000 }) {
+  const [status, setStatus] = useState({ ok: false, msg: 'Checking…', ts: null })
+
+  const backendBase = useMemo(() => {
+    const isDev = import.meta.env.DEV
+    const prod = (import.meta.env.VITE_PROD_API || '').replace(/\/+$/, '')
+    return isDev ? '(dev proxy)' : (prod || '(no VITE_PROD_API)')
+  }, [])
+
+  async function check() {
+    try {
+      const j = await safeFetchJSON(api('/health'))
+      setStatus({ ok: !!j?.ok, msg: j?.ok ? 'OK' : 'Not OK', ts: j?.ts || new Date().toISOString() })
+    } catch (e) {
+      setStatus({ ok: false, msg: String(e.message || e), ts: new Date().toISOString() })
+    }
+  }
+
+  useEffect(() => { check() }, [])
+  useInterval(check, intervalMs)
+
+  const good = status.ok
+  return (
+    <div
+      className={className}
+      style={{
+        position: 'fixed',
+        bottom: 8,
+        right: 8,
+        zIndex: 9999,
+        background: good ? '#0f0' : '#f33',
+        color: '#000',
+        border: '2px solid #000',
+        borderRadius: 10,
+        padding: '6px 10px',
+        fontSize: 12,
+        maxWidth: 420
+      }}
+      aria-live="polite"
+      title={`Backend: ${backendBase}`}
+    >
+      <strong>Backend:</strong> {good ? 'Healthy' : 'Unavailable'}
+      <span style={{ marginLeft: 6, opacity: 0.8 }}>@ {backendBase}</span>
+      <div
+        style={{
+          marginTop: 4,
+          fontFamily: 'monospace',
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis'
+        }}
+      >
+        {status.msg}
+      </div>
+    </div>
+  )
+}

--- a/app/src/lib/apiBase.js
+++ b/app/src/lib/apiBase.js
@@ -1,20 +1,27 @@
-const PROD = (import.meta.env.VITE_PROD_API || '').toString().trim()
-const DEV_BASE = (import.meta.env.VITE_API_BASE || '').toString().trim()
-
-function normalizeBase(base) {
-  return base.replace(/\/+$/, '')
-}
-
-export function api(pathname = '') {
-  const path = pathname.startsWith('/') ? pathname : `/${pathname}`
-  if (PROD && /^https?:\/\//i.test(PROD)) {
-    return `${normalizeBase(PROD)}${path}`
-  }
-  const base = DEV_BASE ? normalizeBase(DEV_BASE) : ''
+// app/src/lib/apiBase.js
+// In dev: use same-origin (Vite proxy handles /api paths to backend).
+// In prod: use VITE_PROD_API.
+const PROD = import.meta.env.VITE_PROD_API || ''
+export const api = (p = '') => {
+  const base = (import.meta.env.DEV ? '' : PROD).replace(/\/+$/,'')
+  const path = p.startsWith('/') ? p : `/${p}`
   return `${base}${path}`
 }
 
-export function apiBase() {
-  if (PROD && /^https?:\/\//i.test(PROD)) return normalizeBase(PROD)
-  return DEV_BASE ? normalizeBase(DEV_BASE) : ''
+/**
+ * Fetch JSON and detect accidental HTML (e.g., 404 index.html).
+ * Throws with a helpful message if content-type is HTML.
+ */
+export async function safeFetchJSON(url, init) {
+  const res = await fetch(url, init)
+  const ct = res.headers.get('content-type') || ''
+  if (!res.ok) {
+    const body = ct.includes('html') ? await res.text() : ''
+    throw new Error(`HTTP ${res.status} for ${url}${ct.includes('html') ? ' (HTML received)' : ''}${body ? ' :: ' + body.slice(0,120) : ''}`)
+  }
+  if (ct.includes('html')) {
+    const body = await res.text()
+    throw new Error(`Expected JSON from ${url}, but got HTML (likely a 404 or SPA index). First bytes: ${body.slice(0,120)}`)
+  }
+  return res.json()
 }

--- a/app/src/lib/apiBase.js
+++ b/app/src/lib/apiBase.js
@@ -1,17 +1,10 @@
-// app/src/lib/apiBase.js
-// In dev: use same-origin (Vite proxy handles /api paths to backend).
-// In prod: use VITE_PROD_API.
 const PROD = import.meta.env.VITE_PROD_API || ''
 export const api = (p = '') => {
-  const base = (import.meta.env.DEV ? '' : PROD).replace(/\/+$/,'')
+  const base = (import.meta.env.DEV ? '' : PROD).replace(/\/+$/, '')
   const path = p.startsWith('/') ? p : `/${p}`
   return `${base}${path}`
 }
 
-/**
- * Fetch JSON and detect accidental HTML (e.g., 404 index.html).
- * Throws with a helpful message if content-type is HTML.
- */
 export async function safeFetchJSON(url, init) {
   const res = await fetch(url, init)
   const ct = res.headers.get('content-type') || ''

--- a/app/src/lib/gameAdapters/sources.js
+++ b/app/src/lib/gameAdapters/sources.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { api } from '@/lib/apiBase.js'
+import { api, safeFetchJSON } from '@/lib/apiBase.js'
 
 export function adaptToSpec(it){
   if (!it) return null
@@ -25,23 +25,21 @@ export function adaptToSpec(it){
 
 // Good Word
 export async function fetchGoodItem(id){
-  const r = await fetch(api(`/goodword/game/${encodeURIComponent(id)}`))
-  if (!r.ok) throw new Error(String(r.status))
-  return adaptToSpec(await r.json())
+  const j = await safeFetchJSON(api(`/goodword/game/${encodeURIComponent(id)}`))
+  return adaptToSpec(j)
 }
 export async function listGoodIds(){
-  const r = await fetch(api('/goodword/catalog')); const j = await r.json()
+  const j = await safeFetchJSON(api('/goodword/catalog'))
   return j.games || []
 }
 
 // Sigil_&_Syntax
 export async function fetchSigilItem(id){
-  const r = await fetch(api(`/sigil/game/${encodeURIComponent(id)}`))
-  if (!r.ok) throw new Error(String(r.status))
-  return adaptToSpec(await r.json())
+  const j = await safeFetchJSON(api(`/sigil/game/${encodeURIComponent(id)}`))
+  return adaptToSpec(j)
 }
 export async function firstSigilId(){
-  const r = await fetch(api('/sigil/catalog')); const j = await r.json()
+  const j = await safeFetchJSON(api('/sigil/catalog'))
   return j.first || (j.games && j.games[0]) || null
 }
 

--- a/app/src/pages/Home.jsx
+++ b/app/src/pages/Home.jsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
 import '@/styles/links.css'
+import BackendHealth from '@/components/BackendHealth.jsx'
 
 export default function Home() {
   return (
@@ -20,6 +21,8 @@ export default function Home() {
         <p>Do you not know shit about writing or you suck at it? Me too. I made these games to learn grammar, character, narrative structure, and of course — the literary devices. You write, you read, you get feedback. It’s a lot like an interactive textbook on creative writing. If you know how to write already you will probably get bored. Thanks for playing.</p>
         <p><Link className="link-white" to="/sigil">Start →</Link></p>
       </section>
+
+      <BackendHealth />
     </main>
   )
 }

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 import path from 'path'
 
 const REPO = process.env.GHPAGES_REPO || 'projects-from-the-projects'
+const BACKEND = process.env.VITE_DEV_API || 'http://localhost:3001' // or your Codespace port-forward URL
 
 export default defineConfig({
   plugins: [react()],
@@ -12,5 +13,15 @@ export default defineConfig({
       '@sigil': path.resolve(__dirname, 'src/sigil-syntax')
     }
   },
-  base: process.env.GHPAGES_BASE || `/${REPO}/`
+  base: process.env.GHPAGES_BASE || `/${REPO}/`,
+  server: {
+    proxy: {
+      // gameplay + content endpoints
+      '^/(sigil|goodword|catalog|bundle|report-types|writer-types|api)/.*': {
+        target: BACKEND,
+        changeOrigin: true,
+        secure: false
+      }
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- add a shared API helper that normalizes base URLs and guards against HTML responses
- update the game adapters to use the new helper for all backend fetches
- configure the Vite dev server to proxy gameplay and API routes to the backend during development

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ef017a9748832f99861de574bd96be