### PR TITLE
Simplify api helpers and align smoke route import

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { HashRouter, Routes, Route } from "react-router-dom";
 import GameRoot from "./pages/GameRoot"; // adjust path if needed
-import Smoke from "./pages/Smoke";
+import Smoke from "@/pages/Smoke";
 
 const modules = import.meta.glob(
     [

--- a/app/src/lib/apiBase.ts
+++ b/app/src/lib/apiBase.ts
@@ -16,14 +16,9 @@ export async function safeFetchJSON<T = any>(
   init?: RequestInit
 ): Promise<T> {
   const url = toUrl(path);
-  const headers = new Headers({ Accept: 'application/json' });
-  if (init?.headers) {
-    const extra = new Headers(init.headers as HeadersInit);
-    extra.forEach((value, key) => headers.set(key, value));
-  }
   const res = await fetch(url, {
+    headers: { Accept: 'application/json' },
     ...init,
-    headers,
   });
   if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
   return res.json() as Promise<T>;


### PR DESCRIPTION
## Summary
- simplify the shared api helper to rely on a straightforward Accept header and fetch usage
- update the Smoke debug page import to use the project alias

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f43147bb9c832fbcda006809b2928e