### PR TITLE
Align API base helper usage with router proxy setup

### DIFF
--- a/src/games/guard.tsx
+++ b/src/games/guard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { apiBase } from "../lib/apiBase";
+import { apiBase } from "@/lib/apiBase";
 
 type Flags = { gameEnabled?: boolean; maintenanceMessage?: string };
 

--- a/src/lib/apiBase.ts
+++ b/src/lib/apiBase.ts
@@ -1,4 +1,2 @@
-// Use absolute API only when you explicitly set VITE_ABS_API.
-// Otherwise use relative (lets Vite proxy kill CORS in dev).
 const ABS = import.meta.env.VITE_ABS_API?.trim();
 export const apiBase = ABS ? ABS.replace(/\/$/, '') : '';

--- a/src/lib/cutGamesClient.ts
+++ b/src/lib/cutGamesClient.ts
@@ -1,5 +1,5 @@
 // src/lib/cutGamesClient.ts
-import { apiBase } from "./apiBase";
+import { apiBase } from "@/lib/apiBase";
 
 const withApiBase = (path: string) => `${apiBase}${path.startsWith("/") ? path : `/${path}`}`;
 


### PR DESCRIPTION
## Summary
- replace the apiBase helper with the standardized snippet required for relative dev requests
- update guard and cutGamesClient to consume the helper through the shared alias

## Testing
- npm run build *(fails: vite binary missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f118e6c918832fbe80dff518f07689