### PR TITLE
Improve Sigil continue behavior with local fallback

### DIFF
--- a/app/src/lib/lastSeen.js
+++ b/app/src/lib/lastSeen.js
@@ -1,0 +1,8 @@
+const K = 'sigil:lastSeen:v1'
+
+export function getLastSeen() {
+  try { return localStorage.getItem(K) || null } catch { return null }
+}
+export function setLastSeen(lessonId) {
+  try { if (lessonId) localStorage.setItem(K, lessonId) } catch {}
+}

--- a/app/src/lib/progressApi.js
+++ b/app/src/lib/progressApi.js
@@ -1,5 +1,6 @@
 import { api, safeFetchJSON } from '@/lib/apiBase'
 import { getUserId } from '@/lib/userId.js'
+import { getLastSeen } from '@/lib/lastSeen.js'
 
 export async function markStarted(lessonId){
   const userId = getUserId()
@@ -17,8 +18,23 @@ export async function markSubmitted(lessonId, verdict){
     body: JSON.stringify({ userId, lessonId, kind:'submitted', verdict })
   })
 }
-export async function fetchNextId(){
+export async function fetchNextId(validIds = []){
   const userId = getUserId()
-  const j = await safeFetchJSON(api(`/progress/next?userId=${encodeURIComponent(userId)}`))
-  return j?.nextId || null
+  // 1) Try backend with a 3s timeout
+  const ctl = new AbortController()
+  const t = setTimeout(()=>ctl.abort(), 3000)
+  try {
+    const res = await fetch(api(`/progress/next?userId=${encodeURIComponent(userId)}`), { signal: ctl.signal })
+    clearTimeout(t)
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const j = await res.json()
+    const id = j?.nextId || null
+    if (id && (!Array.isArray(validIds) || validIds.includes(id))) return id
+  } catch {
+    clearTimeout(t)
+  }
+  // 2) Fallback to local last seen (only if it’s in the catalog)
+  const local = getLastSeen()
+  if (local && Array.isArray(validIds) && validIds.includes(local)) return local
+  return null
 }

--- a/app/src/pages/SigilRunner.jsx
+++ b/app/src/pages/SigilRunner.jsx
@@ -11,6 +11,7 @@ import BeatPalette from '@/components/BeatPalette.jsx'
 import FeedbackTray from '@/components/FeedbackTray.jsx'
 import { submitAttempt } from '@/lib/attemptApi.js'
 import { markStarted, markSubmitted } from '@/lib/progressApi.js'
+import { setLastSeen } from '@/lib/lastSeen.js'
 
 export default function SigilRunner() {
   const { id } = useParams()
@@ -74,10 +75,11 @@ export default function SigilRunner() {
   const promptHtml = useMemo(() => lessonToHtml(lesson), [lesson])
   const lessonId = lesson?.id ?? (id ? String(id) : null)
 
-  // mark started once we have the lesson (backend only; no UI)
+  // mark started once we have the lesson (backend only; no UI) + remember locally
   useEffect(() => {
     if (lessonId && lesson) {
-      markStarted(lessonId).catch(() => {})
+      markStarted(lessonId)
+      setLastSeen(lessonId)
     }
   }, [lessonId, lesson])
 
@@ -97,7 +99,9 @@ export default function SigilRunner() {
       const memo = rsp?.report?.memo
       setRayMemo(Array.isArray(memo) ? memo : memo ? [String(memo)] : [])
       // save “submitted” on backend (no visible progress)
-      if (lessonId) markSubmitted(lessonId, rsp?.report?.verdict).catch(() => {})
+      if (lessonId) markSubmitted(lessonId, rsp?.report?.verdict)
+      // also refresh local last seen
+      if (lessonId) setLastSeen(lessonId)
       const tray = document.querySelector('.sigil-tray')
       tray?.scrollIntoView({ behavior: 'smooth', block: 'start' })
     } catch (e) {

--- a/app/src/pages/SigilSyntax.jsx
+++ b/app/src/pages/SigilSyntax.jsx
@@ -6,26 +6,28 @@ import { fetchNextId } from '@/lib/progressApi.js'
 
 export default function SigilSyntax(){
   const nav = useNavigate()
-  const [cat, setCat] = useState({ items: [], first: null })
+  const [cat, setCat] = useState({ games: [], first: null })
   const [err, setErr] = useState('')
   const [nextId, setNextId] = useState(null)
 
   useEffect(()=>{
     setErr('')
     safeFetchJSON(api('/sigil/catalog'))
-      .then((j)=>{
-        const items = Array.isArray(j?.items) ? j.items : []
-        const first = j?.first ? String(j.first) : (items[0]?.id ?? null)
-        setCat({ items, first })
-        // ask backend what to resume; no counts shown
-        fetchNextId().then(setNextId).catch(()=>setNextId(null))
+      .then(async (j)=>{
+        const games = Array.isArray(j?.games)
+          ? j.games.map(it => typeof it === 'string' ? it : it?.id).filter(Boolean)
+          : []
+        const first = j?.first ? String(j.first) : (games[0] ?? null)
+        setCat({ ...j, games, first })
+        // ask backend what to resume; fallback to local if needed; validate against catalog
+        try { setNextId(await fetchNextId(games)) } catch { setNextId(null) }
       })
       .catch(e=>setErr(String(e)))
   },[])
 
   if (err) return <main style={{padding:24}}><b>Catalog:</b> Error: {String(err)}</main>
 
-  const count = cat.items?.length || 0
+  const count = cat.games?.length || 0
 
   return (
     <main style={{padding:24, display:'grid', gap:16}}>


### PR DESCRIPTION
## Summary
- add a tiny localStorage helper to persist the last seen Sigil lesson
- harden the progress API by timing out the backend request and validating IDs with a local fallback
- remember the last seen lesson in the runner and guard the Continue button behind catalog validation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f48c468228832fa6ea89344d227904