### PR TITLE
Add smoke debug page and Playwright smoke coverage

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build && node scripts/copy404.mjs",
-    "preview": "vite preview --port 4173 --strictPort"
+    "preview": "vite preview --port 5173",
+    "test:smoke": "playwright test app/tests/smoke.spec.ts",
+    "shots": "playwright test app/tests/smoke.spec.ts --grep screenshot --update-snapshots"
   },
   "dependencies": {
     "clsx": "^2.1.1",
@@ -17,6 +19,7 @@
   "devDependencies": {
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.1",
+    "@playwright/test": "^1.50.0",
     "@vitejs/plugin-react": "^5.0.4",
     "vite": "^7.1.9"
   }

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -2,11 +2,13 @@ import { Routes, Route } from 'react-router-dom'
 import Home from '@/pages/Home.jsx'
 import SigilSyntax from '@/pages/SigilSyntax.jsx'
 import SigilRunner from '@/pages/SigilRunner.jsx'
+import Smoke from '@/pages/Smoke.tsx'
 
 export default function App(){
   return (
     <Routes>
       <Route path="/" element={<Home />} />
+      <Route path="/_ui/smoke" element={<Smoke />} />
       <Route path="/sigil" element={<SigilSyntax />} />
       <Route path="/sigil/:id" element={<SigilRunner />} />
     </Routes>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { HashRouter, Routes, Route } from "react-router-dom";
 import GameRoot from "./pages/GameRoot"; // adjust path if needed
+import Smoke from "./pages/Smoke";
 
 const modules = import.meta.glob(
     [
@@ -79,6 +80,7 @@ export function App() {
         <HashRouter>
             <Routes>
                 <Route path="/" element={<GameRoot />} />
+                <Route path="/_ui/smoke" element={<Smoke />} />
                 <Route path="*" element={<GameRoot />} />
             </Routes>
         </HashRouter>

--- a/app/src/lib/apiBase.ts
+++ b/app/src/lib/apiBase.ts
@@ -1,62 +1,38 @@
-const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '');
-const ensureLeadingSlash = (value: string) => {
-  if (!value) return '';
-  return value.startsWith('/') ? value : `/${value}`;
-};
+// Single source of truth for API base and helpers.
+// Dev uses Vite proxy (''), prod uses VITE_ABS_API if set.
 
-const resolveFromEnv = () => {
-  const raw = (import.meta.env.VITE_DEV_API as string | undefined)?.trim();
-  return raw ? trimTrailingSlash(raw) : '';
-};
+const ABS = import.meta.env.VITE_ABS_API?.trim()?.replace(/\/$/, '');
+export const apiBase: string = import.meta.env.DEV ? '' : (ABS || '');
 
-const resolveCodespacesBase = () => {
-  if (typeof window === 'undefined') return '';
-  const { origin, host } = window.location;
-  if (!host?.includes('.app.github.dev')) return '';
-  return trimTrailingSlash(origin.replace(/-\d+\.app\.github.dev$/, '-3001.app.github.dev'));
-};
-
-const ABS = (import.meta.env.VITE_ABS_API as string | undefined)?.trim();
-export const apiBase = import.meta.env.DEV ? '' : (ABS ? ABS.replace(/\/$/, '') : '');
-
-/**
- * Pick the backend base URL in dev (env > Codespaces guess > relative).
- */
-export const api = (() => {
-  const base = resolveFromEnv() || resolveCodespacesBase() || '';
-  return (path: string) => {
-    if (!path.startsWith('/')) path = '/' + path;
-    // In dev, return relative so Vite proxy handles it; in prod prepend ABS if set
-    return (import.meta.env.DEV ? '' : (ABS ? ABS.replace(/\/$/, '') : '')) + (base && !import.meta.env.DEV ? base + path : path);
-  };
-})();
-
-/** Helper that fetches JSON and throws a helpful error on non-JSON or non-OK responses */
-export async function safeFetchJSON(input: RequestInfo | string, init?: RequestInit): Promise<any> {
-  const url = typeof input === 'string' ? input : input;
-  const r = await fetch(url, init);
-  if (!r.ok) throw new Error(`HTTP ${r.status} for ${typeof url === 'string' ? url : ''}`);
-  const ct = r.headers.get('content-type') || '';
-  if (!ct.includes('application/json')) throw new Error(`Invalid content-type ${ct}`);
-  return r.json();
+// Compose a full URL from a path
+function toUrl(path: string): string {
+  const p = path.startsWith('/') ? path : `/${path}`;
+  return `${apiBase}${p}`;
 }
 
-// example usage in a component
-import { api, safeFetchJSON } from '@/lib/apiBase';
-
-useEffect(() => {
-  safeFetchJSON(api('/sigil/catalog'))
-    .then(j => { /* handle JSON */ })
-    .catch(e => { /* handle error */ });
-}, []);
-
-// one-time console breadcrumb (useful in dev to verify the chosen base)
-if (typeof window !== 'undefined') {
-  const marker = '__PFTP_API_BASE_LOGGED__';
-  const scope = window as unknown as Record<string, boolean>;
-  if (!scope[marker]) {
-    scope[marker] = true;
-    const label = apiBase || '(relative via Vite proxy)';
-    console.log('[apiBase]', label);
+// Safe JSON fetch
+export async function safeFetchJSON<T = any>(
+  path: string,
+  init?: RequestInit
+): Promise<T> {
+  const url = toUrl(path);
+  const headers = new Headers({ Accept: 'application/json' });
+  if (init?.headers) {
+    const extra = new Headers(init.headers as HeadersInit);
+    extra.forEach((value, key) => headers.set(key, value));
   }
+  const res = await fetch(url, {
+    ...init,
+    headers,
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+  return res.json() as Promise<T>;
 }
+
+// Lightweight helper object
+export const api = {
+  getJSON: safeFetchJSON,
+  get: safeFetchJSON,
+};
+
+// NOTE: No example usage or imports in this file.

--- a/app/src/pages/SigilSyntax.jsx
+++ b/app/src/pages/SigilSyntax.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { api, apiBase, safeFetchJSON } from '@/lib/apiBase'
+import { apiBase, safeFetchJSON } from '@/lib/apiBase'
 import { useNavigate } from 'react-router-dom'
 import { snapAndDownload } from '@/lib/snapshot.js'
 import { toCatalogItems } from '@/lib/normalize'
@@ -13,14 +13,15 @@ export default function SigilSyntax(){
 
   useEffect(() => {
     const base = apiBase || '(relative)'
-    const url = api('/sigil/catalog')
+    const path = '/sigil/catalog'
+    const url = `${apiBase}${path}`
     setDebug({ base, tried: url })
     let alive = true
     ;(async () => {
       try {
         setLoading(true)
         setError('')
-        const json = await safeFetchJSON(url)
+        const json = await safeFetchJSON(path)
         if (alive) setRaw(json)
       } catch (e) {
         console.warn('Catalog load failed:', e?.message || e)

--- a/app/src/pages/Smoke.tsx
+++ b/app/src/pages/Smoke.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import { api } from '@/lib/apiBase';
+
+export default function Smoke() {
+  const [out, setOut] = useState<any>({});
+
+  useEffect(() => {
+    (async () => {
+      const result: any = { env: {
+        DEV: import.meta.env.DEV,
+        BASE_URL: import.meta.env.BASE_URL,
+        VITE_ABS_API: import.meta.env.VITE_ABS_API
+      }};
+      try {
+        result.health = await api.getJSON('/health');
+      } catch (e:any) {
+        result.health = { error: String(e) };
+      }
+      try {
+        const cat = await api.getJSON('/sigil/catalog');
+        result.catalog = { ok: true, count: Array.isArray(cat?.items) ? cat.items.length : 0 };
+        result.firstId = cat?.items?.[0]?.id ?? null;
+      } catch (e:any) {
+        result.catalog = { error: String(e) };
+      }
+      setOut(result);
+    })();
+  }, []);
+
+  return (
+    <div style={{ padding: 16 }}>
+      <h1>Smoke Debug</h1>
+      <pre style={{ whiteSpace:'pre-wrap' }}>{JSON.stringify(out, null, 2)}</pre>
+    </div>
+  );
+}

--- a/app/src/sigil-syntax/GameRunner.jsx
+++ b/app/src/sigil-syntax/GameRunner.jsx
@@ -7,7 +7,7 @@ import LevelUpModal from '@sigil/LevelUpModal'
 import BadgeStrip from '@sigil/BadgeStrip'
 import StyleReportBox from '@sigil/StyleReportBox'
 import { toSpec } from '@/lib/gameAdapter.js'
-import { api } from '@/lib/apiBase'
+import { safeFetchJSON } from '@/lib/apiBase'
 
 export default function GameRunner() {
     const { id } = useParams()
@@ -23,10 +23,9 @@ export default function GameRunner() {
 
     useEffect(() => {
         setErr(''); setFeedback([]); setPoints(0); setLevelUp(null); setNewBadges([]); setStyleReport(null); setStyleStatus('')
-        fetch(api(`/catalog/game/${id}`))
-            .then(r => r.ok ? r.json() : Promise.reject(r.status))
+        safeFetchJSON(`/catalog/game/${id}`)
             .then(setGame)
-            .catch(e => setErr(`Could not load game "${id}" (${e}).`))
+            .catch(e => setErr(`Could not load game "${id}" (${e?.message || e}).`))
     }, [id])
 
     const spec = game ? toSpec(game) : null
@@ -42,12 +41,11 @@ export default function GameRunner() {
         setFeedback(lines)
         // ask backend to award XP + badges using this attempt
         const payload = { user_id: 'local-user', item_id: game.id, response: r.response, score: r.score }
-        fetch(api('/api/submit'), {
+        safeFetchJSON('/api/submit', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload)
         })
-            .then(resp => resp.ok ? resp.json() : Promise.reject(resp.status))
             .then(data => {
                 setPoints(p => p + Math.round(r.score * 10))
                 if (data.levelUp) setLevelUp(data.levelUp)
@@ -59,12 +57,11 @@ export default function GameRunner() {
         if (game?.input_type === 'write' && textResponse && textResponse.trim()) {
             setStyleReport(null)
             setStyleStatus('Analyzing style…')
-            fetch(api('/style-report'), {
+            safeFetchJSON('/style-report', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ text: textResponse })
             })
-                .then(resp => resp.ok ? resp.json() : Promise.reject(resp.status))
                 .then(data => {
                     setStyleReport(data)
                     setStyleStatus('')

--- a/app/tests/smoke.spec.ts
+++ b/app/tests/smoke.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.PREVIEW_URL || 'http://localhost:5173';
+
+test('smoke: health and catalog', async ({ page }) => {
+  await page.goto(`${BASE}/_ui/smoke`, { waitUntil: 'networkidle' });
+  const pre = page.locator('pre');
+  await expect(pre).toContainText('"DEV": true', { timeout: 15000 });
+  await expect(pre).toContainText('"ok": true'); // health ok
+  // catalog exists or shows error; we at least want no crash:
+  await expect(pre).toBeVisible();
+});
+
+test('screenshot: /sigil', async ({ page }) => {
+  await page.goto(`${BASE}/`, { waitUntil: 'networkidle' });
+  // navigate via client routing to avoid deep-link preview 404s
+  await page.evaluate(() => {
+    window.history.pushState({}, '', '/sigil');
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  });
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(800); // settle
+  await page.screenshot({ path: `screenshots/sigil.png`, fullPage: true });
+});

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -2,19 +2,31 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'node:path'
 
-const proxyTargets = ['/sigil', '/goodword', '/cut', '/health', '/__diag', '/api', '/style-report', '/catalog']
+const baseProxyTarget = 'http://127.0.0.1:3001'
+const defaultProxy = {
+  '/sigil': { target: baseProxyTarget, changeOrigin: true, secure: false },
+  '/health': { target: baseProxyTarget, changeOrigin: true, secure: false },
+} as const
 
-const proxyConfig = process.env.VITE_DEV_API
-  ? Object.fromEntries(
-      proxyTargets.map((prefix) => [
-        prefix,
-        {
-          target: process.env.VITE_DEV_API,
-          changeOrigin: true,
-        },
-      ]),
-    )
-  : undefined
+const extraProxyTargets = ['/goodword', '/cut', '/__diag', '/api', '/style-report', '/catalog'] as const
+
+const proxyConfig = (() => {
+  const target = process.env.VITE_DEV_API?.trim()
+  if (!target) return { ...defaultProxy }
+
+  const entries = extraProxyTargets.map((prefix) => [
+    prefix,
+    {
+      target,
+      changeOrigin: true,
+    },
+  ])
+
+  return {
+    ...defaultProxy,
+    ...Object.fromEntries(entries),
+  }
+})()
 
 export default defineConfig({
   base: process.env.VITE_PAGES_BASE || '/',


### PR DESCRIPTION
## Summary
- replace the API base helper with a minimal export that centralizes base URL resolution and safe JSON fetch helpers
- update Sigil data loaders to use the new helper and add a Smoke debug page/route for quick backend verification
- point the Vite dev proxy at 127.0.0.1 and add Playwright smoke/screenshot coverage with supporting npm scripts

## Testing
- not run (Playwright package install is blocked in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f401233664832fb7f4319e90201c44