### PR TITLE
Add server health, version, and debug endpoints

### DIFF
--- a/packages/server/src/routes/debugContent.ts
+++ b/packages/server/src/routes/debugContent.ts
@@ -1,0 +1,55 @@
+import { Router } from "express";
+import pickNext from "../scheduler/selector";
+import { getAllItems } from "../content/items";
+
+const router = Router();
+
+router.get("/debug/content", async (req, res) => {
+  try {
+    const userIdRaw = req.query.userId;
+    const userId = typeof userIdRaw === "string" && userIdRaw.trim() ? userIdRaw.trim() : "dev";
+
+    let items: ReturnType<typeof getAllItems> = [];
+    try {
+      items = getAllItems();
+    } catch {
+      items = [];
+    }
+
+    const byMode = items.reduce<Record<string, number>>((acc, item) => {
+      const mode = item?.mode || "unknown";
+      acc[mode] = (acc[mode] || 0) + 1;
+      return acc;
+    }, {});
+
+    const sample = items.length
+      ? {
+          id: items[0]?.id ?? null,
+          mode: items[0]?.mode ?? null,
+          meta: items[0]?.meta ?? {},
+        }
+      : null;
+
+    let nextItem: { id: string; mode?: string } | null = null;
+    try {
+      const candidate = await pickNext(userId);
+      if (candidate) {
+        nextItem = { id: candidate.id, mode: candidate.mode };
+      }
+    } catch {
+      nextItem = null;
+    }
+
+    res.json({
+      total: items.length,
+      byMode,
+      sample,
+      nextItem,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    res.status(500).json({ error: message });
+  }
+});
+
+export default router;

--- a/packages/server/src/routes/health.ts
+++ b/packages/server/src/routes/health.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+
+const router = Router();
+
+router.get("/healthz", (_req, res) => {
+  res.type("text/plain").send("ok");
+});
+
+export default router;

--- a/packages/server/src/routes/version.ts
+++ b/packages/server/src/routes/version.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+
+const router = Router();
+
+router.get("/version", (_req, res) => {
+  res.json({
+    sha: process.env.GIT_SHA || "dev",
+    builtAt: process.env.BUILT_AT || new Date().toISOString(),
+  });
+});
+
+export default router;

--- a/server/index.js
+++ b/server/index.js
@@ -13,6 +13,9 @@ import { listSigilIds } from './sigil/catalogIds.js';
 import attemptRoutes from './routes/attempt.js';
 import nextRoutes from './routes/next.js';
 import skipRoutes from './routes/skip.js';
+import versionRoutes from './routes/version.js';
+import healthRoutes from './routes/health.js';
+import debugContentRoutes from './routes/debugContent.js';
 
 const app = express();
 app.use(cors());
@@ -40,6 +43,9 @@ if (isProd) {
 app.use('/api', attemptRoutes);
 app.use('/api', nextRoutes);
 app.use('/api', skipRoutes);
+app.use('/api', versionRoutes);
+app.use('/api', healthRoutes);
+app.use('/api', debugContentRoutes);
 
 // ====== Sigil JSONL endpoints (unchanged) ======
 const FILE = resolve(process.cwd(), 'labeled data', 'tweetrunk_renumbered.jsonl');

--- a/server/routes/debugContent.js
+++ b/server/routes/debugContent.js
@@ -1,0 +1,55 @@
+import { Router } from "express";
+import pickNext from "../scheduler/selector.js";
+import { getAllItems } from "../content/items.js";
+
+const router = Router();
+
+router.get("/debug/content", async (req, res) => {
+  try {
+    const userIdRaw = req.query.userId;
+    const userId = typeof userIdRaw === "string" && userIdRaw.trim() ? userIdRaw.trim() : "dev";
+
+    let items = [];
+    try {
+      items = getAllItems();
+    } catch {
+      items = [];
+    }
+
+    const byMode = items.reduce((acc, item) => {
+      const mode = item?.mode || "unknown";
+      acc[mode] = (acc[mode] || 0) + 1;
+      return acc;
+    }, {});
+
+    const sample = items.length
+      ? {
+          id: items[0]?.id ?? null,
+          mode: items[0]?.mode ?? null,
+          meta: items[0]?.meta ?? {},
+        }
+      : null;
+
+    let nextItem = null;
+    try {
+      const candidate = await pickNext(userId);
+      if (candidate) {
+        nextItem = { id: candidate.id, mode: candidate.mode };
+      }
+    } catch {
+      nextItem = null;
+    }
+
+    res.json({
+      total: items.length,
+      byMode,
+      sample,
+      nextItem,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    res.status(500).json({ error: message });
+  }
+});
+
+export default router;

--- a/server/routes/health.js
+++ b/server/routes/health.js
@@ -1,0 +1,9 @@
+import { Router } from "express";
+
+const router = Router();
+
+router.get("/healthz", (_req, res) => {
+  res.type("text/plain").send("ok");
+});
+
+export default router;

--- a/server/routes/version.js
+++ b/server/routes/version.js
@@ -1,0 +1,12 @@
+import { Router } from "express";
+
+const router = Router();
+
+router.get("/version", (_req, res) => {
+  res.json({
+    sha: process.env.GIT_SHA || "dev",
+    builtAt: process.env.BUILT_AT || new Date().toISOString(),
+  });
+});
+
+export default router;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -8,6 +8,9 @@ import cutGamesRouter from "./routes/cutGames";
 import attemptRoutes from "../../packages/server/src/routes/attempt";
 import nextRoutes from "../../packages/server/src/routes/next";
 import skipRoutes from "../../packages/server/src/routes/skip";
+import versionRoute from "../../packages/server/src/routes/version";
+import healthRoute from "../../packages/server/src/routes/health";
+import debugContentRoute from "../../packages/server/src/routes/debugContent";
 
 function loadExpress() {
     const localRequire = createRequire(import.meta.url);
@@ -71,6 +74,9 @@ app.use(express.static(path.resolve(process.cwd(), "public")));
 app.use("/api", attemptRoutes);
 app.use("/api", nextRoutes);
 app.use("/api", skipRoutes);
+app.use("/api", versionRoute);
+app.use("/api", healthRoute);
+app.use("/api", debugContentRoute);
 app.use(cutGamesRouter);
 
 export default app;


### PR DESCRIPTION
## Summary
- add healthz, version, and debug content routes in the shared server package
- wire the new routes into both the production server bootstrap and the dev server entry

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f733e97b0c832fa108ca2aaccb77b7