### PR TITLE
Add backend progress tracking and continue flow

### DIFF
--- a/app/src/lib/apiBase.ts
+++ b/app/src/lib/apiBase.ts
@@ -24,10 +24,16 @@ export async function safeFetchJSON<T = any>(
   return res.json() as Promise<T>;
 }
 
-// Lightweight helper object
-export const api = {
-  getJSON: safeFetchJSON,
-  get: safeFetchJSON,
+// Lightweight helper with callable + helpers
+type ApiHelper = ((path: string) => string) & {
+  getJSON: typeof safeFetchJSON;
+  get: typeof safeFetchJSON;
 };
+
+const apiFunc = ((path: string) => toUrl(path)) as ApiHelper;
+apiFunc.getJSON = safeFetchJSON;
+apiFunc.get = safeFetchJSON;
+
+export const api = apiFunc;
 
 // NOTE: No example usage or imports in this file.

--- a/app/src/lib/progressApi.js
+++ b/app/src/lib/progressApi.js
@@ -1,0 +1,24 @@
+import { api, safeFetchJSON } from '@/lib/apiBase'
+import { getUserId } from '@/lib/userId.js'
+
+export async function markStarted(lessonId){
+  const userId = getUserId()
+  return safeFetchJSON(api('/progress/mark'), {
+    method:'POST',
+    headers:{ 'content-type':'application/json' },
+    body: JSON.stringify({ userId, lessonId, kind:'started' })
+  })
+}
+export async function markSubmitted(lessonId, verdict){
+  const userId = getUserId()
+  return safeFetchJSON(api('/progress/mark'), {
+    method:'POST',
+    headers:{ 'content-type':'application/json' },
+    body: JSON.stringify({ userId, lessonId, kind:'submitted', verdict })
+  })
+}
+export async function fetchNextId(){
+  const userId = getUserId()
+  const j = await safeFetchJSON(api(`/progress/next?userId=${encodeURIComponent(userId)}`))
+  return j?.nextId || null
+}

--- a/app/src/lib/userId.js
+++ b/app/src/lib/userId.js
@@ -1,0 +1,27 @@
+const K = 'pfp:userId'
+
+function createId(){
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    try { return crypto.randomUUID() } catch {}
+  }
+  const bytes = Array.from({ length: 16 }, () => Math.floor(Math.random() * 256))
+  const toHex = (arr) => arr.map(b => b.toString(16).padStart(2, '0')).join('')
+  const parts = [
+    toHex(bytes.slice(0, 4)),
+    toHex(bytes.slice(4, 6)),
+    toHex(bytes.slice(6, 8)),
+    toHex(bytes.slice(8, 10)),
+    toHex(bytes.slice(10, 16)),
+  ]
+  return parts.join('-')
+}
+
+export function getUserId() {
+  let id = null
+  try { id = localStorage.getItem(K) } catch {}
+  if (!id) {
+    id = createId()
+    try { localStorage.setItem(K, id) } catch {}
+  }
+  return id
+}

--- a/app/src/pages/SigilRunner.jsx
+++ b/app/src/pages/SigilRunner.jsx
@@ -10,6 +10,7 @@ import { getLesson } from '@/services/sigilLesson'
 import BeatPalette from '@/components/BeatPalette.jsx'
 import FeedbackTray from '@/components/FeedbackTray.jsx'
 import { submitAttempt } from '@/lib/attemptApi.js'
