### PR TITLE
Add beat rail overflow override stylesheet

### DIFF
--- a/app/src/main.jsx
+++ b/app/src/main.jsx
@@ -4,6 +4,7 @@ import App from './App.jsx'
 import './index.css'
 import './styles/layout.css'
 import './styles/sigil-layout.css'
+import './styles/beat-rail-fix.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/app/src/styles/beat-rail-fix.css
+++ b/app/src/styles/beat-rail-fix.css
@@ -1,0 +1,29 @@
+/* === Beat Rail unclipping & positioning (scoped) === */
+
+/* Unclip the editor only when the rail wrapper is present */
+.beat-writing-wrap .sigil-editor,
+.beat-writing-wrap [class*="sigil-editor"] {
+  overflow: visible !important;  /* <-- stop clipping the rail */
+}
+
+/* Ensure the wrapper provides a positioning context & reserves left space */
+.beat-writing-wrap {
+  position: relative !important;
+  --rail-left: 96px;             /* width to reserve for 1-column rail */
+  margin-left: var(--rail-left) !important;
+}
+
+/* Pin the rail outside-left of the writing area */
+.beat-rail {
+  position: absolute !important;
+  top: 0;
+  bottom: 0;
+  left: calc(-1 * var(--rail-left)) !important;
+  z-index: 10000;                /* above editor chrome */
+  pointer-events: auto;
+}
+
+/* Optional: when you switch to 2 columns later */
+.beat-rail.two {
+  --rail-left: 160px; /* ~2*btn + gaps */
+}


### PR DESCRIPTION
## Summary
- add a scoped stylesheet to ensure the beat rail is visible beside the editor
- import the override stylesheet in the Vite entrypoint so it participates in the cascade

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f64771cc84832f9b6bcd90c4b472f2