### PR TITLE
Add audit readiness tooling and diagnostics

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -2,7 +2,8 @@ import React from 'react'
 import { BrowserRouter, Routes, Route, Link } from 'react-router-dom'
 import Home from '@/pages/Home.jsx'
 import SigilSyntax from '@/pages/SigilSyntax.jsx'
-import GoodWord from '@/pages/GoodWord.stub.jsx'
+import GoodWord from '@/pages/GoodWord.jsx'
+import DebugAudit from '@/pages/DebugAudit.jsx'
 
 export default function App() {
   return (
@@ -11,6 +12,7 @@ export default function App() {
         <Route path="/" element={<Home />} />
         <Route path="/sigil" element={<SigilSyntax />} />
         <Route path="/sigil/:id" element={<SigilSyntax />} />
+        <Route path="/debug/audit" element={<DebugAudit />} />
         <Route path="/goodword/:id" element={<GoodWord />} />
         <Route
           path="*"

--- a/app/src/pages/DebugAudit.jsx
+++ b/app/src/pages/DebugAudit.jsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react'
+import { api, safeFetchJSON } from '@/lib/apiBase.js'
+import { Link } from 'react-router-dom'
+
+export default function DebugAudit(){
+  const [d, setD] = useState(null)
+  const [err, setErr] = useState('')
+  useEffect(() => {
+    safeFetchJSON(api('/__diag')).then(setD).catch(e => setErr(String(e)))
+  }, [])
+  if (err) return <main style={{padding:24}}><h2>Audit Error</h2><pre>{err}</pre></main>
+  if (!d) return <main style={{padding:24}}>Running audit…</main>
+
+  const Line = ({ok, name, extra}) => (
+    <li style={{margin:'6px 0'}}>
+      <span>{ok ? '✅' : '❌'} {name}</span>
+      {extra ? <div style={{opacity:.7, fontSize:12}}>{extra}</div> : null}
+    </li>
+  )
+
+  const f = d.frontend, c = d.content
+  const checks = [
+    [f.indexHtml.exists, 'app/index.html present'],
+    [f.mainJsx.exists, 'app/src/main.jsx present'],
+    [f.appJsx.exists, 'app/src/App.jsx present'],
+    [f.sigilPage.exists, 'SigilSyntax.jsx present'],
+    [f.apiBase.exists, 'apiBase present (dev/prod base URL)'],
+    [f.viteCfg.exists, 'vite.config.js present', (f.viteNotes||[]).join(' • ')],
+    [c.bundleInfo.exists || c.bundle.exists || c.bundleOld.exists, 'Sigil bundle exists'],
+    [(c.bundleInfo.items||0) > 0, `Sigil bundle has lessons (${c.bundleInfo.items})`, 'Run emit:sigil:labeled if 0'],
+  ]
+
+  return (
+    <main style={{ padding:24 }}>
+      <h1>Audit</h1>
+      <p>Backend base: {import.meta.env.DEV ? (import.meta.env.VITE_DEV_API || '(proxy)') : (import.meta.env.VITE_PROD_API || '(unset)')}</p>
+      <ul>{checks.map(([ok,name,extra],i)=><Line key={i} ok={ok} name={name} extra={extra}/>)}</ul>
+      <p><Link to="/">Home</Link></p>
+    </main>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "audit": "node tools/audit_readiness.mjs",
     "dev:app": "npm run dev --prefix app",
     "build:app": "npm run build --prefix app",
     "preview:app": "npm run preview --prefix app",

--- a/server/diag.js
+++ b/server/diag.js
@@ -1,0 +1,43 @@
+import fs from 'fs'
+import path from 'path'
+
+const R = (...s) => path.resolve(...s)
+const E = (p) => ({ path: p, exists: fs.existsSync(p) })
+
+export function collectDiagnostics() {
+  const indexHtml = E(R('app','index.html'))
+  const mainJsx   = E(R('app','src','main.jsx'))
+  const appJsx    = E(R('app','src','App.jsx'))
+  const sigilPage = E(R('app','src','pages','SigilSyntax.jsx'))
+  const apiBase   = E(R('app','src','lib','apiBase.js')) || E(R('app','src','lib','apiBase.jsx'))
+
+  const viteCfg   = E(R('app','vite.config.js'))
+  let viteNotes = []
+  try {
+    const txt = fs.readFileSync(R('app','vite.config.js'),'utf8')
+    if (!/base:/.test(txt)) viteNotes.push('vite.base missing (GitHub Pages needs /<repo>/)')
+    if (!/proxy:/.test(txt) && !/VITE_DEV_API/.test(fs.readFileSync(R('app','.env.local'),'utf8')||'')) {
+      viteNotes.push('no dev proxy and no VITE_DEV_API — dev calls may 404')
+    }
+  } catch {}
+  const bundle = R('game things','build','sigil-syntax','bundle_sigil_syntax.json')
+  const bundleOld = R('game thingss','build','sigil-syntax','bundle_sigil_syntax.json')
+  let bundleInfo = { exists: fs.existsSync(bundle) || fs.existsSync(bundleOld), items: 0 }
+  try {
+    const p = fs.existsSync(bundle) ? bundle : bundleOld
+    if (p) {
+      const j = JSON.parse(fs.readFileSync(p,'utf8'))
+      bundleInfo.items = Array.isArray(j?.items) ? j.items.length : 0
+    }
+  } catch {}
+
+  return {
+    frontend: { indexHtml, mainJsx, appJsx, sigilPage, apiBase, viteCfg, viteNotes },
+    content: { bundle: E(bundle), bundleOld: E(bundleOld), bundleInfo },
+    env: {
+      NODE_ENV: process.env.NODE_ENV || 'development',
+      VITE_DEV_API: process.env.VITE_DEV_API || null,
+      VITE_PROD_API: process.env.VITE_PROD_API || null
+    }
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -18,6 +18,7 @@ import { listGoodIds, getGoodItem } from './goodword/index.js'
 import { listSigilIds, getSigilItem, firstSigilId, getSigilDebug } from './sigil-syntax/content.js'
 import basicAuth from 'basic-auth'
 import { debugResolvedPaths } from './lib/resolvePaths.js'
+import { collectDiagnostics } from './diag.js'
 
 let morgan = null
 try {
@@ -122,6 +123,14 @@ app.get('/_debug/cors', (req, res) => {
         allowed,
         allowedOrigins: Array.from(allowedOrigins)
     })
+})
+
+app.get('/__diag', (req, res) => {
+    try {
+        res.json({ ok: true, ...collectDiagnostics() })
+    } catch (e) {
+        res.status(500).json({ ok: false, error: String(e) })
+    }
 })
 
 app.get('/whoami', (req, res) => {

--- a/tools/audit_readiness.mjs
+++ b/tools/audit_readiness.mjs
@@ -1,0 +1,70 @@
+import fs from 'fs'
+import path from 'path'
+
+const out = []
+const add = (ok, name, detail='') => out.push({ ok, name, detail })
+
+const R = (...s) => path.resolve(...s)
+const exists = (p) => fs.existsSync(p)
+
+function readJSON(p) {
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')) } catch { return null }
+}
+
+// 1) Frontend entry points
+add(exists(R('app','index.html')), 'app/index.html exists',
+  exists(R('app','index.html')) ? '' : 'Vite needs index.html with <div id="root">')
+add(exists(R('app','src','main.jsx')), 'app/src/main.jsx exists')
+add(exists(R('app','src','App.jsx')), 'app/src/App.jsx exists')
+add(exists(R('app','src','pages','SigilSyntax.jsx')), 'SigilSyntax page present', 'Needed for /sigil route')
+
+// 2) apiBase helper
+add(exists(R('app','src','lib','apiBase.js')) || exists(R('app','src','lib','apiBase.jsx')),
+  'apiBase helper present', 'Required so dev/prod hit the right backend')
+
+// 3) Vite config sanity
+const vitecfg = exists(R('app','vite.config.js')) ? fs.readFileSync(R('app','vite.config.js'),'utf8') : ''
+add(!!vitecfg, 'vite.config.js present')
+add(/base:\s*process\.env\.GHPAGES_BASE|base:\s*`\/.+\/'`/.test(vitecfg) || !vitecfg,
+  'vite base set for Pages', 'BASE should be /<repo>/ for GitHub Pages')
+add(/server:\s*{[\s\S]*proxy:/.test(vitecfg) || /VITE_DEV_API/.test(vitecfg),
+  'dev uses proxy or VITE_DEV_API', 'Either Vite proxy keys or VITE_DEV_API required in dev')
+
+// 4) Dev env override
+add(exists(R('app','.env.local')) || process.env.VITE_DEV_API,
+  'VITE_DEV_API set for dev (Option A)', 'Create app/.env.local with VITE_DEV_API=https://<codespace-3001>.app.github.dev')
+
+// 5) Backend endpoints
+add(exists(R('server','index.js')), 'server/index.js exists')
+const serverSrc = exists(R('server','index.js')) ? fs.readFileSync(R('server','index.js'),'utf8') : ''
+add(/app\.get\(['"]\/health['"]/.test(serverSrc), 'GET /health route wired')
+add(/app\.get\(['"]\/sigil\/catalog['"]/.test(serverSrc), 'GET /sigil/catalog route wired')
+add(/app\.get\(['"]\/sigil\/game\/:id['"]/.test(serverSrc), 'GET /sigil/game/:id route wired')
+
+// 6) Content bundle present
+const bundle = R('game things','build','sigil-syntax','bundle_sigil_syntax.json')
+add(exists(bundle) || exists(R('game thingss','build','sigil-syntax','bundle_sigil_syntax.json')),
+  'Sigil bundle exists', 'Run npm run emit:sigil:labeled to generate')
+let items = 0
+try {
+  const b = JSON.parse(fs.readFileSync(exists(bundle) ? bundle : R('game thingss','build','sigil-syntax','bundle_sigil_syntax.json'),'utf8'))
+  items = Array.isArray(b?.items) ? b.items.length : 0
+} catch {}
+add(items > 0, `Sigil bundle has items (${items})`, 'Builder found no lessons; check labeled data/tweetrunk_renumbered')
+
+const result = {
+  summary: {
+    ok: out.every(x=>x.ok),
+    passed: out.filter(x=>x.ok).length,
+    total: out.length
+  },
+  checks: out
+}
+const okCount = result.summary.passed, total = result.summary.total
+console.log(`\n=== AUDIT: ${okCount}/${total} checks passed ===\n`)
+for (const c of out) {
+  const mark = c.ok ? '✅' : '❌'
+  console.log(`${mark} ${c.name}${c.detail ? ` — ${c.detail}` : ''}`)
+}
+console.log('\nTip: run the backend (node server/index.js), set VITE_DEV_API in app/.env.local, then npm run dev --prefix app\n')
+process.exit(result.summary.ok ? 0 : 1)


### PR DESCRIPTION
## Summary
- add a CLI audit script to check frontend, backend, and bundle readiness
- expose server-side diagnostics via a new /__diag endpoint
- surface a browser audit page and register it in the router

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f047c42280832f8b9ba09fe135de99