+import { markStarted, markSubmitted } from '@/lib/progressApi.js'
 
 export default function SigilRunner() {
   const { id } = useParams()
@@ -73,6 +74,13 @@ export default function SigilRunner() {
   const promptHtml = useMemo(() => lessonToHtml(lesson), [lesson])
   const lessonId = lesson?.id ?? (id ? String(id) : null)
 
+  // mark started once we have the lesson (backend only; no UI)
+  useEffect(() => {
+    if (lessonId && lesson) {
+      markStarted(lessonId).catch(() => {})
+    }
+  }, [lessonId, lesson])
+
   // “Ray Ray Says” — live from backend once you submit
   const [rayMemo, setRayMemo] = useState(null)
   const rayLines = rayMemo && Array.isArray(rayMemo) && rayMemo.length
@@ -88,6 +96,8 @@ export default function SigilRunner() {
       const rsp = await submitAttempt({ id, text, minWords: stats.min })
       const memo = rsp?.report?.memo
       setRayMemo(Array.isArray(memo) ? memo : memo ? [String(memo)] : [])
+      // save “submitted” on backend (no visible progress)
+      if (lessonId) markSubmitted(lessonId, rsp?.report?.verdict).catch(() => {})
       const tray = document.querySelector('.sigil-tray')
       tray?.scrollIntoView({ behavior: 'smooth', block: 'start' })
     } catch (e) {

--- a/app/src/pages/SigilSyntax.jsx
+++ b/app/src/pages/SigilSyntax.jsx
@@ -1,36 +1,56 @@
 import { useEffect, useState } from 'react'
-// ensure the Sigil UI stylesheet is loaded (shared source copy)
 import '../../../src/pages/SigilSyntaxGame.css'
-import { apiBase, safeFetchJSON } from '@/lib/apiBase'
+import { api, safeFetchJSON } from '@/lib/apiBase'
 import { useNavigate } from 'react-router-dom'
-import { snapAndDownload } from '@/lib/snapshot.js'
-import { toCatalogItems } from '@/lib/normalize'
+import { fetchNextId } from '@/lib/progressApi.js'
 
-export default function SigilSyntax() {
-  const [intro, setIntro] = useState('')
+export default function SigilSyntax(){
   const nav = useNavigate()
+  const [cat, setCat] = useState({ items: [], first: null })
+  const [err, setErr] = useState('')
+  const [nextId, setNextId] = useState(null)
+
+  useEffect(()=>{
+    setErr('')
+    safeFetchJSON(api('/sigil/catalog'))
+      .then((j)=>{
+        const items = Array.isArray(j?.items) ? j.items : []
+        const first = j?.first ? String(j.first) : (items[0]?.id ?? null)
+        setCat({ items, first })
+        // ask backend what to resume; no counts shown
+        fetchNextId().then(setNextId).catch(()=>setNextId(null))
+      })
+      .catch(e=>setErr(String(e)))
+  },[])
+
+  if (err) return <main style={{padding:24}}><b>Catalog:</b> Error: {String(err)}</main>
+
+  const count = cat.items?.length || 0
 
   return (
-    <main className="sigil-root surface" style={{ padding: 24, display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: '60vh' }}>
-      <div style={{ maxWidth: 720, width: '100%', textAlign: 'center' }}>
-        <h1 style={{ marginTop: 0 }}>Sigil &amp; Syntax</h1>
-        <p style={{ marginTop: 8, marginBottom: 8 }}>Write the short intro or instructions for the lesson below. This text is a placeholder for now.</p>
-        <textarea
-          value={intro}
-          onChange={e => setIntro(e.target.value)}
-          placeholder="Write your intro/instructions here..."
-          style={{ width: '100%', minHeight: 140, padding: 12, border: '1px solid #000', background: '#fff', color: '#000' }}
-        />
-
-        <div style={{ marginTop: 16, display: 'flex', justifyContent: 'center', gap: 12 }}>
+    <main style={{padding:24, display:'grid', gap:16}}>
+      <h1>Sigil &amp; Syntax</h1>
+      <p>Catalog: Found {count} lessons</p>
+      <div style={{display:'flex', gap:8, flexWrap:'wrap'}}>
+        {!!cat.first && (
           <button
-            onClick={() => nav('/sigil/1')}
-            style={{ padding: '10px 18px', border: '1px solid #000', background: '#000', color: '#fff', cursor: 'pointer' }}
+            onClick={()=>nav(`/sigil/${encodeURIComponent(cat.first)}`)}
+            style={{padding:'10px 16px', border:'1px solid #000', background:'#fff', cursor:'pointer'}}
           >
-            Start
+            Start first lesson
           </button>
-        </div>
+        )}
+        {!!nextId && (
+          <button
+            onClick={()=>nav(`/sigil/${encodeURIComponent(nextId)}`)}
+            style={{padding:'10px 16px', border:'1px solid #000', background:'#fff', cursor:'pointer'}}
+            title="Continue where you left off"
+          >
+            Continue where I left off
+          </button>
+        )}
       </div>
+      <p><a href="/">Back home</a></p>
     </main>
   )
 }

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,8 @@ import { createReadStream, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import * as readline from 'node:readline';
 import { buildReport } from './report/index.js';
+import { mark, getUserState } from './progress/store.js';
+import { listSigilIds } from './sigil/catalogIds.js';
 
 const app = express();
 app.use(cors());
@@ -87,6 +89,36 @@ app.get('/sigil/lesson/:id', async (req, res) => {
     console.error('[Sigil] /sigil/lesson error', e);
     res.status(200).json({ error: 'read_error' });
   }
+});
+
+// Save progress events (started/submitted)
+app.post('/progress/mark', express.json(), async (req, res) => {
+  const { userId, lessonId, kind, verdict } = req.body || {};
+  if (!userId || !lessonId || !kind) return res.status(400).json({ error: 'bad_request' });
+  const state = await mark(userId, lessonId, String(kind), verdict);
+  res.json({ ok: true, state });
+});
+
+// Minimal state (for debugging or future use)
+app.get('/progress/state', async (req, res) => {
+  const userId = String(req.query.userId || '');
+  if (!userId) return res.status(400).json({ error: 'bad_request' });
+  const state = await getUserState(userId);
+  res.json({ ok: true, state });
+});
+
+// What lesson should "Continue" open?
+app.get('/progress/next', async (req, res) => {
+  const userId = String(req.query.userId || '');
+  if (!userId) return res.status(400).json({ error: 'bad_request' });
+  const ids = listSigilIds();
+  const state = await getUserState(userId);
+  if (!ids.length) return res.json({ ok: true, nextId: null });
+  // first unfinished, else fall back to lastId, else first
+  const set = new Set(state.submitted || []);
+  const firstUnfinished = ids.find(id => !set.has(id)) || null;
+  const nextId = firstUnfinished || state.lastId || ids[0];
+  res.json({ ok: true, nextId });
 });
 
 // POST attempt analysis

--- a/server/progress/store.js
+++ b/server/progress/store.js
@@ -1,0 +1,43 @@
+import fs from 'fs'
+import fsp from 'fs/promises'
+import path from 'path'
+
+const DATA_DIR = path.resolve('server', 'data')
+const FILE = path.join(DATA_DIR, 'progress.json')
+
+function ensureDir() { fs.mkdirSync(DATA_DIR, { recursive: true }) }
+
+export async function readProgress() {
+  ensureDir()
+  try { return JSON.parse(await fsp.readFile(FILE, 'utf8') || '{}') } catch { return {} }
+}
+
+export async function writeProgress(obj) {
+  ensureDir()
+  await fsp.writeFile(FILE, JSON.stringify(obj, null, 2), 'utf8')
+}
+
+/**
+ * shape: map of userId -> { lastId?: string, started: string[], submitted: string[], verdicts: Record<string,string> }
+ */
+export async function mark(userId, lessonId, kind, verdict) {
+  if (!userId || !lessonId) return
+  const db = await readProgress()
+  const u = db[userId] ||= { lastId: null, started: [], submitted: [], verdicts: {} }
+  if (kind === 'started') {
+    if (!u.started.includes(lessonId)) u.started.push(lessonId)
+    u.lastId = lessonId
+  } else if (kind === 'submitted') {
+    if (!u.started.includes(lessonId)) u.started.push(lessonId)
+    if (!u.submitted.includes(lessonId)) u.submitted.push(lessonId)
+    if (verdict) u.verdicts[lessonId] = verdict
+    u.lastId = lessonId
+  }
+  await writeProgress(db)
+  return u
+}
+
+export async function getUserState(userId) {
+  const db = await readProgress()
+  return db[userId] || { lastId: null, started: [], submitted: [], verdicts: {} }
+}

--- a/server/sigil/catalogIds.js
+++ b/server/sigil/catalogIds.js
@@ -1,0 +1,15 @@
+import fs from 'fs'
+import path from 'path'
+
+const DEFAULT_BUNDLE = path.resolve('game things','build','sigil-syntax','bundle_sigil_syntax.json')
+
+export function listSigilIds() {
+  const p = process.env.SIGIL_BUNDLE || DEFAULT_BUNDLE
+  try {
+    const j = JSON.parse(fs.readFileSync(p,'utf8'))
+    const items = Array.isArray(j?.items) ? j.items : []
+    return items.map(x => x.id).filter(Boolean)
+  } catch {
+    return []
+  }
+}


### PR DESCRIPTION
## Summary
- add a JSON-backed progress store with routes for marking events and computing the next lesson
- expose frontend helpers for progress tracking with a persistent anonymous user id
- mark lesson activity in the runner and surface a catalog "Continue" button without showing counters

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f4893bdcd4832f9bc67e76ae990061