### PR TITLE
Normalize sigil catalog data before rendering

### DIFF
--- a/src/lib/normalize.ts
+++ b/src/lib/normalize.ts
@@ -1,0 +1,21 @@
+// src/lib/normalize.ts
+export type CatalogItem = {
+  id: string;
+  title: string;
+  level?: number;
+  type?: string; // 'lesson' | 'drill' | etc.
+};
+
+// Accepts anything and returns a safe array of CatalogItem with defaults.
+export function toCatalogItems(input: any): CatalogItem[] {
+  const arr = Array.isArray(input) ? input : input?.items ?? [];
+  if (!Array.isArray(arr)) return [];
+  return arr
+    .filter(Boolean)
+    .map((it: any, idx: number): CatalogItem => ({
+      id: String(it?.id ?? `item-${idx}`),
+      title: String(it?.title ?? "Untitled"),
+      level: typeof it?.level === "number" ? it.level : undefined,
+      type: typeof it?.type === "string" ? it.type : undefined,
+    }));
+}

--- a/src/pages/SigilSyntaxGame.css
+++ b/src/pages/SigilSyntaxGame.css
@@ -17,3 +17,7 @@
   color: var(--card-fg);
   border-color: var(--card-fg);
 }
+
+.muted {
+  color: var(--muted, #9a9a9a);
+}

--- a/src/pages/SigilSyntaxGame.tsx
+++ b/src/pages/SigilSyntaxGame.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from "react";
 import { Routes, Route, Link, useNavigate } from "react-router-dom";
 import sigilSyntaxItems from "@/sigilSyntaxItems"; // or "@/sigilSyntaxItems.json"
 import { loadSigilPackSafe } from "@/games/sigilSyntaxData";
+import { toCatalogItems } from "@/lib/normalize";
 import "@/styles/brutalist.css";
 import "@/styles/theme/theme.css";
 import "./SigilSyntaxGame.css";
@@ -22,6 +23,11 @@ function Menu() {
 function Play() {
   const pack = useMemo(() => loadSigilPackSafe(), []);
   const [index, setIndex] = useState(0);
+  const catalogItems = useMemo(() => toCatalogItems(sigilSyntaxItems), []);
+  const rawCatalog = useMemo(
+    () => (Array.isArray(sigilSyntaxItems) ? sigilSyntaxItems : []),
+    []
+  );
 
   if (!pack) {
     return (
@@ -38,16 +44,37 @@ function Play() {
     );
   }
 
-  const items = pack.items;
-  const cur = items[index] ?? null;
+  const items = Array.isArray(pack.items) ? pack.items : [];
+  const hasItems = items.length > 0;
+  const safeItemIndex = hasItems
+    ? Math.min(Math.max(index, 0), items.length - 1)
+    : 0;
+  const cur = hasItems ? items[safeItemIndex] ?? null : null;
+  const hasCatalogItems = catalogItems.length > 0;
+  const safeCatalogIndex = hasCatalogItems
+    ? Math.min(Math.max(index, 0), catalogItems.length - 1)
+    : 0;
+  const catalogEntry = hasCatalogItems ? catalogItems[safeCatalogIndex] : null;
+  const catalogTitle = catalogEntry?.title ?? "Untitled";
+  const catalogType = catalogEntry?.type ?? "lesson";
+  const catalogLevel = catalogEntry?.level ?? 1;
+  const rawDescription =
+    typeof rawCatalog[safeCatalogIndex]?.description === "string"
+      ? rawCatalog[safeCatalogIndex].description
+      : "—";
 
   function nextItem() {
-    setIndex((i) => (i + 1) % sigilSyntaxItems.length);
+    setIndex((i) => {
+      if (catalogItems.length <= 0) {
+        return 0;
+      }
+      return (i + 1) % catalogItems.length;
+    });
   }
 
   return (
     <main className="p-6 font-mono text-sm border-t-4 border-black" data-testid="sigil-play">
-      <h2 className="mb-2">Round {index + 1}</h2>
+      <h2 className="mb-2">Round {safeItemIndex + 1}</h2>
       {cur ? (
         <>
           <div className="mb-3">
@@ -67,7 +94,14 @@ function Play() {
             </button>
             <button
               className="border-2 border-black px-3 py-1"
-              onClick={() => setIndex((i) => Math.min(items.length - 1, i + 1))}
+              onClick={() =>
+                setIndex((i) => {
+                  if (!hasItems) {
+                    return 0;
+                  }
+                  return Math.min(items.length - 1, i + 1);
+                })
+              }
             >
               Next
             </button>
@@ -84,20 +118,30 @@ function Play() {
           </Link>
         </>
       )}
-      <div className="bg-neutral-900 text-white rounded-xl shadow-lg p-8 mb-6 text-xl font-semibold text-center">
-        <div style={{ fontSize: "2rem", fontWeight: "bold" }}>
-          {sigilSyntaxItems[index].title}
+      {hasCatalogItems ? (
+        <>
+          <div className="bg-neutral-900 text-white rounded-xl shadow-lg p-8 mb-6 text-xl font-semibold text-center">
+            <div style={{ fontSize: "2rem", fontWeight: "bold" }}>{catalogTitle}</div>
+            <div style={{ fontSize: "1.1rem", marginTop: "1rem" }}>{rawDescription}</div>
+            <div style={{ fontSize: "0.95rem", marginTop: "1rem", opacity: 0.85 }}>
+              {catalogType} • L{catalogLevel}
+            </div>
+          </div>
+          <button
+            className="bg-neutral-800 text-white px-6 py-2 rounded hover:bg-neutral-700 transition"
+            onClick={nextItem}
+          >
+            Next
+          </button>
+        </>
+      ) : (
+        <div className="surface" style={{ padding: "1rem", margin: "1rem 0" }}>
+          <strong>No lessons yet.</strong>
+          <div className="muted" style={{ fontSize: ".9rem" }}>
+            Add items to <code>src/sigilSyntaxItems.ts</code> and reload.
+          </div>
         </div>
-        <div style={{ fontSize: "1.1rem", marginTop: "1rem" }}>
-          {sigilSyntaxItems[index].description}
-        </div>
-      </div>
-      <button
-        className="bg-neutral-800 text-white px-6 py-2 rounded hover:bg-neutral-700 transition"
-        onClick={nextItem}
-      >
-        Next
-      </button>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add a reusable catalog normalizer for Sigil & Syntax catalog responses
- guard the Sigil play view against missing catalog entries and render a safe empty state
- add a muted helper style for Sigil screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f262bf63fc832f941ffa79d8d8c162