### PR TITLE
Add dev CSP header and adjust Sigil textarea identifiers

### DIFF
--- a/app/src/pages/SigilRunner.jsx
+++ b/app/src/pages/SigilRunner.jsx
@@ -213,8 +213,8 @@ export default function SigilRunner() {
               <BeatWritingBox lesson={{ id: lesson?.id, number: lesson?.number, emoticonColor: lesson?.emoticonColor }} />
             </div>
             <textarea
-              id="sigil-text"
-              name="sigilText"
+              id="sigil-textarea"
+              name="sigil"
               aria-label="Sigil response"
               value={text}
               onChange={e => setText(e.target.value)}

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -45,6 +45,10 @@ export default defineConfig({
     },
   },
   server: {
+    headers: {
+      // DEV ONLY: allow HMR/react-refresh to eval while debugging in the browser.
+      'Content-Security-Policy': "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' blob:; connect-src 'self' ws: wss:;",
+    },
     proxy: proxyConfig,
     host: '0.0.0.0',
     port: 5173,


### PR DESCRIPTION
## Summary
- configure the Vite dev server to send a permissive Content-Security-Policy header for local debugging
- update the Sigil textarea to use stable id and name attributes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f651d64d98832f83a789fa75e60c59