### PR TITLE
Scaffold attempt API endpoints and shared types

### DIFF
--- a/apps/web/hooks/useAttempt.ts
+++ b/apps/web/hooks/useAttempt.ts
@@ -1,0 +1,24 @@
+import { useState } from "react";
+
+export function useAttempt(mode: string, userId = "dev") {
+  const [result, setResult] = useState<any>(null);
+  const [isLoading, setLoading] = useState(false);
+  const submit = async (itemId: string, answer: any) => {
+    setLoading(true);
+    const r = await fetch("/api/attempt", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-user-id": userId },
+      body: JSON.stringify({ userId, itemId, mode, answer }),
+    });
+    const j = await r.json(); setResult(j); setLoading(false);
+  };
+  const next = async () => {
+    const r = await fetch(`/api/next`, { headers: { "x-user-id": userId } });
+    return r.json();
+  };
+  const latestReport = async () => {
+    const r = await fetch(`/api/reports/latest`, { headers: { "x-user-id": userId } });
+    return r.json();
+  };
+  return { submit, result, isLoading, next, latestReport };
+}

--- a/packages/server/src/db/repo.ts
+++ b/packages/server/src/db/repo.ts
@@ -1,0 +1,15 @@
+import type { AttemptPayload, AttemptResult } from "../types";
+
+export async function saveAttempt(userId: string, payload: AttemptPayload, result: AttemptResult) {
+  // TODO: write to attempts table (payload + result + timestamps)
+}
+
+export async function updateMastery(userId: string, payload: AttemptPayload, result: AttemptResult) {
+  // TODO: increment skill exp based on item/skills; return new level/badges if changed
+  return { leveledUp: false, level: undefined, badges: [] as string[] };
+}
+
+export async function latestReport(userId: string) {
+  // TODO: pull last style report memo row
+  return null as null | { createdAt: string; title: string; body: string };
+}

--- a/packages/server/src/graders/fixChoice.ts
+++ b/packages/server/src/graders/fixChoice.ts
@@ -1,0 +1,11 @@
+import type { AttemptPayload, AttemptResult } from "../types";
+
+export default async function fixChoice(payload: AttemptPayload): Promise<AttemptResult> {
+  return {
+    itemId: payload.itemId,
+    mode: payload.mode,
+    score: 0,
+    rubric: [],
+    details: { message: "fixChoice grader not implemented" },
+  };
+}

--- a/packages/server/src/graders/highlightSignal.ts
+++ b/packages/server/src/graders/highlightSignal.ts
@@ -1,0 +1,11 @@
+import type { AttemptPayload, AttemptResult } from "../types";
+
+export default async function highlightSignal(payload: AttemptPayload): Promise<AttemptResult> {
+  return {
+    itemId: payload.itemId,
+    mode: payload.mode,
+    score: 0,
+    rubric: [],
+    details: { message: "highlightSignal grader not implemented" },
+  };
+}

--- a/packages/server/src/graders/index.ts
+++ b/packages/server/src/graders/index.ts
@@ -1,0 +1,25 @@
+import type { AttemptPayload, AttemptResult } from "../types";
+
+import nameBeat from "./nameBeat";
+import missingBeat from "./missingBeat";
+import orderBeats from "./orderBeats";
+import highlightSignal from "./highlightSignal";
+import fixChoice from "./fixChoice";
+import whyReflect from "./whyReflect";
+import rewriteGrader from "./rewriteGrader";
+
+export default async function gradeAttempt(p: AttemptPayload): Promise<AttemptResult> {
+  switch (p.mode) {
+    case "name":      return nameBeat(p);
+    case "missing":   return missingBeat(p);
+    case "order":     return orderBeats(p);
+    case "highlight": return highlightSignal(p);
+    case "fix":       return fixChoice(p);
+    case "why":       return whyReflect(p);
+    case "rewrite":   return rewriteGrader ? rewriteGrader(p) : {
+      itemId: p.itemId, mode: p.mode, score: 0, rubric: [], details:{message:"No rewrite grader yet"}
+    };
+    default:
+      return { itemId: p.itemId, mode: p.mode, score: 0, rubric: [], details:{message:"Unknown mode"} };
+  }
+}

