### PR TITLE
feat: add attempt router to server

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -16,6 +16,7 @@ import skipRoutes from './routes/skip.js';
 import versionRoutes from './routes/version.js';
 import healthRoutes from './routes/health.js';
 import debugContentRoutes from './routes/debugContent.js';
+import attemptRoutes from './routes/attempt.js';
 
 const { createReadStream, appendFileSync } = fs;
 const { resolve } = path;
@@ -57,66 +58,12 @@ try {
   console.warn('Route mounting warning:', e && e.message);
 }
 
-app.get('/api/attempt', (_req, res) => {
-  res.json({ ok: true, ping: 'attempt-route-alive' });
-});
-
-app.post('/api/attempt', (req, res) => {
-  const body = req.body ?? {};
-  const { userId, itemId, mode, answer } = body;
-
-  const hasUserId = typeof userId === 'string' && userId.trim().length > 0;
-  const hasMode = typeof mode === 'string' && mode.trim().length > 0;
-  const hasItemId =
-    (typeof itemId === 'string' && itemId.trim().length > 0) ||
-    (typeof itemId === 'number' && Number.isFinite(itemId));
-  const hasAnswer = Object.prototype.hasOwnProperty.call(body, 'answer');
-
-  if (!hasUserId || !hasMode || !hasItemId || !hasAnswer) {
-    return res.status(400).json({ ok: false, error: 'BadRequest' });
-  }
-
-  let echo;
-  if (typeof answer === 'string') {
-    echo = answer;
-  } else {
-    try {
-      echo = JSON.stringify(answer).slice(0, 200);
-    } catch (err) {
-      echo = String(answer);
-    }
-  }
-
-  res.json({
-    ok: true,
-    itemId,
-    mode,
-    score: 0.8,
-    rubric: [
-      { key: 'Accuracy', ok: true },
-      { key: 'Clarity', ok: true },
-      { key: 'Voice', ok: true },
-      { key: 'Consistency', ok: true },
-      { key: 'Professionalism', ok: true },
-    ],
-    spans: [],
-    correctSequence: [],
-    fixSuggestion: 'Tighten the sentence. Cut a hedge word.',
-    nextHints: ['Try adding a Reveal 👁️ before the Payoff 🎉.'],
-    details: {
-      message: 'Stub grader: received your answer and awarded provisional credit.',
-      mode,
-      echo,
-    },
-    gradedAt: new Date().toISOString(),
-  });
-});
-
-console.log('>>> Mounted POST /api/attempt (stub grader)');
+app.use('/api/attempt', attemptRoutes);
+console.log('>>> Mounted routes: /api/attempt');
 app.use('/api', nextRoutes);
 app.use('/api', skipRoutes);
 
-console.log('>>> Mounted routes: /api/attempt, /api/healthz, /api/version, /api/debug/content, /api/skip');
+console.log('>>> Mounted routes: /api/next, /api/skip, /api/healthz, /api/version, /api/debug/content');
 
 // ====== Sigil JSONL endpoints (unchanged) ======
 const FILE = resolve(process.cwd(), 'labeled data', 'tweetrunk_renumbered.jsonl');

--- a/server/routes/attempt.js
+++ b/server/routes/attempt.js
@@ -1,9 +1,9 @@
-import { Router, json } from "express";
+import { Router } from "express";
 
 const router = Router();
 
 // GET ping so we can verify the route is mounted
-router.get("/api/attempt", (_req, res) => {
+router.get("/", (_req, res) => {
   res.json({ ok: true, ping: "attempt-route-alive" });
 });
 
@@ -12,8 +12,9 @@ router.get("/api/attempt", (_req, res) => {
  * body: { userId, itemId, mode, answer }
  * Returns a normalized result so the UI can render feedback.
  */
-router.post("/api/attempt", json(), async (req, res) => {
+router.post("/", async (req, res) => {
   const { userId, itemId, mode, answer } = req.body || {};
+
   if (!userId || !itemId || !mode) {
     return res.status(400).json({ error: "missing userId, itemId, or mode" });
   }
@@ -47,6 +48,7 @@ router.post("/api/attempt", json(), async (req, res) => {
 
   return res.json({
     ok: true,
+    userId,
     itemId,
     mode,
     score,


### PR DESCRIPTION
## Summary
- replace the inline attempt endpoints with a dedicated Express router that returns the stub grading payload
- mount the attempt router ahead of static serving and log the mounted API routes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f8122374e4832fb69495420cda61e4