### PR TITLE
Add defensive attempt route mount and ping endpoint

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -19,7 +19,6 @@ const require = createRequire(import.meta.url);
 const fs = require("fs");
 const path = require("path");
 const express = require("express");
-const attemptRoutes = require("./routes/attempt.js");
 const { createReadStream, appendFileSync } = fs;
 const { resolve } = path;
 
@@ -60,7 +59,12 @@ try {
   console.warn('Route mounting warning:', e && e.message);
 }
 
-app.use(attemptRoutes);
+try {
+  app.use(require("./routes/attempt")); // adds GET/POST /api/attempt
+  console.log(">>> Mounted route: /api/attempt");
+} catch (e) {
+  console.warn("Attempt route mount failed:", e && e.message);
+}
 app.use('/api', nextRoutes);
 app.use('/api', skipRoutes);
 

--- a/server/routes/attempt.js
+++ b/server/routes/attempt.js
@@ -1,6 +1,11 @@
 const express = require("express");
 const router = express.Router();
 
+// GET ping so we can verify the route is mounted
+router.get("/api/attempt", (_req, res) => {
+  res.json({ ok: true, ping: "attempt-route-alive" });
+});
+
 /**
  * POST /api/attempt
  * body: { userId, itemId, mode, answer }
@@ -12,8 +17,6 @@ router.post("/api/attempt", express.json(), async (req, res) => {
     return res.status(400).json({ error: "missing userId, itemId, or mode" });
   }
 
-  // TODO: swap this stub for real graders later.
-  // For now: naive scoring (has some answer → pass-ish), echo details.
   const hasAnswer =
     answer != null &&
     (typeof answer === "string" ? answer.trim().length > 0 : true);
@@ -27,10 +30,8 @@ router.post("/api/attempt", express.json(), async (req, res) => {
     { key: "Professionalism", ok: true },
   ];
 
-  // keep spans/sequence shape so Highlight/Order UIs don’t break
-  const spans = [];            // e.g., [{ start: 10, end: 22, tag: "signal" }]
-  const correctSequence = [];  // e.g., ["setup","reveal","payoff"]
-
+  const spans = [];
+  const correctSequence = [];
   const details = {
     message: hasAnswer
       ? "Stub grader: received your answer and awarded provisional credit."
@@ -47,12 +48,12 @@ router.post("/api/attempt", express.json(), async (req, res) => {
     ok: true,
     itemId,
     mode,
-    score,              // 0..1
-    rubric,             // [{key, ok}]
-    spans,              // []
-    correctSequence,    // []
+    score,
+    rubric,
+    spans,
+    correctSequence,
     fixSuggestion: hasAnswer ? "Tighten the sentence. Cut a hedge word." : null,
-    nextHints,          // string[]
+    nextHints,
     details,
     gradedAt: new Date().toISOString(),
   });


### PR DESCRIPTION
## Summary
- add a GET ping endpoint to the attempt router alongside the existing POST handler
- defensively mount the attempt router inside a try/catch to log mounting issues

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f7dfe90cfc832fb7a1113e8b3e7a0a