### PR TITLE
Allow dev mode with small content and fallback sigil catalog

### DIFF
--- a/src/data/loadAllPacksSafe.ts
+++ b/src/data/loadAllPacksSafe.ts
@@ -120,14 +120,18 @@ export function reportPackHealth(packs: Pack[], report: string[]): void {
   console.log("TOTAL ENTRIES:", total);
 }
 
-export function assertMinimum(total: number, min: number): void {
-  if (total < min) {
-    const msg = [
-      `Not enough entries: have ${total}, need at least ${min}.`,
-      '• Make sure your JSON packs are in /src/labeled-data and end with ".json".',
-      '• Only arrays or { entries: [...] } are accepted.',
-      '• Use "npm i zod" and our validator to drop bad rows safely.',
-    ].join("\n");
+export function assertMinimum(count: number): void {
+  const MIN = import.meta.env.DEV ? 1 : 2000;
+  if (count < MIN) {
+    const msg =
+      `Not enough entries: have ${count}, need at least ${MIN}.` +
+      (import.meta.env.DEV
+        ? ` (DEV mode: allowed, continuing with small pack.)`
+        : `\n• Make sure your JSON packs are in /src/labeled-data and end with ".json".\n• Only arrays or { entries: [...] } are accepted.\n• Use "npm i zod" and our validator to drop bad rows safely.`);
+    if (import.meta.env.DEV) {
+      console.warn('Word pack health report (dev):', msg);
+      return;
+    }
     throw new Error(msg);
   }
 }

--- a/src/data/sigilCatalog.json
+++ b/src/data/sigilCatalog.json
@@ -1,0 +1,10 @@
+{
+  "items": [
+    { "id": "clause-001", "title": "Independent vs Dependent Clause", "level": 1, "type": "lesson" },
+    { "id": "punct-001",  "title": "Comma Splices: Cut or Join?",     "level": 1, "type": "drill" },
+    { "id": "device-001", "title": "Metaphor vs Simile",               "level": 1, "type": "drill" },
+    { "id": "pacing-001", "title": "Quick Cuts (Trim & Swap)",         "level": 1, "type": "drill" },
+    { "id": "dialog-001", "title": "Tag, Beat, or Action?",            "level": 1, "type": "lesson" },
+    { "id": "end-001",    "title": "Scene Enders: Button vs Fade",     "level": 1, "type": "lesson" }
+  ]
+}

--- a/src/lib/loadSigil.ts
+++ b/src/lib/loadSigil.ts
@@ -46,11 +46,11 @@ export async function loadSigilCatalog(apiBase:string): Promise<{items:SigilItem
 
   // 2) Local candidates (common names you’ve used)
   const candidates = [
+    '/src/data/sigilCatalog.json',
     '/src/games/sigilSyntaxItems.ts',
     '/src/games/sigilSyntaxItems.tsx',
     '/src/games/sigil/index.ts',
     '/src/data/sigilSyntaxItems.json',
-    '/src/data/sigilCatalog.json',
     '/src/game thingss/sigil/catalog.json',      // your phrasing suggests this path
     '/src/game thingss/sigil/index.ts',          // fallback
   ];

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,9 +20,13 @@ if (import.meta.env.DEV) {
     try {
       const { packs, report, total } = await loadAllPacksSafe();
       reportPackHealth(packs, report);
-      assertMinimum(total, 2000);
+      assertMinimum(total);
     } catch (error) {
-      console.error('Failed to load word pack health report:', error);
+      if (import.meta.env.DEV) {
+        console.warn('Continuing without full word pack (dev):', error);
+      } else {
+        throw error;
+      }
     }
   })();
 }

--- a/src/pages/SigilSyntaxGame.tsx
+++ b/src/pages/SigilSyntaxGame.tsx
@@ -11,6 +11,8 @@ export default function SigilSyntaxGame() {
   const [source, setSource] = useState<string>("loading");
   const [sample, setSample] = useState<any>(null);
   const [loading, setLoading] = useState(true);
+  const debugEnabled =
+    typeof window !== "undefined" && new URLSearchParams(window.location.search).get("debug") === "1";
 
   useEffect(() => {
     let alive = true;
@@ -33,6 +35,14 @@ export default function SigilSyntaxGame() {
       <h1>Sigil &amp; Syntax</h1>
       <DebugPanel source={source} count={items.length} sample={sample} apiBase={apiBase ?? ""} />
 
+      {debugEnabled && (
+        <div className="surface" style={{ padding: 8, margin: "8px 0" }}>
+          <small>
+            Sigil data source: <code>{source}</code>
+          </small>
+        </div>
+      )}
+
       {loading && <div className="surface" style={{ padding: "12px" }}>Loading…</div>}
 
       {!loading && items.length === 0 && (
@@ -45,10 +55,10 @@ export default function SigilSyntaxGame() {
       {items.length > 0 && (
         <div className="grid">
           {items.map((it, i) => (
-            <article key={it.id || `item-${i}`} className="card" style={{ padding: "12px" }}>
-              <h3 style={{ margin: 0 }}>{it.title || "Untitled"}</h3>
+            <article key={it?.id ?? `item-${i}`} className="card" style={{ padding: "12px" }}>
+              <h3 style={{ margin: 0 }}>{it?.title ?? "Untitled"}</h3>
               <div className="muted" style={{ fontSize: 12 }}>
-                {(it.type || "lesson")} • {it.level ? `L${it.level}` : "L1"}
+                {(it?.type ?? "lesson")} • L{it?.level ?? 1}
               </div>
               <footer style={{ marginTop: 8 }}>
                 <button className="btn btn-primary">Play</button>


### PR DESCRIPTION
## Summary
- relax the word pack health gate in development while keeping production limits
- add a local sigil catalog JSON and serve it (or a static fallback) from the backend when the DB is unavailable
- make the sigil catalog loader and UI resilient to missing data and surface the active data source in debug mode

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f26d2818cc832f97d431bab03ce860