--- a/packages/server/src/graders/missingBeat.ts
+++ b/packages/server/src/graders/missingBeat.ts
@@ -1,0 +1,11 @@
+import type { AttemptPayload, AttemptResult } from "../types";
+
+export default async function missingBeat(payload: AttemptPayload): Promise<AttemptResult> {
+  return {
+    itemId: payload.itemId,
+    mode: payload.mode,
+    score: 0,
+    rubric: [],
+    details: { message: "missingBeat grader not implemented" },
+  };
+}

--- a/packages/server/src/graders/nameBeat.ts
+++ b/packages/server/src/graders/nameBeat.ts
@@ -1,0 +1,11 @@
+import type { AttemptPayload, AttemptResult } from "../types";
+
+export default async function nameBeat(payload: AttemptPayload): Promise<AttemptResult> {
+  return {
+    itemId: payload.itemId,
+    mode: payload.mode,
+    score: 0,
+    rubric: [],
+    details: { message: "nameBeat grader not implemented" },
+  };
+}

--- a/packages/server/src/graders/orderBeats.ts
+++ b/packages/server/src/graders/orderBeats.ts
@@ -1,0 +1,11 @@
+import type { AttemptPayload, AttemptResult } from "../types";
+
+export default async function orderBeats(payload: AttemptPayload): Promise<AttemptResult> {
+  return {
+    itemId: payload.itemId,
+    mode: payload.mode,
+    score: 0,
+    rubric: [],
+    details: { message: "orderBeats grader not implemented" },
+  };
+}

--- a/packages/server/src/graders/rewriteGrader.ts
+++ b/packages/server/src/graders/rewriteGrader.ts
@@ -1,0 +1,11 @@
+import type { AttemptPayload, AttemptResult } from "../types";
+
+export default async function rewriteGrader(payload: AttemptPayload): Promise<AttemptResult> {
+  return {
+    itemId: payload.itemId,
+    mode: payload.mode,
+    score: 0,
+    rubric: [],
+    details: { message: "rewrite grader not implemented" },
+  };
+}

--- a/packages/server/src/graders/whyReflect.ts
+++ b/packages/server/src/graders/whyReflect.ts
@@ -1,0 +1,11 @@
+import type { AttemptPayload, AttemptResult } from "../types";
+
+export default async function whyReflect(payload: AttemptPayload): Promise<AttemptResult> {
+  return {
+    itemId: payload.itemId,
+    mode: payload.mode,
+    score: 0,
+    rubric: [],
+    details: { message: "whyReflect grader not implemented" },
+  };
+}

--- a/packages/server/src/routes/attempt.ts
+++ b/packages/server/src/routes/attempt.ts
@@ -1,0 +1,59 @@
+import { Router } from "express";
+import type { AttemptPayload, AttemptResult } from "../types";
+import gradeAttempt from "../graders";
+import { saveAttempt, updateMastery, latestReport } from "../db/repo";
+import { maybeBuildStyleReport } from "../styleReport";
+import pickNext from "../scheduler/selector";
+
+const router = Router();
+
+// POST /api/attempt
+router.post("/attempt", async (req, res) => {
+  try {
+    const payload = req.body as AttemptPayload;
+    if (!payload?.userId || !payload?.itemId || !payload?.mode) {
+      return res.status(400).json({ error: "Missing userId, itemId, or mode" });
+    }
+
+    const result: AttemptResult = await gradeAttempt(payload);
+
+    const { leveledUp, level, badges } = await updateMastery(payload.userId, payload, result);
+    result.leveledUp = leveledUp;
+    if (level != null) result.level = level;
+    if (badges?.length) result.badges = badges;
+
+    await saveAttempt(payload.userId, payload, result);
+
+    if (leveledUp) {
+      await maybeBuildStyleReport(payload.userId, true);
+    }
+
+    res.json(result);
+  } catch (e: any) {
+    res.status(500).json({ error: "Attempt failed", message: e?.message });
+  }
+});
+
+// GET /api/next
+router.get("/next", async (req, res) => {
+  try {
+    const userId = String(req.query.userId || req.headers["x-user-id"] || "anon");
+    const item = await pickNext(userId);
+    res.json(item);
+  } catch (e: any) {
+    res.status(500).json({ error: "Next failed", message: e?.message });
+  }
+});
+
+// GET /api/reports/latest
+router.get("/reports/latest", async (req, res) => {
+  try {
+    const userId = String(req.query.userId || req.headers["x-user-id"] || "anon");
+    const rpt = await latestReport(userId);
+    res.json(rpt || {});
+  } catch (e: any) {
+    res.status(500).json({ error: "Report lookup failed", message: e?.message });
+  }
+});
+
+export default router;

