### PR TITLE
Add beat spawner sandbox editor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import SiteChrome from "@/components/SiteChrome";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import GoodWord from "@/games/goodword";
 import SigilSyntaxGame from "@/pages/SigilSyntaxGame";
+import BeatSandbox from "@/pages/BeatSandbox";
 
 function useDebugParam() {
   useEffect(() => {
@@ -58,6 +59,7 @@ export default function App() {
           <Route path="/games" element={<Games />} />
           <Route path="/games/goodword" element={<GoodWord />} />
           <Route path="/sigil/*" element={<SigilSyntaxGame />} />
+          <Route path="/beat-sandbox" element={<BeatSandbox />} />
 
           {/* --- Aliases / legacy paths --- */}
           <Route path="/games/sigil-syntax/*" element={<Navigate to="/sigil" replace />} />

--- a/src/components/BeatEditor.tsx
+++ b/src/components/BeatEditor.tsx
@@ -1,0 +1,566 @@
+import React, { useEffect, useRef } from "react";
+import { BeatBoxNode } from "@/lib/beatTypes";
+import { load, save } from "@/lib/storage";
+import { useUndo } from "@/state/useUndo";
+import "./beat-editor.css";
+
+type TextSegment = { kind: "text"; text: string };
+type BeatSegment = { kind: "beat"; beat: BeatBoxNode };
+
+type EditorState = {
+  nodes: Array<TextSegment | BeatSegment>;
+};
+
+const KEY = "editor";
+const IMPORT_EVENT = "beat-editor:import";
+
+function emptyState(): EditorState {
+  return { nodes: [] };
+}
+
+function cloneState(state: EditorState): EditorState {
+  return JSON.parse(JSON.stringify(state));
+}
+
+function serialize(state: EditorState) {
+  save(KEY, state);
+}
+
+function deserialize(): EditorState {
+  return load<EditorState>(KEY, emptyState());
+}
+
+function uuid() {
+  return `b${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function createBeatElement(node: BeatBoxNode) {
+  const el = document.createElement("span");
+  el.className = "beat-box";
+  el.dataset.beatId = node.id;
+  el.dataset.beatType = node.type;
+  el.dataset.color = node.color;
+  el.dataset.createdAt = String(node.createdAt);
+  if (node.sourceLesson) {
+    el.dataset.sourceLesson = node.sourceLesson;
+  }
+  el.dataset.sealed = node.sealed ? "true" : "false";
+  el.style.backgroundColor = node.color;
+
+  const content = document.createElement("span");
+  content.className = "beat-content";
+  content.contentEditable = node.sealed ? "false" : "true";
+  content.spellcheck = false;
+  content.innerText = node.text;
+  el.appendChild(content);
+
+  const del = document.createElement("button");
+  del.type = "button";
+  del.className = "beat-delete";
+  del.textContent = "×";
+  del.setAttribute("aria-label", "Delete beat");
+  el.appendChild(del);
+
+  if (node.sealed) {
+    el.classList.add("sealed");
+  } else {
+    el.classList.add("editing");
+  }
+
+  return el;
+}
+
+function findBeatElement(root: HTMLElement, id: string) {
+  return root.querySelector<HTMLElement>(`[data-beat-id="${id}"]`);
+}
+
+function normalizeStructure(root: HTMLDivElement) {
+  let node: ChildNode | null = root.firstChild;
+  while (node) {
+    const next = node.nextSibling;
+    if (node instanceof HTMLElement) {
+      if (node.dataset?.beatId) {
+        const content = node.querySelector<HTMLElement>(".beat-content");
+        content?.querySelectorAll("br").forEach((br) => {
+          br.replaceWith(document.createTextNode("\n"));
+        });
+      } else if (node.tagName === "BR") {
+        root.replaceChild(document.createTextNode("\n"), node);
+      } else {
+        const isBlock = /^(DIV|P|SECTION|ARTICLE|UL|OL|LI)$/i.test(node.tagName);
+        let insertedBreak = false;
+        while (node.firstChild) {
+          const child = node.firstChild;
+          if (child instanceof HTMLElement && child.tagName === "BR") {
+            root.insertBefore(document.createTextNode("\n"), node);
+            node.removeChild(child);
+            insertedBreak = true;
+          } else {
+            root.insertBefore(child, node);
+          }
+        }
+        if (isBlock && !insertedBreak) {
+          root.insertBefore(document.createTextNode("\n"), node);
+        }
+        root.removeChild(node);
+      }
+    }
+    node = next;
+  }
+  root.normalize();
+}
+
+function readStateFromDom(root: HTMLDivElement): EditorState {
+  normalizeStructure(root);
+  const nodes: EditorState["nodes"] = [];
+  const children = Array.from(root.childNodes);
+  children.forEach((child) => {
+    if (child.nodeType === Node.TEXT_NODE) {
+      nodes.push({ kind: "text", text: child.textContent ?? "" });
+      return;
+    }
+    if (child instanceof HTMLElement && child.dataset.beatId) {
+      const content = child.querySelector<HTMLElement>(".beat-content");
+      const text = content?.innerText ?? "";
+      const sealed = child.dataset.sealed !== "false";
+      const beat: BeatBoxNode = {
+        id: child.dataset.beatId,
+        type: child.dataset.beatType ?? "",
+        text,
+        sealed,
+        color: child.dataset.color ?? child.style.backgroundColor ?? "",
+        createdAt: Number(child.dataset.createdAt) || Date.now(),
+        sourceLesson: child.dataset.sourceLesson || undefined,
+      };
+      nodes.push({ kind: "beat", beat });
+      return;
+    }
+    if (child instanceof HTMLElement && child.tagName === "BR") {
+      root.replaceChild(document.createTextNode("\n"), child);
+      nodes.push({ kind: "text", text: "\n" });
+      return;
+    }
+    if (child instanceof HTMLElement) {
+      nodes.push({ kind: "text", text: child.innerText });
+    }
+  });
+  return { nodes };
+}
+
+function applyStateToDom(root: HTMLDivElement, state: EditorState) {
+  root.innerHTML = "";
+  for (const node of state.nodes) {
+    if (node.kind === "text") {
+      if (node.text) {
+        root.appendChild(document.createTextNode(node.text));
+      } else {
+        root.appendChild(document.createTextNode(""));
+      }
+    } else {
+      const beatEl = createBeatElement(node.beat);
+      root.appendChild(beatEl);
+    }
+  }
+  root.normalize();
+}
+
+function placeCaretAtEnd(el: HTMLElement) {
+  const range = document.createRange();
+  range.selectNodeContents(el);
+  range.collapse(false);
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+}
+
+function placeCaretAfter(node: Node) {
+  const range = document.createRange();
+  range.setStartAfter(node);
+  range.collapse(true);
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+}
+
+export type BeatInsert = { type: string; color: string; sourceLesson?: string };
+
+export default function BeatEditor(props: {
+  pendingInsert?: BeatInsert | null;
+  onConsumeInsert?: () => void;
+}) {
+  const editorRef = useRef<HTMLDivElement>(null);
+  const stateRef = useRef<EditorState>(emptyState());
+  const undo = useUndo<EditorState>(emptyState());
+  const editingIdRef = useRef<string | null>(null);
+  const suppressPersistRef = useRef(false);
+
+  useEffect(() => {
+    const initial = deserialize();
+    stateRef.current = cloneState(initial);
+    undo.reset(cloneState(initial));
+    if (editorRef.current) {
+      suppressPersistRef.current = true;
+      applyStateToDom(editorRef.current, initial);
+      suppressPersistRef.current = false;
+    }
+  }, []);
+
+  useEffect(() => {
+    const handleImport = () => {
+      const next = deserialize();
+      stateRef.current = cloneState(next);
+      undo.reset(cloneState(next));
+      if (editorRef.current) {
+        suppressPersistRef.current = true;
+        applyStateToDom(editorRef.current, next);
+        suppressPersistRef.current = false;
+      }
+      editingIdRef.current = null;
+    };
+    document.addEventListener(IMPORT_EVENT, handleImport);
+    return () => document.removeEventListener(IMPORT_EVENT, handleImport);
+  }, []);
+
+  useEffect(() => {
+    if (!props.pendingInsert) return;
+    const root = editorRef.current;
+    if (!root) return;
+
+    const selection = window.getSelection();
+    if (selection?.rangeCount) {
+      const range = selection.getRangeAt(0);
+      const anchorNode = selection.anchorNode as HTMLElement | null;
+      const beatAncestor = anchorNode?.closest?.("[data-beat-id]") as HTMLElement | null;
+      if (beatAncestor && beatAncestor.parentElement) {
+        range.setStartAfter(beatAncestor);
+        range.collapse(true);
+      }
+    }
+
+    const beat: BeatBoxNode = {
+      id: uuid(),
+      type: props.pendingInsert.type,
+      text: "",
+      sealed: false,
+      color: props.pendingInsert.color,
+      createdAt: Date.now(),
+      sourceLesson: props.pendingInsert.sourceLesson,
+    };
+
+    const beatEl = createBeatElement(beat);
+    const selectionRange = window.getSelection()?.getRangeAt(0);
+    if (selectionRange) {
+      selectionRange.collapse(true);
+      selectionRange.insertNode(beatEl);
+    } else {
+      root.appendChild(beatEl);
+    }
+
+    const content = beatEl.querySelector<HTMLElement>(".beat-content");
+    if (content) {
+      content.focus();
+      placeCaretAtEnd(content);
+    }
+    editingIdRef.current = beat.id;
+    commitSnapshot(true);
+    props.onConsumeInsert?.();
+  }, [props.pendingInsert, props.onConsumeInsert]);
+
+  useEffect(() => {
+    const handleMouseDown = (event: MouseEvent) => {
+      const editingId = editingIdRef.current;
+      if (!editingId) return;
+      const root = editorRef.current;
+      if (!root) return;
+      const beatEl = findBeatElement(root, editingId);
+      if (!beatEl) {
+        editingIdRef.current = null;
+        return;
+      }
+      if (beatEl.contains(event.target as Node)) return;
+      sealBeat(beatEl, true);
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        const editingId = editingIdRef.current;
+        if (!editingId) return;
+        const root = editorRef.current;
+        if (!root) return;
+        const beatEl = findBeatElement(root, editingId);
+        if (beatEl) {
+          event.preventDefault();
+          sealBeat(beatEl, true);
+        }
+      }
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, []);
+
+  useEffect(() => {
+    const root = editorRef.current;
+    if (!root) return;
+
+    const handleInput = () => {
+      if (suppressPersistRef.current) return;
+      commitSnapshot(false);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === "z") {
+        event.preventDefault();
+        const prev = undo.undo();
+        stateRef.current = cloneState(prev);
+        serialize(prev);
+        if (root) {
+          suppressPersistRef.current = true;
+          applyStateToDom(root, prev);
+          suppressPersistRef.current = false;
+        }
+        return;
+      }
+      if (((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "y") || ((event.ctrlKey || event.metaKey) && event.shiftKey && event.key.toLowerCase() === "z")) {
+        event.preventDefault();
+        const next = undo.redo();
+        stateRef.current = cloneState(next);
+        serialize(next);
+        if (root) {
+          suppressPersistRef.current = true;
+          applyStateToDom(root, next);
+          suppressPersistRef.current = false;
+        }
+        return;
+      }
+      if (event.key === "Backspace" || event.key === "Delete") {
+        if (removeAdjacentBeat(root, event.key === "Backspace" ? "backward" : "forward")) {
+          event.preventDefault();
+          commitSnapshot(true);
+        }
+      }
+    };
+
+    const handleDblClick = (event: MouseEvent) => {
+      const target = (event.target as HTMLElement).closest<HTMLElement>("[data-beat-id]");
+      if (!target) return;
+      const content = target.querySelector<HTMLElement>(".beat-content");
+      if (!content) return;
+      editingIdRef.current = target.dataset.beatId ?? null;
+      target.classList.add("editing");
+      target.classList.remove("sealed");
+      target.dataset.sealed = "false";
+      content.contentEditable = "true";
+      content.focus();
+      placeCaretAtEnd(content);
+    };
+
+    const handleClick = (event: MouseEvent) => {
+      const deleteBtn = (event.target as HTMLElement).closest<HTMLButtonElement>(".beat-delete");
+      if (deleteBtn) {
+        event.preventDefault();
+        const beat = deleteBtn.closest<HTMLElement>("[data-beat-id]");
+        if (beat) {
+          beat.remove();
+          if (editingIdRef.current === beat.dataset.beatId) {
+            editingIdRef.current = null;
+          }
+          commitSnapshot(true);
+        }
+      }
+    };
+
+    const handleContext = (event: MouseEvent) => {
+      const beat = (event.target as HTMLElement).closest<HTMLElement>("[data-beat-id]");
+      if (!beat) return;
+      event.preventDefault();
+      const id = beat.dataset.beatId;
+      if (!id) return;
+      const ev = new CustomEvent("beat:request-swap", { detail: { id }, bubbles: true });
+      beat.dispatchEvent(ev);
+    };
+
+    const handlePaste = (event: ClipboardEvent) => {
+      const selection = window.getSelection();
+      if (!selection || selection.rangeCount === 0) return;
+      event.preventDefault();
+      const text = event.clipboardData?.getData("text/plain") ?? "";
+      const range = selection.getRangeAt(0);
+      range.deleteContents();
+      const textNode = document.createTextNode(text);
+      range.insertNode(textNode);
+      range.setStartAfter(textNode);
+      range.collapse(true);
+      selection.removeAllRanges();
+      selection.addRange(range);
+      commitSnapshot(false);
+    };
+
+    root.addEventListener("input", handleInput);
+    root.addEventListener("keydown", handleKeyDown as unknown as EventListener);
+    root.addEventListener("dblclick", handleDblClick);
+    root.addEventListener("click", handleClick);
+    root.addEventListener("contextmenu", handleContext);
+    root.addEventListener("paste", handlePaste);
+
+    return () => {
+      root.removeEventListener("input", handleInput);
+      root.removeEventListener("keydown", handleKeyDown as unknown as EventListener);
+      root.removeEventListener("dblclick", handleDblClick);
+      root.removeEventListener("click", handleClick);
+      root.removeEventListener("contextmenu", handleContext);
+      root.removeEventListener("paste", handlePaste);
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleSwap = (event: Event) => {
+      const { id, next } = (event as CustomEvent).detail as {
+        id: string;
+        next: { id: string; color: string };
+      };
+      const root = editorRef.current;
+      if (!root) return;
+      const beat = findBeatElement(root, id);
+      if (!beat) return;
+      beat.dataset.beatType = next.id;
+      beat.dataset.color = next.color;
+      beat.style.backgroundColor = next.color;
+      commitSnapshot(true);
+    };
+    document.addEventListener("beat:perform-swap", handleSwap as EventListener);
+    return () => document.removeEventListener("beat:perform-swap", handleSwap as EventListener);
+  }, []);
+
+  const commitSnapshot = (pushHistory: boolean) => {
+    const root = editorRef.current;
+    if (!root) return;
+    suppressPersistRef.current = true;
+    const snapshot = readStateFromDom(root);
+    suppressPersistRef.current = false;
+    stateRef.current = cloneState(snapshot);
+    serialize(snapshot);
+    if (pushHistory) {
+      undo.set(cloneState(snapshot));
+    }
+  };
+
+  const sealBeat = (beatEl: HTMLElement, pushHistory: boolean) => {
+    const content = beatEl.querySelector<HTMLElement>(".beat-content");
+    if (!content) return;
+    const text = content.innerText.trim();
+    if (!text) {
+      const parent = beatEl.parentNode;
+      if (parent) {
+        const placeholder = document.createTextNode("");
+        parent.insertBefore(placeholder, beatEl);
+        beatEl.remove();
+        placeCaretAfter(placeholder);
+        placeholder.remove();
+      } else {
+        beatEl.remove();
+      }
+      editingIdRef.current = null;
+      commitSnapshot(pushHistory);
+      return;
+    }
+    beatEl.dataset.sealed = "true";
+    beatEl.classList.remove("editing");
+    beatEl.classList.add("sealed");
+    content.contentEditable = "false";
+    placeCaretAfter(beatEl);
+    editingIdRef.current = null;
+    commitSnapshot(pushHistory);
+  };
+
+  const removeAdjacentBeat = (root: HTMLDivElement, direction: "forward" | "backward") => {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) {
+      return false;
+    }
+    const range = selection.getRangeAt(0);
+    let target: Node | null = null;
+    if (direction === "backward") {
+      if (range.startContainer.nodeType === Node.TEXT_NODE) {
+        if (range.startOffset > 0) return false;
+        target = range.startContainer;
+      } else {
+        target = range.startContainer.childNodes[range.startOffset - 1] ?? null;
+      }
+      if (!target) {
+        let node: Node | null = range.startContainer;
+        while (node && node !== root) {
+          if (node.previousSibling) {
+            target = node.previousSibling;
+            break;
+          }
+          node = node.parentNode;
+        }
+      }
+    } else {
+      if (range.startContainer.nodeType === Node.TEXT_NODE) {
+        const text = range.startContainer.textContent ?? "";
+        if (range.startOffset < text.length) return false;
+        target = range.startContainer.nextSibling;
+      } else {
+        target = range.startContainer.childNodes[range.startOffset] ?? null;
+      }
+      if (!target) {
+        let node: Node | null = range.startContainer;
+        while (node && node !== root) {
+          if (node.nextSibling) {
+            target = node.nextSibling;
+            break;
+          }
+          node = node.parentNode;
+        }
+      }
+    }
+    if (!target) return false;
+    if (target instanceof HTMLElement && target.dataset.beatId) {
+      if (editingIdRef.current === target.dataset.beatId) {
+        editingIdRef.current = null;
+      }
+      const parent = target.parentNode;
+      if (parent) {
+        const placeholder = document.createTextNode("");
+        parent.insertBefore(placeholder, direction === "backward" ? target : target.nextSibling);
+        target.remove();
+        placeCaretAfter(placeholder);
+        placeholder.remove();
+      } else {
+        target.remove();
+      }
+      return true;
+    }
+    return false;
+  };
+
+  return (
+    <div
+      ref={editorRef}
+      className="beat-editor"
+      contentEditable
+      suppressContentEditableWarning
+      spellCheck={false}
+      role="textbox"
+      aria-multiline="true"
+    />
+  );
+}
+
+export function exportEditorState(): string {
+  return JSON.stringify(deserialize());
+}
+
+export function importEditorState(json: string) {
+  try {
+    const parsed = JSON.parse(json) as EditorState;
+    save(KEY, parsed);
+    document.dispatchEvent(new Event(IMPORT_EVENT));
+  } catch {
+    // ignore malformed payloads
+  }
+}

--- a/src/components/BeatSpawner.tsx
+++ b/src/components/BeatSpawner.tsx
@@ -1,0 +1,127 @@
+import React, { useEffect, useState } from "react";
+import { useBeatUnlocks } from "@/state/useBeatUnlocks";
+import "./beat-spawner.css";
+
+export type LessonMeta = {
+  id: string;
+  beats: string[];
+  emoticonColor?: Record<string, string>;
+};
+
+type InsertPayload = { type: string; color: string; sourceLesson?: string };
+
+type BeatSpawnerProps = {
+  lesson: LessonMeta;
+  onInsert: (payload: InsertPayload) => void;
+};
+
+export default function BeatSpawner({ lesson, onInsert }: BeatSpawnerProps) {
+  const { visibleButtons, hiddenButtons, unlockBeats, hideBeat, showBeat } = useBeatUnlocks();
+  const [swapTarget, setSwapTarget] = useState<string | null>(null);
+  const swapOptions = [...visibleButtons, ...hiddenButtons];
+
+  useEffect(() => {
+    unlockBeats(lesson.id, lesson.beats, lesson.emoticonColor);
+  }, [lesson, unlockBeats]);
+
+  useEffect(() => {
+    const handleSwapRequest = (event: Event) => {
+      const { id } = (event as CustomEvent<{ id: string }>).detail;
+      setSwapTarget(id);
+    };
+    document.addEventListener("beat:request-swap", handleSwapRequest as EventListener);
+    return () => document.removeEventListener("beat:request-swap", handleSwapRequest as EventListener);
+  }, []);
+
+  useEffect(() => {
+    if (!swapTarget) return;
+    const onEsc = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setSwapTarget(null);
+      }
+    };
+    document.addEventListener("keydown", onEsc);
+    return () => document.removeEventListener("keydown", onEsc);
+  }, [swapTarget]);
+
+  return (
+    <div className="beat-spawner">
+      <div className="row">
+        {visibleButtons.map((btn) => (
+          <button
+            key={btn.id}
+            className="beat-btn"
+            style={{ backgroundColor: btn.color }}
+            onClick={() => onInsert({ type: btn.id, color: btn.color, sourceLesson: btn.firstSeenIn })}
+            title={btn.label}
+          >
+            {btn.label}
+            <span
+              className="hide"
+              role="button"
+              tabIndex={0}
+              onClick={(event) => {
+                event.stopPropagation();
+                hideBeat(btn.id);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  hideBeat(btn.id);
+                }
+              }}
+              aria-label="Hide beat"
+            >
+              –
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {hiddenButtons.length > 0 && (
+        <details className="hidden-list">
+          <summary>Show hidden ({hiddenButtons.length})</summary>
+          <div className="row">
+            {hiddenButtons.map((btn) => (
+              <button key={btn.id} className="beat-btn ghost" onClick={() => showBeat(btn.id)}>
+                {btn.label}
+              </button>
+            ))}
+          </div>
+        </details>
+      )}
+
+      {swapTarget && (
+        <div className="swap-menu" role="dialog" aria-modal="true">
+          <div className="swap-card">
+            <div className="swap-title">Change Beat Type</div>
+            <div className="row">
+              {swapOptions.map((btn) => (
+                <button
+                  key={btn.id}
+                  className="beat-btn"
+                  style={{ backgroundColor: btn.color }}
+                  onClick={() => {
+                    document.dispatchEvent(
+                      new CustomEvent("beat:perform-swap", {
+                        detail: { id: swapTarget, next: { id: btn.id, color: btn.color } },
+                        bubbles: true,
+                      })
+                    );
+                    setSwapTarget(null);
+                  }}
+                >
+                  {btn.label}
+                </button>
+              ))}
+            </div>
+            <button className="close" type="button" onClick={() => setSwapTarget(null)}>
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/beat-editor.css
+++ b/src/components/beat-editor.css
@@ -1,0 +1,47 @@
+.beat-editor {
+  min-height: 160px;
+  padding: 12px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 10px;
+  line-height: 1.6;
+  outline: none;
+  white-space: pre-wrap;
+}
+
+.beat-box {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: 8px;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1) inset;
+  margin: 0 4px;
+}
+
+.beat-box.editing {
+  outline: 2px solid rgba(0, 0, 0, 0.28);
+}
+
+.beat-content {
+  min-width: 32px;
+  outline: none;
+  white-space: pre-wrap;
+}
+
+.beat-box.sealed .beat-content {
+  cursor: pointer;
+}
+
+.beat-delete {
+  border: 0;
+  background: transparent;
+  color: rgba(0, 0, 0, 0.6);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0 2px;
+}
+
+.beat-delete:hover {
+  color: rgba(0, 0, 0, 0.85);
+}

--- a/src/components/beat-spawner.css
+++ b/src/components/beat-spawner.css
@@ -1,0 +1,73 @@
+.beat-spawner {
+  margin-bottom: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.beat-btn {
+  position: relative;
+  border: 0;
+  border-radius: 10px;
+  padding: 6px 12px;
+  cursor: pointer;
+  font-size: 0.95rem;
+  line-height: 1.2;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.08) inset;
+}
+
+.beat-btn .hide {
+  margin-left: 8px;
+  opacity: 0.6;
+}
+
+.beat-btn .hide:hover,
+.beat-btn .hide:focus {
+  opacity: 1;
+}
+
+.beat-btn.ghost {
+  background: #f4f4f4;
+}
+
+.hidden-list summary {
+  cursor: pointer;
+}
+
+.swap-menu {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.18);
+  display: grid;
+  place-items: center;
+  z-index: 20;
+}
+
+.swap-card {
+  background: #fff;
+  border-radius: 14px;
+  padding: 18px;
+  width: min(720px, 92vw);
+  box-shadow: 0 14px 48px rgba(0, 0, 0, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.swap-title {
+  font-weight: 600;
+}
+
+.close {
+  align-self: flex-end;
+  border: 0;
+  border-radius: 8px;
+  padding: 6px 12px;
+  cursor: pointer;
+}

--- a/src/lib/beatTypes.ts
+++ b/src/lib/beatTypes.ts
@@ -1,0 +1,32 @@
+export type BeatId = string;
+
+export type BeatButton = {
+  id: BeatId;
+  label: string;
+  color: string;
+  firstSeenIn: string;
+  unlockedAt: number;
+};
+
+export type BeatBoxNode = {
+  id: string;
+  type: BeatId;
+  text: string;
+  sealed: boolean;
+  color: string;
+  createdAt: number;
+  sourceLesson?: string;
+};
+
+export function titleCase(id: string) {
+  return id
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (m) => m.toUpperCase());
+}
+
+export function hashColor(id: string): string {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = (h << 5) - h + id.charCodeAt(i);
+  const hue = Math.abs(h) % 360;
+  return `hsl(${hue} 70% 65%)`;
+}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,18 @@
+const NS = "ld.beatspawner";
+
+export function load<T>(key: string, fallback: T): T {
+  try {
+    const v = localStorage.getItem(`${NS}.${key}`);
+    return v ? (JSON.parse(v) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function save<T>(key: string, value: T) {
+  try {
+    localStorage.setItem(`${NS}.${key}`, JSON.stringify(value));
+  } catch {
+    // noop
+  }
+}

--- a/src/pages/BeatSandbox.tsx
+++ b/src/pages/BeatSandbox.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from "react";
+import BeatSpawner, { LessonMeta } from "@/components/BeatSpawner";
+import BeatEditor, { BeatInsert } from "@/components/BeatEditor";
+
+const demoLesson: LessonMeta = {
+  id: "lesson-01",
+  beats: ["reveal", "dialogue", "shift"],
+  emoticonColor: {
+    reveal: "#ffd166",
+    dialogue: "#90caf9",
+    shift: "#f48fb1",
+  },
+};
+
+export default function BeatSandbox() {
+  const [pendingInsert, setPendingInsert] = useState<BeatInsert | null>(null);
+
+  return (
+    <div style={{ padding: 24 }}>
+      <h2>Beat Spawner — Minimal Demo</h2>
+      <BeatSpawner
+        lesson={demoLesson}
+        onInsert={(payload) => setPendingInsert(payload)}
+      />
+      <BeatEditor pendingInsert={pendingInsert} onConsumeInsert={() => setPendingInsert(null)} />
+      <p style={{ opacity: 0.7, marginTop: 18 }}>
+        <small>Open another lesson that lists new beats to unlock more buttons.</small>
+      </p>
+    </div>
+  );
+}
+

--- a/src/state/useBeatUnlocks.ts
+++ b/src/state/useBeatUnlocks.ts
@@ -1,0 +1,101 @@
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { load, save } from "@/lib/storage";
+import { BeatButton, hashColor, titleCase } from "@/lib/beatTypes";
+
+type Store = {
+  buttons: Record<string, BeatButton>;
+  hidden: string[];
+  order: string[];
+};
+
+const KEY = "unlocks";
+
+let store: Store = load<Store>(KEY, { buttons: {}, hidden: [], order: [] });
+const subs = new Set<() => void>();
+
+function emit() {
+  subs.forEach((fn) => fn());
+  save(KEY, store);
+}
+
+export function useBeatUnlocks() {
+  const subscribe = useCallback((fn: () => void) => {
+    subs.add(fn);
+    return () => subs.delete(fn);
+  }, []);
+
+  const getSnapshot = useCallback(() => store, []);
+
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  const unlockBeats = useCallback(
+    (lessonId: string, beats: string[], emoticonColor?: Record<string, string>) => {
+      const now = Date.now();
+      let changed = false;
+      for (const id of beats) {
+        if (!id) continue;
+        if (!store.buttons[id]) {
+          const color = emoticonColor?.[id] ?? hashColor(id);
+          store.buttons[id] = {
+            id,
+            label: titleCase(id),
+            color,
+            firstSeenIn: lessonId,
+            unlockedAt: now,
+          };
+          store.order.push(id);
+          changed = true;
+        } else if (emoticonColor?.[id] && store.buttons[id].color !== emoticonColor[id]) {
+          store.buttons[id] = { ...store.buttons[id], color: emoticonColor[id] };
+          changed = true;
+        }
+      }
+      if (changed) emit();
+    },
+    []
+  );
+
+  const hideBeat = useCallback((id: string) => {
+    if (!store.hidden.includes(id)) {
+      store.hidden = [...store.hidden, id];
+      emit();
+    }
+  }, []);
+
+  const showBeat = useCallback((id: string) => {
+    if (store.hidden.includes(id)) {
+      store.hidden = store.hidden.filter((x) => x !== id);
+      emit();
+    }
+  }, []);
+
+  const visibleButtons = useMemo(
+    () =>
+      store.order
+        .filter((id) => !store.hidden.includes(id))
+        .map((id) => store.buttons[id]),
+    [snapshot]
+  );
+
+  const hiddenButtons = useMemo(
+    () =>
+      store.order
+        .filter((id) => store.hidden.includes(id))
+        .map((id) => store.buttons[id]),
+    [snapshot]
+  );
+
+  return {
+    buttons: store.buttons,
+    order: store.order,
+    visibleButtons,
+    hiddenButtons,
+    unlockBeats,
+    hideBeat,
+    showBeat,
+  };
+}
+
+export function listUnlockedBeats(): string[] {
+  return [...store.order];
+}

--- a/src/state/useUndo.ts
+++ b/src/state/useUndo.ts
@@ -1,0 +1,37 @@
+import { useRef } from "react";
+
+export function useUndo<T>(initial: T) {
+  const past = useRef<T[]>([]);
+  const future = useRef<T[]>([]);
+  const current = useRef<T>(initial);
+
+  const get = () => current.current;
+  const set = (next: T) => {
+    past.current.push(current.current);
+    current.current = next;
+    future.current = [];
+  };
+  const undo = () => {
+    const prev = past.current.pop();
+    if (prev !== undefined) {
+      future.current.push(current.current);
+      current.current = prev;
+    }
+    return current.current;
+  };
+  const redo = () => {
+    const next = future.current.pop();
+    if (next !== undefined) {
+      past.current.push(current.current);
+      current.current = next;
+    }
+    return current.current;
+  };
+  const reset = (next: T) => {
+    past.current = [];
+    future.current = [];
+    current.current = next;
+  };
+
+  return { get, set, undo, redo, reset };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,18 @@
 // vite.config.ts
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 export default defineConfig(({ mode }) => {
   const isDev = mode !== 'production';
 
   return {
     plugins: [react()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, 'src'),
+      },
+    },
     server: {
       proxy: {
         '/sigil':  { target: 'http://127.0.0.1:3001', changeOrigin: true, secure: false },


### PR DESCRIPTION
## Summary
- add beat metadata helpers and persistent unlock store for beat buttons
- implement the inline beat editor with sealing, swapping, undo/redo, and localStorage export/import hooks
- expose a beat spawner control panel and sandbox route to exercise the workflow

## Testing
- npm run build *(fails: existing project alias '@/pages/Home' not resolved by Rollup)*

------
https://chatgpt.com/codex/tasks/task_e_68f4d79fbe2c832fad4458c59be10731