### PR TITLE
Add debug overlay and logging instrumentation

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host 0.0.0.0 --port 5173 --strictPort",
     "dev:app": "vite",
     "build": "vite build && node scripts/copy404.mjs",
     "preview": "vite preview --port 5173",

--- a/app/src/DebugOverlay.tsx
+++ b/app/src/DebugOverlay.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+
+export function DebugOverlay({ note }: { note?: string }) {
+    const s: React.CSSProperties = {
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        zIndex: 99999,
+        background: "linear-gradient(90deg,#000,#333)",
+        color: "#0f0",
+        font: "12px/1.4 monospace",
+        padding: "6px 10px",
+        opacity: 0.9,
+        pointerEvents: "none",
+    };
+    const u = (typeof window !== "undefined" && window.location && window.location.href) || "";
+    return (
+        <div style={s}>
+            <span>DEBUG</span>
+            <span style={{ marginLeft: 10 }}>url: {u}</span>
+            <span style={{ marginLeft: 10 }}>time: {new Date().toLocaleTimeString()}</span>
+            {note ? <span style={{ marginLeft: 10 }}>note: {note}</span> : null}
+        </div>
+    );
+}
+
+export class ErrorBoundary extends React.Component<{ children: React.ReactNode }, { err?: any }> {
+    state: { err?: any } = { err: undefined };
+
+    static getDerivedStateFromError(err: any) {
+        return { err };
+    }
+
+    componentDidCatch(err: any, info: any) {
+        console.error("[EB] caught", err, info);
+    }
+
+    render() {
+        if (this.state.err) {
+            return (
+                <div style={{ padding: 16, fontFamily: "monospace" }}>
+                    <h3>💥 UI crashed</h3>
+                    <pre style={{ whiteSpace: "pre-wrap" }}>{String(this.state.err?.stack || this.state.err)}</pre>
+                </div>
+            );
+        }
+        return this.props.children;
+    }
+}

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,12 +1,18 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { ErrorBoundary, DebugOverlay } from "./DebugOverlay";
+
+console.log("[BOOT] main.tsx loaded at", new Date().toISOString());
 
 const el = document.getElementById("root");
 if (!el) throw new Error("Missing #root mount element");
 
 createRoot(el).render(
-    <React.StrictMode>
-        <App />
-    </React.StrictMode>
+    <ErrorBoundary>
+        <DebugOverlay />
+        <React.StrictMode>
+            <App />
+        </React.StrictMode>
+    </ErrorBoundary>
 );

--- a/src/components/BeatWritingBox.tsx
+++ b/src/components/BeatWritingBox.tsx
@@ -12,6 +12,7 @@ export default function BeatWritingBox({ lesson }: { lesson: LessonMeta }) {
   const { unlockBeats } = useBeatUnlocks();
 
   useEffect(() => {
+    console.log('[BWB] mount', lesson?.id, lesson);
     const maybeNumber = (lesson as any)?.number;
     const n = typeof maybeNumber === 'number'
       ? maybeNumber
@@ -26,13 +27,11 @@ export default function BeatWritingBox({ lesson }: { lesson: LessonMeta }) {
     const toUnlock = Array.from(new Set([...scheduled, ...declared].map((b) => String(b))));
 
     if (toUnlock.length) {
-      // keep a debug line while testing
-      // eslint-disable-next-line no-console
-      console.log('[BeatWritingBox] unlocking for lesson', lesson.id, 'n=', n, toUnlock);
+      console.log('[BWB] unlocking with', toUnlock, lesson.emoticonColor);
       unlockBeats(lesson.id, toUnlock, lesson.emoticonColor);
     }
     // only run on lesson id changes
-  }, [lesson.id]);
+  }, [lesson?.id]);
 
   return (
     <div className="beat-writing-wrap">


### PR DESCRIPTION
## Summary
- add a boot-time log and wrap the React root with an error boundary plus debug overlay
- introduce a reusable debug overlay component for displaying environment information
- expand BeatWritingBox logging and force the dev script to bind to 0.0.0.0:5173

## Testing
- npm run build *(fails: vite not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68f5d7c40eb4832fbe43e19e7e0ec117