--- a/packages/server/src/scheduler/selector.ts
+++ b/packages/server/src/scheduler/selector.ts
@@ -1,0 +1,5 @@
+export default async function pickNext(userId: string){
+  // TODO: bias to weak skills, freshness, and tweetrunk introduces_beats gates
+  // Return shape the web app expects: { itemId, mode, passage, options? … }
+  return { itemId: "demo-1", mode: "rewrite", passage: "Write a short scene…" };
+}

--- a/packages/server/src/styleReport.ts
+++ b/packages/server/src/styleReport.ts
@@ -1,0 +1,5 @@
+export async function maybeBuildStyleReport(userId: string, leveledUp: boolean) {
+  if (!leveledUp) return null;
+  // TODO: build Professor Ray Ray memo from recent attempts; save to reports table
+  return { title: "Professor Ray Ray memo", body: "…generated memo…" };
+}

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1,0 +1,1 @@
+export type { AttemptMode, AttemptPayload, AttemptResult } from "../../shared/src/gameTypes";

--- a/packages/shared/src/gameTypes.ts
+++ b/packages/shared/src/gameTypes.ts
@@ -1,0 +1,31 @@
+export type AttemptMode = "name"|"missing"|"order"|"highlight"|"fix"|"why"|"rewrite";
+
+export type AttemptPayload = {
+  userId: string;
+  itemId: string;
+  mode: AttemptMode;
+  answer: {
+    // any mode can send any of these; graders pick what they need
+    choiceId?: string;
+    order?: string[];
+    spans?: { start:number; end:number }[];
+    text?: string;
+    rationale?: string;
+    sigils?: string[];   // beats like [ACTION] parsed client-side or server-side
+  };
+};
+
+export type AttemptResult = {
+  itemId: string;
+  mode: AttemptMode;
+  score: number;                   // 0..1
+  rubric: string[];                // e.g., ["Accuracy","Clarity"]
+  spans?: { start:number; end:number; label?: string }[];
+  correctOrder?: string[];         // for order mode
+  fixSuggestion?: string;          // for fix/rewrite hints
+  next?: string;                   // short next-drill hint
+  details?: Record<string, unknown>;
+  leveledUp?: boolean;
+  level?: number;
+  badges?: string[];
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./gameTypes";

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,6 +5,7 @@ import cookieParser from "cookie-parser";
 import type { NextFunction, Request, Response } from "express";
 import { v4 as uuidv4 } from "uuid";
 import cutGamesRouter from "./routes/cutGames";
+import attemptRoutes from "../../packages/server/src/routes/attempt";
 
 function loadExpress() {
     const localRequire = createRequire(import.meta.url);
@@ -65,6 +66,7 @@ app.use((req: PlayerRequest, res: Response, next: NextFunction) => {
 
 app.use(express.json());
 app.use(express.static(path.resolve(process.cwd(), "public")));
+app.use("/api", attemptRoutes);
 app.use(cutGamesRouter);
 
 export default app;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,12 @@
         "paths": {
             "@/*": [
                 "src/*"
+            ],
+            "@shared/*": [
+                "packages/shared/src/*"
+            ],
+            "@server/*": [
+                "packages/server/src/*"
             ]
         }
     },
@@ -38,7 +44,9 @@
         "scripts/**/*.ts",
         "scripts/**/*.tsx",
         "vite.config.ts",
-        "playwright.config.ts"
+        "playwright.config.ts",
+        "packages/**/*",
+        "apps/**/*"
     ],
     "exclude": [
         "node_modules",


### PR DESCRIPTION
## Summary
- add shared attempt payload/result types and export them for server/client use
- scaffold grader registry, route handlers, db helpers, scheduler, and style report stubs for attempt flow
- wire the /api routes into the server and add a client hook to call attempt/next/report endpoints

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f6bb7bc978832fad4e966beb38d710