### PR TITLE
Add report build pipeline and adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "cross-env": "^7.0.3",
         "eslint": "^9.37.0",
         "eslint-config-prettier": "^10.1.8",
+        "esbuild": "^0.24.0",
         "nodemon": "^3.1.9",
         "postcss": "^8.5.6",
         "prettier": "^3.6.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "emit:progression": "node tools/emit_progression_defaults.mjs",
     "emit:sigil:labeled": "node tools/build_sigil_from_labeled.mjs",
     "reattach:sigil": "node tools/reattach_sigil_ui.mjs",
+    "emit:reports": "node tools/compile_reports.mjs",
     "snap:preview": "cross-env VITE_PROD_API=https://animated-carnival-v4g77qwxgvv3p5p5-3001.app.github.dev npm run build --prefix app && npm run preview --prefix app",
     "snap:test": "playwright test -c app/playwright.config.ts"
   },
@@ -30,6 +31,7 @@
     "cross-env": "^7.0.3",
     "eslint": "^9.37.0",
     "eslint-config-prettier": "^10.1.8",
+    "esbuild": "^0.24.0",
     "nodemon": "^3.1.9",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",

--- a/server/index.js
+++ b/server/index.js
@@ -5,7 +5,7 @@ import helmet from 'helmet';
 import { createReadStream, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import * as readline from 'node:readline';
-import { analyzeAttempt } from './attempt/analyze.js'
+import { buildReport } from './report/index.js';
 
 const app = express();
 app.use(cors());
@@ -90,12 +90,16 @@ app.get('/sigil/lesson/:id', async (req, res) => {
 });
 
 // POST attempt analysis
-app.post('/attempt', express.json(), (req, res) => {
-  const { id, text, minWords } = req.body || {}
-  if (typeof text !== 'string') return res.status(400).json({ error: 'bad_request', message: 'text required' })
-  const report = analyzeAttempt(text, { minWords: Number(minWords || 30) })
-  res.json({ id: id || null, report })
-})
+app.post('/attempt', express.json(), async (req, res) => {
+  const { id, text, minWords } = req.body || {};
+  if (typeof text !== 'string') return res.status(400).json({ error: 'bad_request', message: 'text required' });
+  try {
+    const report = await buildReport(text, { minWords: Number(minWords || 30) });
+    res.json({ id: id || null, report });
+  } catch (e) {
+    res.status(500).json({ error: 'server_error', message: String(e?.message || e) });
+  }
+});
 
 // Start server
 const PORT = process.env.PORT || 3001;

--- a/server/report/index.js
+++ b/server/report/index.js
@@ -1,0 +1,58 @@
+// server/report/index.js
+// Tries to import compiled report modules and build a real report.
+// Falls back to the simple heuristic analyzer if needed.
+
+import { analyzeAttempt as fallbackAnalyze } from '../attempt/analyze.js';
+import fs from 'fs';
+import path from 'path';
+
+const RPT_DIR = path.resolve('server', 'report');
+
+function have(p) {
+  return fs.existsSync(path.join(RPT_DIR, p));
+}
+
+async function loadReports() {
+  const mod = {};
+  try {
+    if (have('reportPhrases.js')) mod.phrases = await import(path.join(RPT_DIR, 'reportPhrases.js'));
+    if (have('reportTypes.js')) mod.types = await import(path.join(RPT_DIR, 'reportTypes.js'));
+    if (have('reportEvolve.js')) mod.evolve = await import(path.join(RPT_DIR, 'reportEvolve.js'));
+  } catch (e) {
+    mod.__error = String(e);
+  }
+  return mod;
+}
+
+export async function buildReport(text, { minWords = 30 } = {}) {
+  const raw = String(text || '');
+  const reports = await loadReports();
+
+  // If an explicit builder exists, use it
+  const evolve = reports?.evolve;
+  const explicitBuilder =
+    evolve?.buildStyleReport ||
+    evolve?.buildReport ||
+    evolve?.default;
+
+  if (typeof explicitBuilder === 'function') {
+    try {
+      const rep = await explicitBuilder(raw, { minWords, phrases: reports?.phrases, types: reports?.types });
+      // Normalize a bit so the UI gets what it expects
+      return {
+        verdict: rep?.verdict || rep?.status || 'revise',
+        counts:  rep?.counts || { words: (raw.trim() ? raw.trim().split(/\s+/).length : 0), minWords },
+        rubric:  rep?.rubric || [],
+        spans:   rep?.spans  || [],
+        memo:    rep?.memo   || rep?.notes || [],
+        badge:   rep?.badge  || null,
+        level:   rep?.level  || null,
+      };
+    } catch (e) {
+      // fall through to heuristic
+    }
+  }
+
+  // Heuristic fallback (previous behavior)
+  return fallbackAnalyze(raw, { minWords });
+}

--- a/tools/compile_reports.mjs
+++ b/tools/compile_reports.mjs
@@ -1,0 +1,57 @@
+// tools/compile_reports.mjs
+// Compiles your TypeScript report modules into server/report/*.js using esbuild.
+// It searches common locations for the three files and builds whatever it finds.
+
+import fs from 'fs';
+import path from 'path';
+import { build } from 'esbuild';
+
+const OUT_DIR = path.resolve('server', 'report');
+fs.mkdirSync(OUT_DIR, { recursive: true });
+
+const CANDIDATES = [
+  // common spots from your tree
+  'reportPhrases.ts',
+  'reportTypes.ts',
+  'reportEvolve.ts',
+  path.join('app', 'src', 'reportPhrases.ts'),
+  path.join('app', 'src', 'reportTypes.ts'),
+  path.join('app', 'src', 'reportEvolve.ts'),
+  path.join('packages', 'shared', 'src', 'reportPhrases.ts'),
+  path.join('packages', 'shared', 'src', 'reportTypes.ts'),
+  path.join('packages', 'server', 'src', 'reportEvolve.ts'),
+  // fallbacks you uploaded earlier
+  'reportPhrases.ts',
+  'reportTypes.ts',
+  'reportEvolve.ts',
+];
+
+function existing(files) {
+  const seen = new Set();
+  const out = [];
+  for (const f of files) {
+    const abs = path.resolve(f);
+    if (!seen.has(abs) && fs.existsSync(abs)) { seen.add(abs); out.push(abs); }
+  }
+  return out;
+}
+
+const inputs = existing(CANDIDATES);
+if (!inputs.length) {
+  console.warn('⚠️ No report TS files found. Keeping previous analyzer.');
+  process.exit(0);
+}
+
+console.log('🛠️ compiling reports → server/report');
+await build({
+  entryPoints: inputs,
+  outdir: OUT_DIR,
+  format: 'esm',
+  platform: 'node',
+  sourcemap: false,
+  bundle: false,
+  target: ['node18'],
+  loader: { '.ts': 'ts' },
+});
+
+console.log('✅ compiled:', inputs.map((p) => path.relative(process.cwd(), p)).join(', '));


### PR DESCRIPTION
## Summary
- add a compile_reports tool that emits JS report modules when TypeScript sources are present
- provide a runtime adapter that loads compiled reports with a fallback to the heuristic analyzer
- update the attempt endpoint and npm scripts to use the new reporting pipeline

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f4864b0438832fb612e556258132db