### PR TITLE
Simplify Sigil submission memo handling

### DIFF
--- a/app/src/pages/SigilRunner.jsx
+++ b/app/src/pages/SigilRunner.jsx
@@ -86,7 +86,8 @@ export default function SigilRunner() {
   async function handleSubmit() {
     try {
       const rsp = await submitAttempt({ id, text, minWords: stats.min })
-      setRayMemo(rsp?.report?.memo || [])
+      const memo = rsp?.report?.memo
+      setRayMemo(Array.isArray(memo) ? memo : memo ? [String(memo)] : [])
       const tray = document.querySelector('.sigil-tray')
       tray?.scrollIntoView({ behavior: 'smooth', block: 'start' })
     } catch (e) {


### PR DESCRIPTION
## Summary
- normalize the memo returned from submitAttempt before updating the Ray Ray feedback so no modal logic is triggered

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f484c856ec832f9b9bb59b7637a1ec