### PR TITLE
Disable foundations loader and add resilient Sigil progression defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,14 +6,10 @@
     "dev:app": "npm run dev --prefix app",
     "build:app": "npm run build --prefix app",
     "preview:app": "npm run preview --prefix app",
-
     "dev:server": "node server/index.js",
     "start:server": "node server/index.js",
     "start": "npm run dev:server & npm run dev:app",
-
-    "dev:server": "node server/index.js",
-    "start:server": "node server/index.js",
-    "start": "npm run dev:server & npm run dev:app",
+    "emit:progression": "node tools/emit_progression_defaults.mjs",
     "emit:sigil:labeled": "node tools/build_sigil_from_labeled.mjs"
   },
   "devDependencies": {

--- a/server/index.js
+++ b/server/index.js
@@ -215,7 +215,9 @@ app.get('/bundle/info', (req, res) => {
 })
 
 // --- For /api/next, /api/submit, /api/progress, use bundle lessons/items ---
-const { lessons, items } = loadFoundations() // use bundle for lessons/items
+// foundations disabled (Sigil_&_Syntax uses bundle from tweetrunk)
+const lessons = []
+const items = []
 
 // mastery rollup per skill (for the Progress panel)
 app.get('/api/mastery', (req, res) => {

--- a/server/sigil-syntax/progression.js
+++ b/server/sigil-syntax/progression.js
@@ -1,73 +1,129 @@
 import fs from 'fs'
 import path from 'path'
 
-// NOTE: prefers `game things/...`; falls back to legacy `game thingss/...`.
-
 function firstExisting(...paths) {
     for (const p of paths) {
         if (fs.existsSync(p)) return p
     }
-    return paths[0]
+    return null
 }
 
-function readJsonOrNull(p) {
-    try { return JSON.parse(fs.readFileSync(p, 'utf8')) } catch { return null }
-}
-
-const L_JSON = firstExisting(
+const LEVELS_JSON = firstExisting(
     path.resolve('game things', 'sigil-syntax', 'levels.json'),
     path.resolve('game thingss', 'sigil-syntax', 'levels.json')
 )
-const B_JSON = firstExisting(
+const BADGES_JSON = firstExisting(
     path.resolve('game things', 'sigil-syntax', 'badges.json'),
     path.resolve('game thingss', 'sigil-syntax', 'badges.json')
 )
 
-let LEVELS = readJsonOrNull(L_JSON)
-let BADGES = readJsonOrNull(B_JSON)
+const DEFAULT_LEVELS = [
+    { id: 1, code: 'rookie', title: 'Rookie', xp_threshold: 0, perk: 'Begin your Sigil_&_Syntax journey.' },
+    { id: 2, code: 'novice', title: 'Novice', xp_threshold: 100, perk: 'Unlocks basic practice sets.' },
+    { id: 3, code: 'apprentice', title: 'Apprentice', xp_threshold: 250, perk: 'Grants access to intermediate drills.' },
+    { id: 4, code: 'journeyman', title: 'Journeyman', xp_threshold: 500, perk: 'Opens advanced gauntlets.' },
+    { id: 5, code: 'adept', title: 'Adept', xp_threshold: 800, perk: 'Marks you as a Sigil mentor.' }
+]
+const DEFAULT_BADGES = [
+    { id: 'first_write', title: 'First Draft Down', desc: 'Submit your first write.', criteria: { type: 'attempt_count', count: 1 } },
+    { id: 'three_reads', title: 'Close Reader', desc: 'Complete 3 read tasks.', criteria: { type: 'attempt_count', count: 3 } },
+    { id: 'mcq_streak_5', title: 'On a Roll', desc: '5 MCQs correct in a row.', criteria: { type: 'first_try_high_score' } }
+]
 
-function sanitizeTS(tsText) {
-    return tsText
-        .replace(/^import.*$/gm, '')
-        .replace(/^export\s+type.*$/gm, '')
-        .replace(/^export\s+default\s*/gm, '')
-        .replace(/^export\s+const\s+\w+\s*=\s*/gm, '')
-        .replace(/\s+as\s+const\s*;?/g, '')
-        .replace(/;$/gm, '')
-        .trim()
-}
-
-function parseTSFile(tsPath, name) {
+function safeJSON(p, fallback, what) {
+    if (!p) {
+        console.warn(`[progression] ${what}.json missing → using defaults`)
+        return fallback
+    }
     try {
-        const raw = fs.readFileSync(tsPath, 'utf8')
-        const sanitized = sanitizeTS(raw)
-        return JSON.parse(sanitized)
+        const raw = fs.readFileSync(p, 'utf8')
+        const parsed = JSON.parse(raw)
+        if (Array.isArray(parsed)) return parsed
+        if (Array.isArray(parsed?.levels)) return parsed.levels
+        if (Array.isArray(parsed?.badges)) return parsed.badges
+        console.warn(`[progression] ${what}.json (${p}) missing expected array → using defaults`)
+        return fallback
     } catch (e) {
-        console.warn(`[progression] Failed to parse ${name}: ${e.message}`)
-        return []
+        console.warn(`[progression] Failed to parse ${what}.json (${p}): ${e.message} → using defaults`)
+        return fallback
     }
 }
 
-if (!LEVELS) {
-    console.warn('[progression] levels.json missing, trying to read TypeScript source. Run: npm run emit:progression')
-    LEVELS = parseTSFile(path.resolve('app/src/ai/sigil-syntax/levels.ts'), 'levels.ts')
+function normalizeLevel(row, idx) {
+    const id = Number.isFinite(row?.id) ? row.id : idx + 1
+    const title = typeof row?.title === 'string' && row.title.trim() ? row.title.trim() : (typeof row?.name === 'string' && row.name.trim() ? row.name.trim() : `Level ${id}`)
+    const code = typeof row?.code === 'string' && row.code.trim()
+        ? row.code.trim()
+        : title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || `level-${id}`
+    const xp_threshold_raw = row?.xp_threshold ?? row?.threshold ?? row?.xp ?? 0
+    const xp_threshold = Number.isFinite(xp_threshold_raw) ? xp_threshold_raw : parseInt(xp_threshold_raw, 10)
+    const perk = typeof row?.perk === 'string' && row.perk.trim() ? row.perk.trim() : (typeof row?.rule === 'string' ? row.rule : '')
+    return {
+        id,
+        code,
+        title,
+        xp_threshold: Number.isFinite(xp_threshold) ? xp_threshold : 0,
+        perk
+    }
 }
-if (!BADGES) {
-    console.warn('[progression] badges.json missing, trying to read TypeScript source. Run: npm run emit:progression')
-    BADGES = parseTSFile(path.resolve('app/src/ai/sigil-syntax/badges.ts'), 'badges.ts')
+
+function normalizeCriteria(criteria) {
+    if (!criteria || typeof criteria !== 'object') return { type: 'attempt_count', count: 1 }
+    switch (criteria.type) {
+        case 'attempt_count':
+        case 'daily_streak':
+        case 'mastery_count':
+        case 'family_presence_in_session':
+        case 'solid_in_family':
+        case 'time_bonus_count':
+            return { ...criteria, count: Number.isFinite(criteria.count) ? criteria.count : parseInt(criteria.count, 10) || 0 }
+        case 'solid_combo':
+            return { type: 'solid_combo', beats: Array.isArray(criteria.beats) ? criteria.beats : [] }
+        case 'first_try_high_score':
+        case 'no_hint_run':
+            return { type: criteria.type }
+        default:
+            return { type: 'attempt_count', count: 1 }
+    }
 }
+
+function normalizeBadge(row, idx) {
+    const id = typeof row?.id === 'string' && row.id.trim() ? row.id.trim() : (typeof row?.key === 'string' && row.key.trim() ? row.key.trim() : `badge-${idx + 1}`)
+    const title = typeof row?.title === 'string' && row.title.trim() ? row.title.trim() : (typeof row?.label === 'string' ? row.label : `Badge ${idx + 1}`)
+    const desc = typeof row?.desc === 'string' && row.desc.trim() ? row.desc.trim() : (typeof row?.rule === 'string' ? row.rule : '')
+    const xpBonusRaw = row?.xp_bonus ?? row?.bonus
+    const xp_bonus = Number.isFinite(xpBonusRaw) ? xpBonusRaw : (xpBonusRaw != null ? parseInt(xpBonusRaw, 10) : undefined)
+    return {
+        id,
+        title,
+        desc,
+        xp_bonus: Number.isFinite(xp_bonus) ? xp_bonus : undefined,
+        criteria: normalizeCriteria(row?.criteria)
+    }
+}
+
+export function loadLevels() {
+    return safeJSON(LEVELS_JSON, DEFAULT_LEVELS, 'levels').map((row, idx) => normalizeLevel(row, idx))
+}
+
+export function loadBadges() {
+    return safeJSON(BADGES_JSON, DEFAULT_BADGES, 'badges').map((row, idx) => normalizeBadge(row, idx))
+}
+
+const LEVELS = loadLevels()
+const BADGES = loadBadges()
 
 export function allLevels() { return LEVELS }
 export function allBadges() { return BADGES }
 
 export function levelForXp(xp = 0) {
-    let lvl = 1
+    const value = Number.isFinite(xp) ? xp : parseInt(xp, 10) || 0
+    let lvl = LEVELS[0]
     for (const row of LEVELS) {
-        if (xp >= (row.xp_threshold ?? 0)) lvl = row.id
+        if (value >= (row.xp_threshold ?? 0)) lvl = row
         else break
     }
-    const def = LEVELS.find(r => r.id === lvl) || LEVELS[0]
-    return { id: def.id, code: def.code, title: def.title, perk: def.perk, xp_threshold: def.xp_threshold }
+    return lvl
 }
 
 export function checkBadges(userState) {

--- a/tools/emit_progression_defaults.mjs
+++ b/tools/emit_progression_defaults.mjs
@@ -1,0 +1,22 @@
+import fs from 'fs'
+import path from 'path'
+
+const OUT_DIR = path.resolve('game things', 'sigil-syntax')
+fs.mkdirSync(OUT_DIR, { recursive: true })
+
+const levels = [
+  { id: 1, code: 'rookie', title: 'Rookie', xp_threshold: 0, perk: 'Begin your Sigil_&_Syntax journey.' },
+  { id: 2, code: 'novice', title: 'Novice', xp_threshold: 100, perk: 'Unlocks basic practice sets.' },
+  { id: 3, code: 'apprentice', title: 'Apprentice', xp_threshold: 250, perk: 'Grants access to intermediate drills.' },
+  { id: 4, code: 'journeyman', title: 'Journeyman', xp_threshold: 500, perk: 'Opens advanced gauntlets.' },
+  { id: 5, code: 'adept', title: 'Adept', xp_threshold: 800, perk: 'Marks you as a Sigil mentor.' }
+]
+const badges = [
+  { id: 'first_write', title: 'First Draft Down', desc: 'Submit your first write.', criteria: { type: 'attempt_count', count: 1 } },
+  { id: 'three_reads', title: 'Close Reader', desc: 'Complete 3 read tasks.', criteria: { type: 'attempt_count', count: 3 } },
+  { id: 'mcq_streak_5', title: 'On a Roll', desc: '5 MCQs correct in a row.', criteria: { type: 'first_try_high_score' } }
+]
+
+fs.writeFileSync(path.join(OUT_DIR, 'levels.json'), JSON.stringify(levels, null, 2))
+fs.writeFileSync(path.join(OUT_DIR, 'badges.json'), JSON.stringify(badges, null, 2))
+console.log('✅ wrote', path.join(OUT_DIR, 'levels.json'), 'and', path.join(OUT_DIR, 'badges.json'))


### PR DESCRIPTION
## Summary
- disable the runtime foundations loader and fall back to empty lessons/items in the server entry
- replace the Sigil progression module with a JSON-backed loader that falls back to sane defaults when files are missing or invalid
- add a helper script to emit the default progression JSON files and expose it through the root package scripts

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68f04011d6a4832fadc2be42e5489a9a