### PR TITLE
Add development CSP overrides for Sigil UI

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -27,6 +27,7 @@ if (process.env.NODE_ENV === 'production') {
     },
   }));
 } else {
+  // Dev: turn off CSP so Vite’s dev client can run
   app.use(helmet({
     contentSecurityPolicy: false,
   }));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,28 +2,58 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'node:path';
 
-export default defineConfig({
-  base: process.env.VITE_PAGES_BASE || '/',
-  plugins: [react()],
-  resolve: { alias: { '@': path.resolve(__dirname, 'src') } },
-  server: {
-    proxy: {
-      '/sigil': {
-        target: 'http://127.0.0.1:3001',
-        changeOrigin: true,
-        secure: false,
+export default defineConfig(({ mode }) => {
+  const isDev = mode !== 'production';
+
+  return {
+    base: process.env.VITE_PAGES_BASE || '/',
+    plugins: [react()],
+    resolve: { alias: { '@': path.resolve(__dirname, 'src') } },
+    server: {
+      proxy: {
+        '/sigil': {
+          target: 'http://127.0.0.1:3001',
+          changeOrigin: true,
+          secure: false,
+        },
+        '/health': {
+          target: 'http://127.0.0.1:3001',
+          changeOrigin: true,
+          secure: false,
+        },
+        '/_debug': {
+          target: process.env.VITE_DEV_API || 'http://127.0.0.1:3001',
+          changeOrigin: true,
+          secure: false,
+        },
       },
-      '/health': {
-        target: 'http://127.0.0.1:3001',
-        changeOrigin: true,
-        secure: false,
-      },
-      '/_debug': {
-        target: process.env.VITE_DEV_API || 'http://127.0.0.1:3001',
-        changeOrigin: true,
-        secure: false,
+      headers: isDev
+        ? {
+            'Content-Security-Policy': [
+              "default-src 'self' blob: data:",
+              "script-src 'self' 'unsafe-eval' blob: data:",
+              "style-src 'self' 'unsafe-inline' blob: data:",
+              "img-src 'self' data: blob:",
+              'connect-src *',
+              "font-src 'self' data:",
+              "frame-ancestors *",
+            ].join('; '),
+          }
+        : {},
+    },
+    preview: {
+      headers: {
+        'Content-Security-Policy': [
+          "default-src 'self' blob: data:",
+          "script-src 'self' blob: data:",
+          "style-src 'self' 'unsafe-inline' blob: data:",
+          "img-src 'self' data: blob:",
+          "connect-src 'self'",
+          "font-src 'self' data:",
+          "frame-ancestors 'self'",
+        ].join('; '),
       },
     },
-  },
-  build: { sourcemap: true },
+    build: { sourcemap: true },
+  };
 });


### PR DESCRIPTION
## Summary
- add development-time CSP headers to the Vite dev server while keeping stricter preview headers
- document disabling Helmet CSP in development so the Sigil SPA can load under CSP constraints

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f43cf708d4832fbe4268f45c23b572