### PR TITLE
Spin up Sigil JSONL API service

### DIFF
--- a/app/src/lib/gameAdapters/sources.jsx
+++ b/app/src/lib/gameAdapters/sources.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { safeFetchJSON } from '@/lib/apiBase'
 import { toCatalogItems } from '@/lib/normalize'
+import { getLesson } from '@/services/sigilLesson'
 
 export function adaptToSpec(it){
   if (!it) return null
@@ -36,12 +37,45 @@ export async function listGoodIds(){
 
 // Sigil_&_Syntax
 export async function fetchSigilItem(id){
-  const j = await safeFetchJSON(`/sigil/game/${encodeURIComponent(id)}`)
-  return adaptToSpec(j)
+  const lesson = await getLesson(id)
+  if (!lesson) return null
+  const prompt_html = lessonToHtml(lesson)
+  return adaptToSpec({
+    id: lesson.id,
+    title: lesson.title,
+    prompt_html,
+    input_type: 'write',
+    min_words: 30,
+  })
 }
 export async function firstSigilId(){
   const j = await safeFetchJSON('/sigil/catalog')
   const items = toCatalogItems(j)
   return j?.first || (items[0]?.id ?? null)
+}
+
+function escapeHtml(str = '') {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function blockHtml(text = '') {
+  const safe = escapeHtml(text)
+  return safe
+    .split(/\n\s*\n/)
+    .map(block => `<p>${block.replace(/\n/g, '<br />')}</p>`)
+    .join('')
+}
+
+function lessonToHtml(lesson) {
+  if (!lesson) return ''
+  const parts = []
+  if (lesson.intro) parts.push(blockHtml(lesson.intro))
+  if (lesson.prompt) parts.push(blockHtml(lesson.prompt))
+  return parts.join('')
 }
 

--- a/app/src/services/sigilLesson.ts
+++ b/app/src/services/sigilLesson.ts
@@ -1,0 +1,150 @@
+export type Lesson = { id: string; title: string; intro: string; prompt: string };
+
+function splitIntroPrompt(text: string): { intro: string; prompt: string } {
+  const t = (text ?? "").toString();
+  const marker = /(?:^|\n)\s*Before we start:/i;
+  const m = t.search(marker);
+  if (m >= 0) {
+    return { intro: t.slice(0, m).trim(), prompt: t.slice(m).trim() };
+  }
+  const parts = t.split(/\n\s*\n/);
+  if (parts.length >= 2) {
+    const prompt = parts.pop()!.trim();
+    const intro = parts.join("\n\n").trim();
+    return { intro, prompt };
+  }
+  return { intro: t.trim(), prompt: "" };
+}
+
+async function tryServer(wantId?: string): Promise<Lesson | null> {
+  try {
+    let lessonId = wantId?.trim();
+    if (!lessonId) {
+      const cat = await fetch("/sigil/catalog", { headers: { Accept: "application/json" } });
+      if (!cat.ok) return null;
+      const cjson = await cat.json();
+      const first = Array.isArray(cjson?.items) ? cjson.items[0] : null;
+      if (!first?.id) return null;
+      lessonId = String(first.id);
+    }
+    const r = await fetch(`/sigil/lesson/${encodeURIComponent(lessonId)}`, {
+      headers: { Accept: "application/json" },
+    });
+    if (!r.ok) return null;
+    const l = await r.json();
+    if (l?.id && (l.intro ?? l.prompt) !== undefined) {
+      return {
+        id: String(l.id),
+        title: String(l.title ?? "Untitled"),
+        intro: String(l.intro ?? ""),
+        prompt: String(l.prompt ?? ""),
+      };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+const jsonlRawImport = import.meta.glob("/labeled data/tweetrunk_renumbered.jsonl", { as: "raw", eager: true });
+
+function parseJSONL(raw: string): any[] {
+  const out: any[] = [];
+  if (!raw) return out;
+  for (const ln of raw.split(/\r?\n/)) {
+    const s = ln.trim();
+    if (!s || s.startsWith("//")) continue;
+    try {
+      out.push(JSON.parse(s.replace(/,?$/, "")));
+    } catch {
+      // ignore malformed rows
+    }
+  }
+  return out;
+}
+
+function rowToLesson(row: any, fallbackIndex: number): Lesson {
+  const id = String(
+    row?.new_id ??
+      row?.original_id ??
+      row?.id ??
+      row?.slug ??
+      row?.key ??
+      row?.uid ??
+      row?.code ??
+      row?.hash ??
+      row?.guid ??
+      `item-${fallbackIndex}`,
+  );
+  const title = String(
+    row?.title ??
+      row?.heading ??
+      row?.name ??
+      row?.label ??
+      row?.prompt ??
+      row?.text ??
+      row?.tweet ??
+      row?.tweet_text ??
+      row?.full_text ??
+      row?.content ??
+      row?.body ??
+      row?.message ??
+      row?.excerpt ??
+      row?.line ??
+      row?.sentence ??
+      `Untitled ${id}`,
+  );
+  const text = (row?.text ?? "").toString();
+  const { intro, prompt } = splitIntroPrompt(text);
+  return { id, title, intro, prompt };
+}
+
+function fromRawRows(rows: any[], wantId?: string): Lesson | null {
+  if (!rows.length) return null;
+  if (wantId) {
+    const match = rows.find((row, index) => {
+      const lessonId = String(
+        row?.new_id ??
+          row?.original_id ??
+          row?.id ??
+          row?.slug ??
+          row?.key ??
+          row?.uid ??
+          row?.code ??
+          row?.hash ??
+          row?.guid ??
+          `item-${index}`,
+      );
+      return lessonId === wantId;
+    });
+    if (match) {
+      const index = rows.indexOf(match);
+      return rowToLesson(match, index >= 0 ? index : 0);
+    }
+  }
+  return rowToLesson(rows[0], 0);
+}
+
+async function getLessonFromRaw(wantId?: string): Promise<Lesson | null> {
+  const mod = Object.values(jsonlRawImport)[0] as unknown as string | undefined;
+  if (!mod) return null;
+  const rows = parseJSONL(mod);
+  const lesson = fromRawRows(rows, wantId);
+  return lesson ?? null;
+}
+
+export async function getFirstLesson(): Promise<Lesson | null> {
+  const fromServer = await tryServer();
+  if (fromServer) return fromServer;
+  return getLessonFromRaw();
+}
+
+export async function getLesson(id?: string): Promise<Lesson | null> {
+  const wantId = id?.trim();
+  if (!wantId) {
+    return getFirstLesson();
+  }
+  const fromServer = await tryServer(wantId);
+  if (fromServer) return fromServer;
+  return getLessonFromRaw(wantId);
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,75 +1,73 @@
 // server/index.js
-import express from 'express'
-import cors from 'cors'
-import cookieParser from 'cookie-parser'
-import { fileURLToPath } from 'url'
+import express from 'express';
+import cors from 'cors';
+import { createReadStream, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import * as readline from 'node:readline';
 
-// Sigil content loader (reads the cached bundle)
-import {
-  getSigilItem,
-  getSigilDebug,
-} from './sigil-syntax/content.js'
-import { installSigilCatalogRoute } from './sigilCatalog'
+const app = express();
+app.use(cors());
 
-const app = express()
+const FILE = resolve(process.cwd(), 'labeled data', 'tweetrunk_renumbered.jsonl'); // <-- exact path with space
 
-app.use((req, res, next) => {
-  // allow all for testing; tighten later if needed
-  res.header('Access-Control-Allow-Origin', '*')
-  res.header('Access-Control-Allow-Methods', 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS')
-  res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With')
-  if (req.method === 'OPTIONS') return res.sendStatus(204)
-  next()
-})
-app.use(cors({ origin: true, credentials: false }))
-
-app.use(express.json({ limit: '1mb' }))
-app.use(cookieParser())
-
-// --- DEV LOGGING ---
-app.use((req, res, next) => {
-  console.log('[API]', req.method, req.url)
-  next()
-})
-
-// --- HEALTH ---
-app.get('/health', (req, res) => res.status(200).json({ ok: true, pid: process.pid }))
-
-installSigilCatalogRoute(app)
-
-// --- DEBUG: show request headers & env
-app.get('/_debug/api', (req, res) => {
-  res.json({
-    headers: req.headers,
-    env: {
-      NODE_ENV: process.env.NODE_ENV,
-      PORT: process.env.PORT,
-    },
-    routes: ['/health', '/sigil/catalog', '/_debug/api'],
-  })
-})
-
-// --- Sigil_&_Syntax API
-app.get('/_debug/sigil', (_req, res) => res.json(getSigilDebug()))
-
-app.get('/sigil/game/:id', (req, res) => {
-  const it = getSigilItem(req.params.id)
-  if (!it) return res.status(404).json({ error: 'not_found', id: req.params.id })
-  res.json(it)
-})
-
-// --- 404 and error handlers
-app.use((req, res) => res.status(404).json({ error: 'not_found', path: req.path }))
-app.use((err, _req, res, next) => {
-  if (res.headersSent) return next(err)
-  res.status(500).json({ error: 'server_error', message: String(err?.message || err) })
-})
-const isEntrypoint = fileURLToPath(import.meta.url) === process.argv[1]
-let server
-
-if (isEntrypoint && !server?.listening && typeof app.listen === 'function') {
-  const PORT = process.env.PORT || 3001
-  server = app.listen(PORT, () => console.log(`[API] listening on http://localhost:${PORT}`))
+function splitIntroPrompt(text) {
+  const t = String(text || '');
+  const m = t.search(/(?:^|\n)\s*Before we start:/i);
+  if (m >= 0) return { intro: t.slice(0, m).trim(), prompt: t.slice(m).trim() };
+  const parts = t.split(/\n\s*\n/);
+  if (parts.length >= 2) return { intro: parts.slice(0, -1).join('\n\n').trim(), prompt: parts.at(-1).trim() };
+  return { intro: t.trim(), prompt: '' };
 }
 
-export default app
+async function* readJSONL(path) {
+  if (!existsSync(path)) { console.warn('[Sigil] JSONL not found:', path); return; }
+  const rl = readline.createInterface({ input: createReadStream(path), crlfDelay: Infinity });
+  for await (const ln of rl) {
+    const s = ln.trim();
+    if (!s || s.startsWith('//')) continue;
+    try { yield JSON.parse(s.replace(/,?$/, '')); } catch {}
+  }
+}
+
+app.get('/health', (_req, res) => res.json({ ok: true }));
+
+app.get('/sigil/catalog', async (_req, res) => {
+  try {
+    const items = [];
+    let i = 0;
+    for await (const row of readJSONL(FILE)) {
+      const id = String(row?.new_id ?? row?.original_id ?? `item-${i}`);
+      const title = String(row?.title ?? (row?.text ?? '').toString().slice(0,140) || `Untitled ${id}`);
+      items.push({ id, title });
+      if (++i >= 500) break;
+    }
+    res.status(200).json({ items });
+  } catch (e) {
+    console.error('[Sigil] /sigil/catalog error', e);
+    res.status(200).json({ items: [] });
+  }
+});
+
+app.get('/sigil/lesson/:id', async (req, res) => {
+  const want = String(req.params.id);
+  try {
+    let i = 0;
+    for await (const row of readJSONL(FILE)) {
+      const id = String(row?.new_id ?? row?.original_id ?? `item-${i}`);
+      if (id === want) {
+        const title = String(row?.title ?? (row?.text ?? '').toString().split('\n')[0] ?? `Untitled ${id}`);
+        const { intro, prompt } = splitIntroPrompt((row?.text ?? '').toString());
+        return res.status(200).json({ id, title, intro, prompt });
+      }
+      i++;
+    }
+    res.status(404).json({ error: 'lesson_not_found', id: want });
+  } catch (e) {
+    console.error('[Sigil] /sigil/lesson error', e);
+    res.status(200).json({ error: 'read_error' });
+  }
+});
+
+const PORT = process.env.PORT || 3001;
+const HOST = '0.0.0.0'; // important for Codespaces
+app.listen(PORT, HOST, () => console.log(`[API] listening on http://${HOST}:${PORT}`));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
         secure: false,
       },
       '/health': {
-        target: process.env.VITE_DEV_API || 'http://localhost:3001',
+        target: 'http://localhost:3001',
         changeOrigin: true,
         secure: false,
       },


### PR DESCRIPTION
## Summary
- replace the existing Express entrypoint with the minimal Sigil JSONL API that serves catalog and lesson endpoints
- expose a health check and listen on 0.0.0.0 so Codespaces can reach the service
- ensure the Vite dev proxy targets the new backend host directly

## Testing
- _not run_

------
https://chatgpt.com/codex/tasks/task_e_68f3f1fd1f24832f89e4f34024bf4b0b