### PR TITLE
Fix Sigil catalog loader fallbacks

### DIFF
--- a/public/sigilCatalog.json
+++ b/public/sigilCatalog.json
@@ -1,0 +1,7 @@
+{
+  "items": [
+    { "id": "clause-001", "title": "Independent vs Dependent Clause", "level": 1, "type": "lesson" },
+    { "id": "punct-001",  "title": "Comma Splices: Cut or Join?",     "level": 1, "type": "drill"  },
+    { "id": "device-001", "title": "Metaphor vs Simile",               "level": 1, "type": "drill"  }
+  ]
+}

--- a/server/index.js
+++ b/server/index.js
@@ -2,8 +2,6 @@
 import express from 'express'
 import cors from 'cors'
 import cookieParser from 'cookie-parser'
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
 
 // Sigil content loader (reads the cached bundle)
 import {
@@ -32,29 +30,26 @@ app.get('/__ping', (req, res) => {
   res.json({ ok: true, path: req.path, origin: req.headers.origin || null })
 })
 
-// --- Sigil_&_Syntax API
-app.get('/_debug/sigil', (_req, res) => res.json(getSigilDebug()))
-
+// Minimal /sigil/catalog that never 500s in dev.
 app.get('/sigil/catalog', (_req, res) => {
   try {
-    const p = join(process.cwd(), 'src', 'data', 'sigilCatalog.json')
-    let payload
-    try {
-      payload = JSON.parse(readFileSync(p, 'utf8'))
-    } catch {
-      payload = {
-        items: [
-          { id: 'fallback-001', title: 'Sigil Welcome', level: 1, type: 'lesson' }
-        ]
-      }
+    // TODO: replace with real data later
+    const payload = {
+      items: [
+        { id: 'clause-001', title: 'Independent vs Dependent Clause', level: 1, type: 'lesson' },
+        { id: 'punct-001',  title: 'Comma Splices: Cut or Join?',     level: 1, type: 'drill'  },
+        { id: 'device-001', title: 'Metaphor vs Simile',               level: 1, type: 'drill'  }
+      ]
     }
-    res.setHeader('Content-Type', 'application/json')
     res.status(200).json(payload)
   } catch (e) {
     console.error('catalog error', e)
-    res.status(200).json({ items: [] })
+    res.status(200).json({ items: [] }) // never throw in dev
   }
 })
+
+// --- Sigil_&_Syntax API
+app.get('/_debug/sigil', (_req, res) => res.json(getSigilDebug()))
 
 app.get('/sigil/game/:id', (req, res) => {
   const it = getSigilItem(req.params.id)

--- a/src/lib/loadSigil.ts
+++ b/src/lib/loadSigil.ts
@@ -1,65 +1,52 @@
 // src/lib/loadSigil.ts
-// Attempts, in order:
-// 1) fetch(`${apiBase}/sigil/catalog`)
-// 2) dynamic import of likely local sources (ts/json) without breaking the build if missing
-// 3) returns a normalized array of items: { id, title, level?, type? }
-
 export type SigilItem = { id: string; title: string; level?: number; type?: string };
 
-function pick<T=any>(o:any, keys:string[]): T | undefined {
-  if (!o) return undefined as any;
-  for (const k of keys) if (k in o) return o[k];
-  return undefined as any;
-}
+const normalize = (input: any): SigilItem[] => {
+  const arr = Array.isArray(input) ? input : (input?.items ?? []);
+  if (!Array.isArray(arr)) return [];
+  return arr.filter(Boolean).map((it: any, i: number) => ({
+    id: String(it?.id ?? it?.slug ?? it?.key ?? `item-${i}`),
+    title: String(it?.title ?? it?.name ?? it?.label ?? 'Untitled'),
+    level: Number.isFinite(Number(it?.level)) ? Number(it.level) : undefined,
+    type: typeof it?.type === 'string' ? it.type : undefined,
+  }));
+};
 
-function coerceItems(input:any): SigilItem[] {
-  const root = Array.isArray(input) ? input
-    : pick<any[]>(input, ['items','data','catalog','lessons','entries']) ?? [];
-  if (!Array.isArray(root)) return [];
-  return root.filter(Boolean).map((it:any, i:number): SigilItem => {
-    const id    = String(pick(it, ['id','slug','key','uid','code','name','title']) ?? `item-${i}`);
-    const title = String(pick(it, ['title','name','label','heading','text']) ?? 'Untitled');
-    const lvl   = Number(pick(it, ['level','lvl','tier']));
-    const typ   = pick<string>(it, ['type','kind','category']) ?? undefined;
-    return { id, title, level: Number.isFinite(lvl) ? lvl : undefined, type: typ };
-  });
-}
+export async function loadSigilCatalog(apiBase: string) {
+  // 1) API first
+  try {
+    const r = await fetch(`${apiBase}/sigil/catalog`, { headers: { Accept: 'application/json' }});
+    if (r.ok) {
+      const json = await r.json();
+      const items = normalize(json);
+      if (items.length) return { items, source: 'api:/sigil/catalog' };
+    }
+  } catch {}
 
-// Try dynamic import safely (Vite will tree-shake if missing)
-async function tryImport(path:string) {
-  try { return await import(/* @vite-ignore */ path); }
-  catch { return undefined; }
-}
+  // 2) public/ fallback (fetchable file)
+  try {
+    const base = import.meta.env.BASE_URL || '/';
+    const r = await fetch(`${base}sigilCatalog.json`, { headers: { Accept: 'application/json' }});
+    if (r.ok) {
+      const json = await r.json();
+      const items = normalize(json);
+      if (items.length) return { items, source: 'public:/sigilCatalog.json' };
+    }
+  } catch {}
 
-export async function loadSigilCatalog(apiBase:string): Promise<{items:SigilItem[], source:string, raw:any}> {
-  // 1) API
-  if (apiBase !== undefined) {
-    try {
-      const res = await fetch(`${apiBase}/sigil/catalog`, { headers: { Accept: 'application/json' }});
-      if (res.ok) {
-        const json = await res.json();
-        const items = coerceItems(json);
-        if (items.length) return { items, source: 'api:/sigil/catalog', raw: json };
-      }
-    } catch {}
+  // 3) src/ fallbacks (import, not fetch)
+  const candidates = import.meta.glob([
+    '/src/data/**/*sigil*.*',
+    '/src/games/**/*sigil*.*',
+    '/src/**/*sigilCatalog*.*'
+  ], { eager: true });
+
+  for (const [path, mod] of Object.entries(candidates)) {
+    const raw = (mod as any)?.default ?? (mod as any)?.items ?? mod;
+    const items = normalize(raw);
+    if (items.length) return { items, source: `src-import:${path}` };
   }
 
-  // 2) Local candidates (common names you’ve used)
-  const candidates = [
-    '/src/data/sigilCatalog.json',
-    '/src/games/sigilSyntaxItems.ts',
-    '/src/games/sigilSyntaxItems.tsx',
-    '/src/games/sigil/index.ts',
-    '/src/data/sigilSyntaxItems.json',
-    '/src/game thingss/sigil/catalog.json',      // your phrasing suggests this path
-    '/src/game thingss/sigil/index.ts',          // fallback
-  ];
-  for (const p of candidates) {
-    const mod = await tryImport(p);
-    const raw = mod?.default ?? mod?.items ?? mod;
-    const items = coerceItems(raw);
-    if (items.length) return { items, source: `local:${p}`, raw };
-  }
-
-  return { items: [], source: 'none', raw: null };
+  // last resort
+  return { items: [], source: 'none' };
 }

--- a/src/pages/SigilSyntaxGame.tsx
+++ b/src/pages/SigilSyntaxGame.tsx
@@ -22,7 +22,7 @@ export default function SigilSyntaxGame() {
       if (!alive) return;
       setItems(res.items);
       setSource(res.source);
-      setSample(res.items[0] ?? res.raw);
+      setSample(res.items[0] ?? null);
       setLoading(false);
     })();
     return () => {
@@ -43,16 +43,16 @@ export default function SigilSyntaxGame() {
         </div>
       )}
 
-      {loading && <div className="surface" style={{ padding: "12px" }}>Loading…</div>}
-
-      {!loading && items.length === 0 && (
+      {loading ? (
+        <div className="surface" style={{ padding: "12px" }}>Loading…</div>
+      ) : items.length === 0 ? (
         <div className="surface" style={{ padding: "12px" }}>
-          <strong>No lessons found</strong>
-          <div className="muted">Source tried: {source}</div>
+          <div className="muted">No lessons yet.</div>
+          <div className="muted" style={{ marginTop: 4 }}>
+            Source tried: <code>{source}</code>
+          </div>
         </div>
-      )}
-
-      {items.length > 0 && (
+      ) : (
         <div className="grid">
           {items.map((it, i) => (
             <article key={it?.id ?? `item-${i}`} className="card" style={{ padding: "12px" }}>


### PR DESCRIPTION
## Summary
- ensure the /sigil/catalog endpoint always returns placeholder data instead of throwing in development
- add a public sigilCatalog.json file and update the loader to fall back to API, public asset, or local source imports
- guard the Sigil page rendering so it handles empty catalogs without crashing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f272cd8980832fa6416bdade785cff