### PR TITLE
Normalize Sigil catalog data before rendering

### DIFF
--- a/app/src/lib/gameAdapters/sources.jsx
+++ b/app/src/lib/gameAdapters/sources.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { safeFetchJSON } from '@/lib/apiBase'
+import { toCatalogItems } from '@/lib/normalize'
 
 export function adaptToSpec(it){
   if (!it) return null
@@ -40,6 +41,7 @@ export async function fetchSigilItem(id){
 }
 export async function firstSigilId(){
   const j = await safeFetchJSON('/sigil/catalog')
-  return j.first || (j.items && j.items[0]) || (j.games && j.games[0]) || null
+  const items = toCatalogItems(j)
+  return j?.first || (items[0]?.id ?? null)
 }
 

--- a/app/src/lib/normalize.ts
+++ b/app/src/lib/normalize.ts
@@ -1,0 +1,21 @@
+// src/lib/normalize.ts
+export type CatalogItem = {
+  id: string;
+  title: string;
+  level?: number;
+  type?: string; // 'lesson' | 'drill' | etc.
+};
+
+// Accepts anything and returns a safe array of CatalogItem with defaults.
+export function toCatalogItems(input: any): CatalogItem[] {
+  const arr = Array.isArray(input) ? input : (input?.items ?? []);
+  if (!Array.isArray(arr)) return [];
+  return arr
+    .filter(Boolean)
+    .map((it: any, idx: number): CatalogItem => ({
+      id: String(it?.id ?? `item-${idx}`),
+      title: String(it?.title ?? 'Untitled'),
+      level: typeof it?.level === 'number' ? it.level : undefined,
+      type: typeof it?.type === 'string' ? it.type : undefined,
+    }));
+}

--- a/app/src/pages/SigilRunner.jsx
+++ b/app/src/pages/SigilRunner.jsx
@@ -3,6 +3,7 @@ import { useParams, Link, useNavigate } from 'react-router-dom'
 import { safeFetchJSON } from '@/lib/apiBase'
 import NotesPanel from '@/components/NotesPanel.jsx'
 import { snapAndDownload } from '@/lib/snapshot.js'
+import { toCatalogItems } from '@/lib/normalize'
 
 export default function SigilRunner(){
   const { id } = useParams()
@@ -89,10 +90,12 @@ export default function SigilRunner(){
           <button style={btn} onClick={()=>{
             // simplistic “next”: go to next id in catalog
             safeFetchJSON('/sigil/catalog').then(cat=>{
-              const ids = cat.items || cat.games || []
-              const i = ids.indexOf(id)
-              const next = ids[i+1] || ids[0]
-              nav(`/sigil/${encodeURIComponent(next)}`)
+              const items = toCatalogItems(cat)
+              const ids = items.map(entry => entry.id)
+              const idx = ids.indexOf(id)
+              const nextIdx = idx >= 0 ? idx + 1 : 0
+              const next = ids[nextIdx] ?? ids[0]
+              if (next) nav(`/sigil/${encodeURIComponent(next)}`)
             })
           }}>Next</button>
           <button style={btn} onClick={()=>setText('')}>Try again</button>

--- a/app/src/pages/SigilSyntax.jsx
+++ b/app/src/pages/SigilSyntax.jsx
@@ -2,10 +2,12 @@ import { useEffect, useState } from 'react'
 import { api, apiBase, safeFetchJSON } from '@/lib/apiBase'
 import { useNavigate } from 'react-router-dom'
 import { snapAndDownload } from '@/lib/snapshot.js'
+import { toCatalogItems } from '@/lib/normalize'
 
 export default function SigilSyntax(){
-  const [cat, setCat] = useState(null)
-  const [err, setErr] = useState('')
+  const [raw, setRaw] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
   const [debug, setDebug] = useState({ base: '', tried: '' })
   const nav = useNavigate()
 
@@ -13,12 +15,29 @@ export default function SigilSyntax(){
     const base = apiBase || '(relative)'
     const url = api('/sigil/catalog')
     setDebug({ base, tried: url })
-    safeFetchJSON(url).then(setCat).catch(e=>setErr(String(e)))
+    let alive = true
+    ;(async () => {
+      try {
+        setLoading(true)
+        setError('')
+        const json = await safeFetchJSON(url)
+        if (alive) setRaw(json)
+      } catch (e) {
+        console.warn('Catalog load failed:', e?.message || e)
+        if (alive) {
+          setRaw(null)
+          setError(e?.message ? String(e.message) : String(e))
+        }
+      } finally {
+        if (alive) setLoading(false)
+      }
+    })()
+    return () => { alive = false }
   }, [])
 
-  if (err) return (
+  if (error) return (
     <main className="sigil-root surface" style={{padding:24}}>
-      Catalog: <b>Error:</b> {err}
+      Catalog: <b>Error:</b> {error}
       <pre style={{marginTop:12, fontSize:12, opacity:.8}}>{`Base: ${debug.base}
 URL:  ${debug.tried}`}</pre>
       <p style={{fontSize:12, opacity:.8}}>
@@ -26,17 +45,19 @@ URL:  ${debug.tried}`}</pre>
       </p>
     </main>
   )
-  if (!cat) return <main className="sigil-root surface" style={{padding:24}}>Catalog: loading…</main>
 
-  const count = (cat.items || cat.games || []).length
+  const items = toCatalogItems(raw)
+  const count = items.length
+  const firstId = raw?.first || (items[0]?.id ?? null)
+
   return (
     <main className="sigil-root surface" style={{padding:24, display:'grid', gap:16}}>
       <h1>Sigil &amp; Syntax</h1>
       <p>Catalog: Found {count} lessons</p>
       <div style={{display:'flex', gap:8, flexWrap:'wrap'}}>
-        {!!cat.first && (
+        {!!firstId && (
           <button
-            onClick={()=>nav(`/sigil/${encodeURIComponent(cat.first)}`)}
+            onClick={()=>nav(`/sigil/${encodeURIComponent(firstId)}`)}
             style={{padding:'10px 16px', border:'1px solid #000', background:'#fff', cursor:'pointer'}}
           >
             Start first lesson
@@ -50,6 +71,48 @@ URL:  ${debug.tried}`}</pre>
         </button>
       </div>
       <p><a href="/">Back home</a></p>
+
+      {loading && (
+        <div className="surface" style={{ padding: '1rem', margin: '1rem 0' }}>
+          <strong>Loading…</strong>
+        </div>
+      )}
+
+      {!loading && items.length === 0 && (
+        <div className="surface" style={{ padding: '1rem', margin: '1rem 0' }}>
+          <strong>No lessons yet.</strong>
+          <div className="muted" style={{ fontSize: '.9rem' }}>Add items to /sigil/catalog and reload.</div>
+        </div>
+      )}
+
+      {items.length > 0 && (
+        <div className="grid" style={{ display: 'grid', gap: '12px', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))' }}>
+          {items.map((it, i) => {
+            const title = it?.title ?? 'Untitled'
+            const id = it?.id ?? `item-${i}`
+            const type = it?.type ?? 'lesson'
+            const level = it?.level ?? 1
+            return (
+              <article key={id} className="card" style={{ padding: '1rem' }}>
+                <header style={{ marginBottom: '.5rem' }}>
+                  <h3 style={{ margin: 0 }}>{title}</h3>
+                  <div className="muted" style={{ fontSize: '.9rem' }}>
+                    {type} • L{level}
+                  </div>
+                </header>
+                <footer>
+                  <button
+                    className="btn btn-primary"
+                    onClick={() => nav(`/sigil/${encodeURIComponent(id)}`)}
+                  >
+                    Play
+                  </button>
+                </footer>
+              </article>
+            )
+          })}
+        </div>
+      )}
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- add a shared catalog normalizer that coerces IDs, titles, and metadata safely
- update Sigil catalog screen to load with guarded states and display normalized lessons
- ensure Sigil runner and adapters rely on normalized catalog items before navigation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f1f06e0e84832fb229baedf402d171