### PR TITLE
feat: update play mode navigation and feedback

### DIFF
--- a/apps/web/app/play/[mode]/page.tsx
+++ b/apps/web/app/play/[mode]/page.tsx
@@ -1,50 +1,118 @@
 "use client";
-import React, { useEffect, useState } from "react";
-import { useAttempt } from "@/hooks/useAttempt";
+import React, { useCallback, useEffect, useState } from "react";
 import EditorWithBeatSpawner from "@/components/EditorWithBeatSpawner";
 import FeedbackTray from "@/components/FeedbackTray";
 import LogicNavButtons from "@/components/LogicNavButtons";
 import HighlightablePassage from "@/components/HighlightablePassage";
+import { postJSON } from "@/lib/api";
 
-export default function PlayModePage({ params }: { params: { mode: string } }) {
-  const mode = params.mode;
-  const { current, loadNext, submit, result, isLoading, skip } = useAttempt(mode);
+type PlayParams = {
+  params: { mode: string };
+};
+
+type Item = {
+  id?: string;
+  itemId?: string;
+  passage?: string;
+  mode?: string;
+  [key: string]: any;
+} | null;
+
+export default function PlayModePage({ params }: PlayParams) {
+  const modeParam = params.mode;
+  const userId = "dev";
+
+  const [mode, setMode] = useState<string>(modeParam);
+  const [item, setItem] = useState<Item>(null);
+  const [result, setResult] = useState<any | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
   const [text, setText] = useState("");
   const [rationale, setRationale] = useState("");
-  const [notes, setNotes] = useState<string | undefined>();
+
+  const loadNext = useCallback(async () => {
+    setIsLoading(true);
+    setResult(null);
+    setText("");
+    setRationale("");
+    try {
+      const res = await fetch(`/api/next`, { headers: { "x-user-id": userId } });
+      if (!res.ok) {
+        throw new Error(await res.text());
+      }
+      const data = await res.json();
+      const nextItem = data?.item ?? data ?? null;
+      setItem(nextItem);
+      if (nextItem && typeof nextItem.mode === "string") {
+        setMode(nextItem.mode);
+      } else {
+        setMode(modeParam);
+      }
+    } catch (error) {
+      console.error("Failed to load next item", error);
+      setItem(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [modeParam, userId]);
+
+  const submit = useCallback(async () => {
+    const itemId = (item as any)?.itemId ?? (item as any)?.id;
+    if (!itemId) return;
+    setIsLoading(true);
+    setResult(null);
+    try {
+      const data = await postJSON("/api/attempt", {
+        userId,
+        itemId,
+        mode,
+        answer: { text, rationale },
+      });
+      setResult(data);
+    } catch (error) {
+      console.error("Failed to submit attempt", error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [item, mode, rationale, text, userId]);
+
+  const skip = useCallback(async () => {
+    const itemId = (item as any)?.itemId ?? (item as any)?.id;
+    if (!itemId) return;
+    setIsLoading(true);
+    try {
+      await postJSON("/api/skip", {
+        userId,
+        itemId,
+        mode,
+        reason: "user_skip",
+      });
+      await loadNext();
+    } catch (error) {
+      console.error("Failed to skip item", error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [item, loadNext, mode, userId]);
+
+  const next = useCallback(() => {
+    if (!result) return;
+    void loadNext();
+  }, [result, loadNext]);
 
   useEffect(() => {
     loadNext();
-  }, []);
-
-  const onSubmit = async () => {
-    if (!current) return;
-    await submit(current.itemId, { text, rationale });
-  };
-  const onNext = async () => {
-    setText("");
-    setRationale("");
-    setNotes(undefined);
-    await loadNext();
-  };
-
-  const onSkip = async () => {
-    if (!current?.itemId) return;
-    setText("");
-    setRationale("");
-    setNotes(undefined);
-    await skip(current.itemId);
-  };
+  }, [loadNext]);
 
   const canNext = !!result;
+  const passage = (item as any)?.passage;
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-[1fr_20rem] gap-4 p-4">
+    <div className="grid grid-cols-1 gap-4 p-4 md:grid-cols-[1fr_20rem]">
       <section className="flex flex-col gap-3">
-        {current?.passage ? (
-          <HighlightablePassage text={current.passage} spans={result?.spans} />
+        {passage ? (
+          <HighlightablePassage text={passage} spans={result?.spans} />
         ) : null}
-        <EditorWithBeatSpawner value={text} onChange={setText} onSubmit={onSubmit} />
+        <EditorWithBeatSpawner value={text} onChange={setText} onSubmit={submit} />
         <label className="text-sm" htmlFor="rationale-input">
           Why did you do that?
         </label>
@@ -55,22 +123,15 @@ export default function PlayModePage({ params }: { params: { mode: string } }) {
           onChange={(e) => setRationale(e.target.value)}
         />
         <div className="flex gap-2">
-          <button className="rounded px-3 py-2 border" disabled={isLoading} onClick={onSubmit}>
+          <button className="rounded px-3 py-2 border" disabled={isLoading || !item} onClick={submit}>
             Submit
           </button>
         </div>
       </section>
 
-      <FeedbackTray result={result} notes={notes} onChangeNotes={setNotes} />
+      <FeedbackTray result={result} isLoading={isLoading} />
       <div className="md:col-span-2">
-        <LogicNavButtons
-          canNext={canNext}
-          isLoading={isLoading}
-          onNext={onNext}
-          onRetry={() => setText(text)}
-          onQueue={() => {}}
-          onSkip={onSkip}
-        />
+        <LogicNavButtons canNext={canNext} onNext={next} onSkip={skip} isLoading={isLoading} />
       </div>
     </div>
   );

--- a/apps/web/components/FeedbackTray.tsx
+++ b/apps/web/components/FeedbackTray.tsx
@@ -1,36 +1,39 @@
 import React from "react";
 
 type Props = {
-  result?: any;
-  notes?: string;
-  onChangeNotes?: (v: string) => void;
-  children?: React.ReactNode;
+  result: any | null;
+  isLoading?: boolean;
 };
-export default function FeedbackTray({
-  result,
-  notes,
-  onChangeNotes,
-  children,
-}: Props) {
-  const auto = [
-    result?.score != null ? `Score: ${(result.score * 100).toFixed(0)}%` : "",
-    result?.rubric?.length ? `Rubric: ${result.rubric.join(", ")}` : "",
-    result?.details?.message ?? "",
-    result?.fixSuggestion ? `Suggestion: ${result.fixSuggestion}` : "",
-    result?.next ? `Next hint: ${result.next}` : "",
-  ]
-    .filter(Boolean)
-    .join("\n");
+
+export default function FeedbackTray({ result, isLoading }: Props) {
+  const text =
+    !result ? "" :
+    typeof result === "string" ? result :
+    JSON.stringify(result, null, 2);
+
   return (
-    <aside className="w-full md:w-80 shrink-0 flex flex-col gap-2">
-      <label className="text-sm font-medium">Feedback</label>
+    <div style={{ display: "grid", gap: 8 }}>
+      <label style={{ fontSize: 12, opacity: 0.8 }}>Feedback</label>
       <textarea
-        className="w-full min-h-[200px] rounded-xl border p-2"
-        value={notes ?? auto}
-        onChange={(e) => onChangeNotes?.(e.target.value)}
-        placeholder="Feedback prints here; you can type over it."
+        aria-label="Feedback"
+        readOnly
+        value={isLoading ? "Grading..." : text}
+        style={{
+          width: "100%",
+          minHeight: 160,
+          padding: 12,
+          background: "#0f0f0f",
+          color: "#ddd",
+          border: "1px solid #333",
+          borderRadius: 8,
+          fontFamily:
+            "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+          fontSize: 12,
+          lineHeight: 1.4,
+          whiteSpace: "pre",
+          overflow: "auto",
+        }}
       />
-      {children}
-    </aside>
+    </div>
   );
 }

--- a/apps/web/components/LogicNavButtons.tsx
+++ b/apps/web/components/LogicNavButtons.tsx
@@ -3,36 +3,17 @@ import React from "react";
 type Props = {
   canNext: boolean;
   onNext: () => void;
-  onRetry?: () => void;
-  onQueue?: () => void;
-  onSkip?: () => void;
+  onSkip: () => void;
   isLoading?: boolean;
 };
-export default function LogicNavButtons({
-  canNext,
-  onNext,
-  onRetry,
-  onQueue,
-  onSkip,
-  isLoading,
-}: Props) {
+
+export default function LogicNavButtons({ canNext, onNext, onSkip, isLoading }: Props) {
   return (
-    <div className="flex gap-2">
-      <button type="button" className="rounded px-3 py-2 border" onClick={onRetry}>
-        Retry
-      </button>
-      <button type="button" className="rounded px-3 py-2 border" onClick={onQueue}>
-        Queue Drill
-      </button>
-      <button type="button" className="rounded px-3 py-2 border" onClick={onSkip}>
+    <div style={{ display: "flex", gap: 8, marginTop: 12 }}>
+      <button type="button" onClick={onSkip} className="btn" aria-label="Skip lesson">
         I don’t feel like it
       </button>
-      <button
-        type="button"
-        className="rounded px-3 py-2 bg-black text-white disabled:opacity-40"
-        disabled={!canNext || !!isLoading}
-        onClick={onNext}
-      >
+      <button type="button" onClick={onNext} disabled={!canNext || !!isLoading} className="btn-primary" aria-label="Next lesson">
         Next
       </button>
     </div>

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,0 +1,9 @@
+export async function postJSON(path: string, body: any) {
+  const res = await fetch(path, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add a shared postJSON helper for posting JSON payloads to the API
- simplify the feedback tray to a read-only textarea and slim the navigation buttons to Skip/Next
- refactor the play mode page to use the helper, display feedback, and wire Skip/Next behavior without word-count gating

## Testing
- npm run build
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68f7d0c7b9d0832f985ddf46113484fb