### PR TITLE
Add Playwright snapshot testing setup

### DIFF
--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -1,0 +1,37 @@
+name: Snapshots (Playwright)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  snap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install root tools
+        run: npm i --no-audit --no-fund
+
+      - name: Install app deps
+        run: npm i --prefix app --no-audit --no-fund
+
+      - name: Run Playwright screenshots
+        env:
+          # Replace with your public backend in CI if needed.
+          # For Codespaces backend, this won’t be reachable from GitHub runners.
+          VITE_PROD_API: https://animated-carnival-v4g77qwxgvv3p5p5-3001.app.github.dev
+        run: npx playwright install --with-deps && npm run snap:test
+
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: sigil-screens
+          path: |
+            app/test-output/**/*.png
+            app/test-output/html

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@playwright/test'
+
+// Vite preview uses 5173 per app/vite.config.js
+export default defineConfig({
+  testDir: './tests',
+  reporter: [['list'], ['html', { outputFolder: './test-output/html' }]],
+  use: {
+    baseURL: 'http://localhost:5173/projects-from-the-projects',
+    trace: 'on-first-retry'
+  },
+  webServer: {
+    command: 'npm run snap:preview',
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000
+  },
+  outputDir: './test-output/run'
+})

--- a/app/tests/sigil.snap.spec.ts
+++ b/app/tests/sigil.snap.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect, request } from '@playwright/test'
+
+const BACKEND = 'https://animated-carnival-v4g77qwxgvv3p5p5-3001.app.github.dev'
+
+test('catalog + first lesson screenshots', async ({ page, baseURL, context }) => {
+  // Get first lesson id from backend
+  const api = await request.newContext()
+  const cat = await api.get(`${BACKEND}/sigil/catalog`, { headers: { accept: 'application/json' } })
+  expect(cat.ok()).toBeTruthy()
+  const j = await cat.json()
+  expect(Array.isArray(j.games)).toBeTruthy()
+  const firstId = j.first || j.games[0]
+  expect(firstId).toBeTruthy()
+
+  // Catalog page
+  await page.goto(`${baseURL}/sigil`, { waitUntil: 'networkidle' })
+  await page.waitForTimeout(500) // settle fonts
+  await page.screenshot({ path: 'app/test-output/sigil-catalog.png', fullPage: true })
+
+  // First lesson page
+  await page.goto(`${baseURL}/sigil/${encodeURIComponent(firstId)}`, { waitUntil: 'networkidle' })
+  await page.waitForSelector('textarea')
+  await page.waitForTimeout(500)
+  await page.screenshot({ path: `app/test-output/sigil-lesson-${firstId.replace(/[:/]/g,'_')}.png`, fullPage: true })
+})

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "start:server": "node server/index.js",
     "start": "npm run dev:server & npm run dev:app",
     "emit:progression": "node tools/emit_progression_defaults.mjs",
-    "emit:sigil:labeled": "node tools/build_sigil_from_labeled.mjs"
+    "emit:sigil:labeled": "node tools/build_sigil_from_labeled.mjs",
+    "snap:preview": "cross-env VITE_PROD_API=https://animated-carnival-v4g77qwxgvv3p5p5-3001.app.github.dev npm run build --prefix app && npm run preview --prefix app",
+    "snap:test": "playwright test -c app/playwright.config.ts"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.14",
@@ -27,7 +29,9 @@
     "prettier": "^3.6.2",
     "tailwindcss": "^4.1.14",
     "typescript": "^5.9.3",
-    "vite": "^7.1.9"
+    "vite": "^7.1.9",
+    "@playwright/test": "^1.48.2",
+    "cross-env": "^7.0.3"
   },
   "dependencies": {
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- add Playwright configuration and snapshot test harness under the app project
- add npm scripts and dev dependencies to enable snapshot previews and Playwright runs
- provide a GitHub Actions workflow to capture and upload Playwright screenshots

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68f09abf5684832faa351e60c684b50e