### PR TITLE
Add Express boot script and static serving fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "dev:down": "bash scripts/dev-down.sh",
     "build": "node scripts/offline-vite-build.mjs",
     "build:app": "node scripts/offline-vite-build.mjs",
-    "smoke:content": "ts-node scripts/smokeContent.ts"
+    "smoke:content": "ts-node scripts/smokeContent.ts",
+    "start": "node server/index.js",
+    "dev": "bash scripts/dev-up.sh"
   },
   "devDependencies": {
     "@playwright/test": "^1.56.1",

--- a/server/index.js
+++ b/server/index.js
@@ -3,7 +3,8 @@ import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import { createReadStream, existsSync, appendFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import path, { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import * as readline from 'node:readline';
 import { buildReport } from './report/index.js';
 import { mark, getUserState } from './progress/store.js';
@@ -17,7 +18,17 @@ import versionRoutes from './routes/version.js';
 import healthRoutes from './routes/health.js';
 import debugContentRoutes from './routes/debugContent.js';
 
+const __filename = fileURLToPath(import.meta.url);
+
 const app = express();
+
+console.log('>>> BOOTED SERVER FROM', __filename);
+
+app.set('trust proxy', true);
+
+const dist = path.join(process.cwd(), 'dist');
+const indexHtmlPath = path.join(dist, 'index.html');
+
 app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
@@ -40,12 +51,23 @@ if (isProd) {
 }
 
 // ====== New API routes ======
+try {
+  app.use(versionRoutes);
+  app.use(healthRoutes);
+  app.use(debugContentRoutes);
+} catch (e) {
+  console.warn('Route mounting warning:', e && e.message);
+}
+
 app.use('/api', attemptRoutes);
 app.use('/api', nextRoutes);
 app.use('/api', skipRoutes);
-app.use('/api', versionRoutes);
-app.use('/api', healthRoutes);
-app.use('/api', debugContentRoutes);
+
+if (existsSync(dist)) {
+  app.use(express.static(dist));
+} else {
+  console.warn(`>>> Static bundle missing at ${dist}`);
+}
 
 // ====== Sigil JSONL endpoints (unchanged) ======
 const FILE = resolve(process.cwd(), 'labeled data', 'tweetrunk_renumbered.jsonl');
@@ -192,7 +214,18 @@ app.post('/attempt', express.json(), async (req, res) => {
   }
 });
 
+app.get('*', (req, res, next) => {
+  if (req.method !== 'GET') return next();
+  if (req.path.startsWith('/api/')) return next();
+  if (existsSync(indexHtmlPath)) {
+    return res.sendFile(indexHtmlPath);
+  }
+  return res.status(404).type('text/plain').send('dist/index.html not found');
+});
+
 // Start server
 const PORT = process.env.PORT || 3002;  // Default to 3002 for consistency with Vite proxy
 const HOST = '0.0.0.0';
-app.listen(PORT, HOST, () => console.log(`[API] listening on http://${HOST}:${PORT}`));
+app.listen(PORT, HOST, () => {
+  console.log(`>>> Server listening on http://localhost:${PORT}`);
+});

--- a/server/routes/debugContent.js
+++ b/server/routes/debugContent.js
@@ -4,7 +4,7 @@ import { getAllItems } from "../content/items.js";
 
 const router = Router();
 
-router.get("/debug/content", async (req, res) => {
+router.get("/api/debug/content", async (req, res) => {
   try {
     const userIdRaw = req.query.userId;
     const userId = typeof userIdRaw === "string" && userIdRaw.trim() ? userIdRaw.trim() : "dev";

--- a/server/routes/health.js
+++ b/server/routes/health.js
@@ -2,7 +2,7 @@ import { Router } from "express";
 
 const router = Router();
 
-router.get("/healthz", (_req, res) => {
+router.get("/api/healthz", (_req, res) => {
   res.type("text/plain").send("ok");
 });
 

--- a/server/routes/version.js
+++ b/server/routes/version.js
@@ -2,7 +2,7 @@ import { Router } from "express";
 
 const router = Router();
 
-router.get("/version", (_req, res) => {
+router.get("/api/version", (_req, res) => {
   res.json({
     sha: process.env.GIT_SHA || "dev",
     builtAt: process.env.BUILT_AT || new Date().toISOString(),


### PR DESCRIPTION
## Summary
- add root npm `start` and `dev` scripts for running the Express server
- update `server/index.js` to log boot info, trust proxies, mount diagnostic routes, and serve the built Vite bundle with an SPA fallback
- adjust diagnostic route files so the endpoints respond under `/api`

## Testing
- node --check server/index.js

------
https://chatgpt.com/codex/tasks/task_e_68f78bdce9f4832f96d61aca502aeac4