### PR TITLE
Add snapshot buttons to Sigil pages

### DIFF
--- a/app/src/lib/snapshot.js
+++ b/app/src/lib/snapshot.js
@@ -1,0 +1,37 @@
+// app/src/lib/snapshot.js
+let html2canvasPromise = null
+
+function loadHtml2Canvas() {
+  if (html2canvasPromise) return html2canvasPromise
+  html2canvasPromise = new Promise((resolve, reject) => {
+    const s = document.createElement('script')
+    s.src = 'https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js'
+    s.async = true
+    s.onload = () => resolve(window.html2canvas)
+    s.onerror = () => reject(new Error('Failed to load html2canvas'))
+    document.head.appendChild(s)
+  })
+  return html2canvasPromise
+}
+
+/**
+ * Capture a DOM element and download a PNG.
+ * @param {string|HTMLElement} target - CSS selector or element to capture (defaults to 'main').
+ * @param {string} filename - Suggested download filename.
+ */
+export async function snapAndDownload(target = 'main', filename = 'screenshot.png') {
+  const html2canvas = await loadHtml2Canvas()
+  const el = typeof target === 'string' ? document.querySelector(target) : target
+  if (!el) throw new Error('snapshot: target element not found')
+  // ensure a background so PNG isn’t transparent
+  const prevBg = el.style.backgroundColor
+  if (!prevBg) el.style.backgroundColor = '#ffffff'
+  const canvas = await html2canvas(el, { useCORS: true, backgroundColor: '#ffffff', scale: 2 })
+  if (!prevBg) el.style.backgroundColor = ''
+  const a = document.createElement('a')
+  a.href = canvas.toDataURL('image/png')
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+}

--- a/app/src/pages/SigilRunner.jsx
+++ b/app/src/pages/SigilRunner.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { useParams, Link, useNavigate } from 'react-router-dom'
 import { api, safeFetchJSON } from '@/lib/apiBase.js'
 import NotesPanel from '@/components/NotesPanel.jsx'
+import { snapAndDownload } from '@/lib/snapshot.js'
 
 export default function SigilRunner(){
   const { id } = useParams()
@@ -47,6 +48,14 @@ export default function SigilRunner(){
 
   return (
     <main style={{padding:24}}>
+      <div style={{display:'flex', gap:8, justifyContent:'flex-end', marginBottom:8}}>
+        <button
+          onClick={()=>snapAndDownload('main', `sigil-${encodeURIComponent(id)}.png`)}
+          style={{padding:'8px 12px', border:'1px solid #000', background:'#fff', cursor:'pointer', fontSize:12}}
+        >
+          Save screenshot
+        </button>
+      </div>
       <div style={{display:'grid', gridTemplateColumns:'2fr 1fr', gap:16, alignItems:'start'}}>
         {/* READ BOX */}
         <section style={{border:'1px solid #000', background:'#f6f6f6', padding:16}}>

--- a/app/src/pages/SigilSyntax.jsx
+++ b/app/src/pages/SigilSyntax.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { api, safeFetchJSON } from '@/lib/apiBase.js'
 import { useNavigate } from 'react-router-dom'
+import { snapAndDownload } from '@/lib/snapshot.js'
 
 export default function SigilSyntax(){
   const [cat, setCat] = useState(null)
@@ -32,14 +33,22 @@ URL:  ${debug.tried}`}</pre>
     <main style={{padding:24, display:'grid', gap:16}}>
       <h1>Sigil &amp; Syntax</h1>
       <p>Catalog: Found {count} lessons</p>
-      {!!cat.first && (
+      <div style={{display:'flex', gap:8, flexWrap:'wrap'}}>
+        {!!cat.first && (
+          <button
+            onClick={()=>nav(`/sigil/${encodeURIComponent(cat.first)}`)}
+            style={{padding:'10px 16px', border:'1px solid #000', background:'#fff', cursor:'pointer'}}
+          >
+            Start first lesson
+          </button>
+        )}
         <button
-          onClick={()=>nav(`/sigil/${encodeURIComponent(cat.first)}`)}
-          style={{padding:'10px 16px', border:'1px solid #000', background:'#fff', cursor:'pointer', width:'fit-content'}}
+          onClick={()=>snapAndDownload('main', 'sigil-catalog.png')}
+          style={{padding:'10px 16px', border:'1px solid #000', background:'#fff', cursor:'pointer'}}
         >
-          Start first lesson
+          Save screenshot
         </button>
-      )}
+      </div>
       <p><a href="/">Back home</a></p>
     </main>
   )


### PR DESCRIPTION
## Summary
- add an html2canvas-based snapshot helper for downloading page captures
- expose "Save screenshot" buttons on the Sigil catalog and lesson views

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f096655b54832faa930fa8bab9a1fb