### PR TITLE
Add sigil game endpoint and sample lesson fallback

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -202,6 +202,23 @@ app.get('/sigil/catalog', (req, res) => {
     }
 })
 
+// NEW: get a single lesson by id
+app.get('/sigil/game/:id', (req, res) => {
+    try {
+        const it = getSigilItem(req.params.id)
+        if (!it) return res.status(404).json({ error: 'not_found', id: req.params.id })
+        return res.json(it)
+    } catch (e) {
+        return res.status(500).json({ error: 'sigil_item_failed', message: String(e), id: req.params.id })
+    }
+})
+
+// Optional: quick peek at first few ids
+app.get('/_debug/sigil/catalog', (req, res) => {
+    const ids = listSigilIds()
+    res.json({ count: ids.length, first: firstSigilId(), sample: ids.slice(0, 10) })
+})
+
 // Lessons endpoints
 app.get('/lessons', (req, res) => {
     res.json({ lessons: listLessons() })

--- a/tools/build_sigil_from_labeled.mjs
+++ b/tools/build_sigil_from_labeled.mjs
@@ -1,8 +1,13 @@
 import fs from 'fs'
 import path from 'path'
 
-const LAB = 'labeled data'
-const TWEETS = path.join(LAB, 'tweetrunk_renumbered')
+const CANDS = [
+  path.join('labeled data', 'tweetrunk_renumbered'),
+  path.join('labeled data', 'tweetrunk-renumbered'),
+  path.join('labeled data', 'sigil-lessons')
+]
+const TWEETS = CANDS.find(p => fs.existsSync(p)) || CANDS[0]
+
 const OUT = path.resolve('game things','build','sigil-syntax')
 fs.mkdirSync(OUT, { recursive: true })
 
@@ -27,17 +32,13 @@ function toItem(o, i){
     id:`sigil:${id}`,
     title: o.title || `Sigil_&_Syntax — Lesson ${i+1}`,
     input_type: o.input_type || 'write',
-    prompt_html: String(prompt),
+    prompt_html: String(prompt || 'Write a few lines about a character who wants something but faces an obstacle.'),
     min_words: +(o.min_words ?? 30)
   }
 }
 
 ;(function main(){
   const files = listSorted(TWEETS)
-  if (files.length === 0) {
-    console.error('❌ No lesson files found in', TWEETS)
-    process.exit(1)
-  }
   let items = []
   for (const p of files) {
     if (p.endsWith('.jsonl')) items.push(...readJSONL(p).map((o,i)=>toItem(o, items.length+i)))
@@ -49,46 +50,21 @@ function toItem(o, i){
       } catch(e) { console.warn('⚠️ Could not parse', p, e.message) }
     }
   }
-  const bundle = { kind:'sigil-syntax', version:1, first: items[0]?.id || null, items }
-  fs.writeFileSync(path.join(OUT,'bundle_sigil_syntax.json'), JSON.stringify(bundle,null,2), 'utf8')
-  console.log('✅ wrote', path.join(OUT,'bundle_sigil_syntax.json'), 'items=', items.length)
-})()
-const LAB = 'labeled data'
-const TWEETS = path.join(LAB, 'tweetrunk_renumbered')
-const OUT = path.resolve('game things', 'build', 'sigil-syntax')
-fs.mkdirSync(OUT, { recursive: true })
 
-function readJSONL(p) {
-  const out = []; if (!fs.existsSync(p)) return out
-  for (const line of fs.readFileSync(p, 'utf8').split('\n')) {
-    const t = line.trim(); if (!t) continue; try { out.push(JSON.parse(t)) } catch { }
-  } return out
-}
-function listSorted(dir) {
-  if (!fs.existsSync(dir)) return []
-  return fs.readdirSync(dir).filter(f => /\.(json|jsonl)$/i.test(f))
-    .map(f => ({ f, n: +(f.match(/^(\d+)/)?.[1] ?? 999999) }))
-    .sort((a, b) => a.n - b.n).map(x => path.join(dir, x.f))
-}
-function toItem(o, i) {
-  const id = o.id || `w:${i + 1}`
-  const prompt = o.prompt_html || o.prompt || o.text || ''
-  return { id: `sigil:${id}`, title: o.title || `Sigil_&_Syntax — Lesson ${i + 1}`, input_type: o.input_type || 'write', prompt_html: String(prompt), min_words: +(o.min_words ?? 30) }
-}
-(function main() {
-  const files = listSorted(TWEETS); let items = []
-  for (const p of files) {
-    if (p.endsWith('.jsonl')) items.push(...readJSONL(p).map((o, i) => toItem(o, items.length + i)))
-    else {
-      try {
-        const raw = JSON.parse(fs.readFileSync(p, 'utf8'))
-        const arr = Array.isArray(raw) ? raw : (raw.items || raw.lessons || [raw])
-        items.push(...arr.map((o, i) => toItem(o, items.length + i)))
-      } catch { }
-    }
+  // Fallback: emit one sample lesson so the catalog isn't empty
+  if (items.length === 0) {
+    console.warn('⚠️ No lessons found in', TWEETS, '→ emitting a sample lesson so the app can run.')
+    items.push(toItem({
+      id: 'sample-001',
+      title: 'Sample: Desire vs. Obstacle',
+      input_type: 'write',
+      prompt_html: '<p>Write 80–120 words where a character wants something badly but faces a specific obstacle. Use sensory detail.</p>',
+      min_words: 80
+    }, 0))
   }
-  const bundle = { kind: 'sigil-syntax', version: 1, first: items[0]?.id || null, items }
-  fs.writeFileSync(path.join(OUT, 'bundle_sigil_syntax.json'), JSON.stringify(bundle, null, 2), 'utf8')
-  console.log('✅ wrote', path.join(OUT, 'bundle_sigil_syntax.json'), 'items=', items.length)
-})()
 
+  const bundle = { kind:'sigil-syntax', version:1, first: items[0]?.id || null, items }
+  const outFile = path.join(OUT,'bundle_sigil_syntax.json')
+  fs.writeFileSync(outFile, JSON.stringify(bundle,null,2), 'utf8')
+  console.log('✅ wrote', outFile, 'items=', items.length, '\n   sourceDir=', TWEETS)
+})()


### PR DESCRIPTION
## Summary
- add REST route to serve individual Sigil & Syntax lessons and expose a catalog debug helper
- harden the sigil build tool to locate data in multiple folders and emit a sample lesson when none exist

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68f049a1946c832fb6cb83281fd42ea6