### PR TITLE
Add Codespaces-aware API base and CORS support

### DIFF
--- a/src/games/guard.tsx
+++ b/src/games/guard.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from "react";
+import { apiUrl } from "../lib/apiBase";
 
 type Flags = { gameEnabled?: boolean; maintenanceMessage?: string };
 
 async function fetchFlags(): Promise<Flags> {
   try {
-    const r = await fetch("/api/flags", { cache: "no-store" });
+    const r = await fetch(apiUrl("/api/flags"), { cache: "no-store" });
     const j = await r.json();
     return (j?.flags ?? j) as Flags;
   } catch {

--- a/src/lib/apiBase.js
+++ b/src/lib/apiBase.js
@@ -1,5 +1,0 @@
-const PROD = import.meta.env.VITE_PROD_API || '';
-export const api = (p = '') => {
-    const base = (import.meta.env.DEV ? '' : PROD).replace(/\/+$/, '');
-    return `${base}${p.startsWith('/') ? p : `/${p}`}`;
-};

--- a/src/lib/apiBase.ts
+++ b/src/lib/apiBase.ts
@@ -1,0 +1,17 @@
+export const apiBase = (() => {
+  const env = import.meta.env.VITE_DEV_API?.toString().trim()
+  if (env) return env.replace(/\/$/, '')
+  if (typeof window !== 'undefined') {
+    const { origin } = window.location
+    if (origin.includes('.app.github.dev')) {
+      return origin.replace(/-\d+\.app\.github\.dev$/, '-3001.app.github.dev')
+    }
+  }
+  return ''
+})()
+
+export const apiUrl = (path: string) => {
+  if (!path) return apiBase
+  const suffix = path.startsWith('/') ? path : `/${path}`
+  return `${apiBase}${suffix}`
+}

--- a/src/lib/cutGamesClient.ts
+++ b/src/lib/cutGamesClient.ts
@@ -1,14 +1,18 @@
 // src/lib/cutGamesClient.ts
+import { apiUrl } from "./apiBase";
+
 export type PracticeItem = { id:number; scene:string; beat?:string; pitfall?:string };
 
 async function get<T>(url: string): Promise<T> {
-  const res = await fetch(url, { credentials: "include" });
+  const target = apiUrl(url);
+  const res = await fetch(target, { credentials: "include" });
   if (!res.ok) throw new Error(`GET ${url} failed: ${res.status}`);
   return res.json();
 }
 
 async function post<T>(url: string, body: any): Promise<T> {
-  const res = await fetch(url, {
+  const target = apiUrl(url);
+  const res = await fetch(target, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     credentials: "include",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,22 @@ export default defineConfig({
   base,
   plugins: [react()],
   resolve: { alias: { "@": path.resolve(__dirname, "src") } },
-  server: { open: "/" },
+  server: {
+    open: "/",
+    proxy: {
+      "/sigil": {
+        target: process.env.VITE_DEV_API || "http://localhost:3001",
+        changeOrigin: true
+      },
+      "/cut-games": {
+        target: process.env.VITE_DEV_API || "http://localhost:3001",
+        changeOrigin: true
+      },
+      "/api": {
+        target: process.env.VITE_DEV_API || "http://localhost:3001",
+        changeOrigin: true
+      }
+    }
+  },
   build: { sourcemap: true },
 });


### PR DESCRIPTION
## Summary
- enable a stricter CORS policy that trusts app.github.dev hosts and handles preflight requests
- introduce an apiBase helper that maps preview origins to the backend and update API clients to use it
- configure the Vite dev server to proxy API routes to the backend when developing locally

## Testing
- npm run build *(fails: vite binary missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f10caf84c0832fbc311f547beca041