### PR TITLE
Handle Sigil & Syntax catalog data safely

### DIFF
--- a/src/lib/safe.ts
+++ b/src/lib/safe.ts
@@ -1,0 +1,31 @@
+// src/lib/safe.ts
+export type Any = any;
+
+export function asArray(x: Any): Any[] {
+  if (Array.isArray(x)) return x;
+  if (x && Array.isArray(x.items)) return x.items;
+  return [];
+}
+
+export function safeItems(x: Any): Any[] {
+  return asArray(x).filter(Boolean);
+}
+
+export function getId(x: Any, i: number): string {
+  const v = x?.id ?? x?.key ?? x?.slug ?? x?.name ?? x?.title;
+  return String(v ?? `item-${i}`);
+}
+
+export function getTitle(x: Any): string {
+  const v = x?.title ?? x?.name ?? x?.label ?? x?.heading;
+  return String(v ?? 'Untitled');
+}
+
+export function getType(x: Any): string {
+  return String(x?.type ?? 'lesson');
+}
+
+export function getLevel(x: Any): number {
+  const n = Number(x?.level);
+  return Number.isFinite(n) && n > 0 ? n : 1;
+}


### PR DESCRIPTION
## Summary
- add safe catalog helper utilities to normalize ids, titles, types, and levels
- update the Sigil & Syntax game page to use the helpers and gracefully handle missing catalog entries

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f266ad4470832f82652c3483a88bff