### PR TITLE
feat(web): add play mode interface components

### DIFF
--- a/apps/web/app/play/[mode]/page.tsx
+++ b/apps/web/app/play/[mode]/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import { useAttempt } from "@/hooks/useAttempt";
+import EditorWithBeatSpawner from "@/components/EditorWithBeatSpawner";
+import FeedbackTray from "@/components/FeedbackTray";
+import LogicNavButtons from "@/components/LogicNavButtons";
+import HighlightablePassage from "@/components/HighlightablePassage";
+import NotesPanel from "@/components/NotesPanel";
+
+export default function PlayModePage({ params }: { params: { mode: string } }) {
+  const mode = params.mode;
+  const { current, loadNext, submit, result, isLoading } = useAttempt(mode);
+  const [text, setText] = useState("");
+  const [rationale, setRationale] = useState("");
+  const [notes, setNotes] = useState<string | undefined>();
+
+  useEffect(() => {
+    loadNext();
+  }, []);
+
+  const onSubmit = async () => {
+    if (!current) return;
+    await submit(current.itemId, { text, rationale });
+  };
+  const onNext = async () => {
+    setText("");
+    setRationale("");
+    setNotes(undefined);
+    await loadNext();
+  };
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-[1fr_20rem] gap-4 p-4">
+      <section className="flex flex-col gap-3">
+        {current?.passage ? (
+          <HighlightablePassage text={current.passage} spans={result?.spans} />
+        ) : null}
+        <EditorWithBeatSpawner value={text} onChange={setText} onSubmit={onSubmit} />
+        <label className="text-sm" htmlFor="rationale-input">
+          Why did you do that?
+        </label>
+        <textarea
+          id="rationale-input"
+          className="rounded border p-2"
+          value={rationale}
+          onChange={(e) => setRationale(e.target.value)}
+        />
+        <div className="flex gap-2">
+          <button className="rounded px-3 py-2 border" disabled={isLoading} onClick={onSubmit}>
+            Submit
+          </button>
+        </div>
+        {current?.meta?.lesson && <NotesPanel {...current.meta.lesson} />}
+      </section>
+
+      <FeedbackTray result={result} notes={notes} onChangeNotes={setNotes} />
+      <div className="md:col-span-2">
+        <LogicNavButtons
+          canNext={!!result}
+          isLoading={isLoading}
+          onNext={onNext}
+          onRetry={() => setText(text)}
+          onQueue={() => {}}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/BeatPalette.tsx
+++ b/apps/web/components/BeatPalette.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { BEATS } from "@shared/beatPalette";
+
+type Props = {
+  onPick: (beatKey: string) => void;
+  unlocked?: Set<string>;
+};
+export default function BeatPalette({ onPick, unlocked }: Props) {
+  const allow = (k: string) => !unlocked || unlocked.has(k);
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+      {BEATS.map((b) => (
+        <button
+          key={b.key}
+          type="button"
+          disabled={!allow(b.key)}
+          style={{ background: b.color }}
+          className="rounded-xl px-2 py-1 text-sm shadow disabled:opacity-30"
+          onClick={() => onPick(b.key)}
+          aria-label={`${b.label} (${b.family})`}
+        >
+          {b.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/components/EditorWithBeatSpawner.tsx
+++ b/apps/web/components/EditorWithBeatSpawner.tsx
@@ -1,0 +1,50 @@
+import React, { useRef } from "react";
+import BeatPalette from "./BeatPalette";
+
+type Props = {
+  value: string;
+  onChange: (v: string) => void;
+  onSubmit?: () => void;
+  onPickBeat?: (beatKey: string) => void;
+};
+export default function EditorWithBeatSpawner({
+  value,
+  onChange,
+  onSubmit,
+  onPickBeat,
+}: Props) {
+  const taRef = useRef<HTMLTextAreaElement | null>(null);
+  const insert = (beat: string) => {
+    const ta = taRef.current;
+    const caret = ta ? ta.selectionStart : value.length;
+    const token = `[${beat.toUpperCase()}]`;
+    const next = value.slice(0, caret) + token + value.slice(caret);
+    onChange(next);
+    requestAnimationFrame(() => {
+      if (ta) {
+        const p = caret + token.length;
+        ta.selectionStart = ta.selectionEnd = p;
+        ta.focus();
+      }
+    });
+  };
+  return (
+    <div className="flex flex-col gap-3">
+      <BeatPalette onPick={onPickBeat ?? insert} />
+      <textarea
+        ref={taRef}
+        className="w-full min-h-[240px] rounded-xl border p-3 leading-6"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+            e.preventDefault();
+            onSubmit?.();
+          }
+        }}
+        placeholder="Write here. Insert beats like [ACTION] [REVEAL] …"
+      />
+      <div className="text-xs opacity-70">Pro tip: ⌘/Ctrl+Enter submits.</div>
+    </div>
+  );
+}

--- a/apps/web/components/FeedbackTray.tsx
+++ b/apps/web/components/FeedbackTray.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+type Props = {
+  result?: any;
+  notes?: string;
+  onChangeNotes?: (v: string) => void;
+  children?: React.ReactNode;
+};
+export default function FeedbackTray({
+  result,
+  notes,
+  onChangeNotes,
+  children,
+}: Props) {
+  const auto = [
+    result?.score != null ? `Score: ${(result.score * 100).toFixed(0)}%` : "",
+    result?.rubric?.length ? `Rubric: ${result.rubric.join(", ")}` : "",
+    result?.details?.message ?? "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+  return (
+    <aside className="w-full md:w-80 shrink-0 flex flex-col gap-2">
+      <label className="text-sm font-medium">Feedback</label>
+      <textarea
+        className="w-full min-h-[200px] rounded-xl border p-2"
+        value={notes ?? auto}
+        onChange={(e) => onChangeNotes?.(e.target.value)}
+        placeholder="Feedback prints here; you can type over it."
+      />
+      {result?.next && (
+        <div className="text-xs opacity-70">Next hint: {result.next}</div>
+      )}
+      {children}
+    </aside>
+  );
+}

--- a/apps/web/components/HighlightablePassage.tsx
+++ b/apps/web/components/HighlightablePassage.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+type Span = { start: number; end: number; label?: string };
+type Props = { text: string; spans?: Span[] };
+export default function HighlightablePassage({ text, spans = [] }: Props) {
+  if (!spans.length) return <pre className="whitespace-pre-wrap">{text}</pre>;
+  const sorted = [...spans].sort((a, b) => a.start - b.start);
+  const parts: React.ReactNode[] = [];
+  let i = 0;
+  sorted.forEach((s, idx) => {
+    if (s.start > i) parts.push(<span key={`t-${idx}-pre`}>{text.slice(i, s.start)}</span>);
+    parts.push(
+      <mark key={`m-${idx}`} className="bg-yellow-200">
+        {text.slice(s.start, s.end)}
+      </mark>
+    );
+    i = s.end;
+  });
+  if (i < text.length) parts.push(<span key="t-last">{text.slice(i)}</span>);
+  return <pre className="whitespace-pre-wrap">{parts}</pre>;
+}

--- a/apps/web/components/LevelUpScreen.tsx
+++ b/apps/web/components/LevelUpScreen.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+type Props = {
+  level: number;
+  badges?: string[];
+  memo?: { title: string; body: string };
+};
+export default function LevelUpScreen({ level, badges, memo }: Props) {
+  return (
+    <section className="rounded-xl border p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Level {level}</h2>
+      {badges?.length ? (
+        <div className="flex flex-wrap gap-2">
+          {badges.map((b) => (
+            <span key={b} className="rounded-full border px-2 py-1 text-xs">
+              {b}
+            </span>
+          ))}
+        </div>
+      ) : null}
+      {memo ? (
+        <article className="rounded-lg border p-3 bg-white">
+          <h3 className="font-medium">{memo.title}</h3>
+          <p className="whitespace-pre-wrap text-sm leading-6">{memo.body}</p>
+        </article>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/components/LogicNavButtons.tsx
+++ b/apps/web/components/LogicNavButtons.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+type Props = {
+  canNext: boolean;
+  onNext: () => void;
+  onRetry?: () => void;
+  onQueue?: () => void;
+  isLoading?: boolean;
+};
+export default function LogicNavButtons({
+  canNext,
+  onNext,
+  onRetry,
+  onQueue,
+  isLoading,
+}: Props) {
+  return (
+    <div className="flex gap-2">
+      <button type="button" className="rounded px-3 py-2 border" onClick={onRetry}>
+        Retry
+      </button>
+      <button type="button" className="rounded px-3 py-2 border" onClick={onQueue}>
+        Queue Drill
+      </button>
+      <button
+        type="button"
+        className="rounded px-3 py-2 bg-black text-white disabled:opacity-40"
+        disabled={!canNext || !!isLoading}
+        onClick={onNext}
+      >
+        Next
+      </button>
+    </div>
+  );
+}

--- a/apps/web/components/NotesPanel.tsx
+++ b/apps/web/components/NotesPanel.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+type Props = {
+  title?: string;
+  definition?: string;
+  signals?: string[];
+  examples?: string[];
+};
+export default function NotesPanel({ title, definition, signals, examples }: Props) {
+  return (
+    <section className="rounded-xl border p-3 flex flex-col gap-2">
+      {title && <h3 className="font-semibold">{title}</h3>}
+      {definition && <p className="text-sm">{definition}</p>}
+      {signals?.length ? (
+        <div>
+          <div className="text-xs uppercase tracking-wide opacity-70 mb-1">Signals</div>
+          <ul className="list-disc pl-5 text-sm">
+            {signals.map((s, i) => (
+              <li key={i}>{s}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      {examples?.length ? (
+        <div>
+          <div className="text-xs uppercase tracking-wide opacity-70 mb-1">Examples</div>
+          <ul className="list-disc pl-5 text-sm">
+            {examples.map((s, i) => (
+              <li key={i}>{s}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/hooks/useAttempt.ts
+++ b/apps/web/hooks/useAttempt.ts
@@ -3,6 +3,16 @@ import { useState } from "react";
 export function useAttempt(mode: string, userId = "dev") {
   const [result, setResult] = useState<any>(null);
   const [isLoading, setLoading] = useState(false);
+  const [current, setCurrent] = useState<any>(null);
+
+  const loadNext = async () => {
+    const r = await fetch(`/api/next`, { headers: { "x-user-id": userId } });
+    const j = await r.json();
+    setCurrent(j);
+    setResult(null);
+    return j;
+  };
+
   const submit = async (itemId: string, answer: any) => {
     setLoading(true);
     const r = await fetch("/api/attempt", {
@@ -10,15 +20,16 @@ export function useAttempt(mode: string, userId = "dev") {
       headers: { "content-type": "application/json", "x-user-id": userId },
       body: JSON.stringify({ userId, itemId, mode, answer }),
     });
-    const j = await r.json(); setResult(j); setLoading(false);
+    const j = await r.json();
+    setResult(j);
+    setLoading(false);
+    return j;
   };
-  const next = async () => {
-    const r = await fetch(`/api/next`, { headers: { "x-user-id": userId } });
-    return r.json();
-  };
+
   const latestReport = async () => {
     const r = await fetch(`/api/reports/latest`, { headers: { "x-user-id": userId } });
     return r.json();
   };
-  return { submit, result, isLoading, next, latestReport };
+
+  return { current, loadNext, submit, result, isLoading, latestReport };
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"],
+      "@shared/*": ["../../packages/shared/src/*"],
+      "@server/*": ["../../packages/server/src/*"]
+    }
+  },
+  "include": ["."],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add beat palette, editor, feedback tray, notes panel, nav buttons, highlightable passage, and level up screen components
- expand the useAttempt hook to track the current item and expose loadNext
- implement the play/[mode] page wiring the new components and add local tsconfig aliases

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f6ceb920a8832fa6bd257cd41ca168