### PR TITLE
Handle skipped lessons and resilient attempt API

### DIFF
--- a/app/src/lib/attemptApi.js
+++ b/app/src/lib/attemptApi.js
@@ -1,8 +1,17 @@
-import { api } from '@/lib/apiBase'
-import { safeFetchJSON } from '@/lib/apiBase'
+import * as API from '@/lib/apiBase'
+
+const makeUrl = typeof API.api === 'function'
+  ? (path) => API.api(path)
+  : (path) => {
+      const base = typeof API.apiBase === 'string' ? API.apiBase.replace(/\/$/, '') : ''
+      const p = path.startsWith('/') ? path : `/${path}`
+      return `${base}${p}`
+    }
+
+const safeFetchJSON = API.safeFetchJSON
 
 export async function submitAttempt({ id, text, minWords }) {
-    return safeFetchJSON(api('/attempt'), {
+    return safeFetchJSON(makeUrl('/attempt'), {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ id, text, minWords })

--- a/app/src/lib/progressApi.js
+++ b/app/src/lib/progressApi.js
@@ -18,6 +18,14 @@ export async function markSubmitted(lessonId, verdict){
     body: JSON.stringify({ userId, lessonId, kind:'submitted', verdict })
   })
 }
+export async function markSkipped(lessonId){
+  const userId = getUserId()
+  return safeFetchJSON(api('/progress/mark'), {
+    method:'POST',
+    headers:{ 'content-type':'application/json' },
+    body: JSON.stringify({ userId, lessonId, kind:'skipped' })
+  })
+}
 export async function fetchNextId(validIds = []){
   const userId = getUserId()
   // 1) Try backend with a 3s timeout

--- a/app/src/pages/SigilRunner.jsx
+++ b/app/src/pages/SigilRunner.jsx
@@ -10,7 +10,7 @@ import { getLesson } from '@/services/sigilLesson'
 import BeatPalette from '@/components/BeatPalette.jsx'
 import FeedbackTray from '@/components/FeedbackTray.jsx'
 import { submitAttempt } from '@/lib/attemptApi.js'
-import { markStarted, markSubmitted } from '@/lib/progressApi.js'
+import { markStarted, markSubmitted, markSkipped } from '@/lib/progressApi.js'
 import { setLastSeen } from '@/lib/lastSeen.js'
 
 export default function SigilRunner() {
@@ -160,7 +160,26 @@ export default function SigilRunner() {
             <div>{stats.words} words {stats.words < stats.min ? `(need at least ${stats.min})` : '✓'}</div>
             <div style={{ display: 'flex', gap: 8 }}>
               <button style={btn} onClick={handleSubmit}>Submit</button>
-              <button style={btn} onClick={() => nav('/sigil')}>I don’t feel like it</button>
+              <button
+                style={btn}
+                onClick={() => {
+                  if (lessonId) void markSkipped(lessonId)
+                  safeFetchJSON('/sigil/catalog')
+                    .then(cat => {
+                      const items = toCatalogItems(cat)
+                      const ids = items.map(entry => entry.id)
+                      const current = lessonId ?? ''
+                      const idx = Math.max(0, ids.indexOf(current))
+                      const next = ids[idx + 1] ?? ids[0]
+                      if (next) {
+                        nav(`/sigil/${encodeURIComponent(next)}`)
+                      } else {
+                        nav('/sigil')
+                      }
+                    })
+                    .catch(() => nav('/sigil'))
+                }}
+              >I don’t feel like it</button>
               <button style={btn} onClick={() => {
                 safeFetchJSON('/sigil/catalog').then(cat => {
                   const items = toCatalogItems(cat)

--- a/server/progress/store.js
+++ b/server/progress/store.js
@@ -18,12 +18,18 @@ export async function writeProgress(obj) {
 }
 
 /**
- * shape: map of userId -> { lastId?: string, started: string[], submitted: string[], verdicts: Record<string,string> }
+ * shape: userId -> {
+ *   lastId?: string,
+ *   started: string[],
+ *   submitted: string[],
+ *   skipped: string[],
+ *   verdicts: Record<string,string>
+ * }
  */
 export async function mark(userId, lessonId, kind, verdict) {
   if (!userId || !lessonId) return
   const db = await readProgress()
-  const u = db[userId] ||= { lastId: null, started: [], submitted: [], verdicts: {} }
+  const u = db[userId] ||= { lastId: null, started: [], submitted: [], skipped: [], verdicts: {} }
   if (kind === 'started') {
     if (!u.started.includes(lessonId)) u.started.push(lessonId)
     u.lastId = lessonId
@@ -32,6 +38,10 @@ export async function mark(userId, lessonId, kind, verdict) {
     if (!u.submitted.includes(lessonId)) u.submitted.push(lessonId)
     if (verdict) u.verdicts[lessonId] = verdict
     u.lastId = lessonId
+  } else if (kind === 'skipped') {
+    if (!u.started.includes(lessonId)) u.started.push(lessonId)
+    if (!u.skipped.includes(lessonId)) u.skipped.push(lessonId)
+    u.lastId = lessonId
   }
   await writeProgress(db)
   return u
@@ -39,5 +49,5 @@ export async function mark(userId, lessonId, kind, verdict) {
 
 export async function getUserState(userId) {
   const db = await readProgress()
-  return db[userId] || { lastId: null, started: [], submitted: [], verdicts: {} }
+  return db[userId] || { lastId: null, started: [], submitted: [], skipped: [], verdicts: {} }
 }


### PR DESCRIPTION
## Summary
- record skipped lessons in the server progress store and client API helper
- allow the "I don’t feel like it" button to log skips and advance to the next lesson
- make the attempt submission API helper resilient to different apiBase exports

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f48fe2fe44832fa4d9c3d9a2291f58