### PR TITLE
Add stub attempt API route

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -16,13 +16,42 @@ import skipRoutes from './routes/skip.js';
 import versionRoutes from './routes/version.js';
 import healthRoutes from './routes/health.js';
 import debugContentRoutes from './routes/debugContent.js';
-import attemptRoutes from './routes/attempt.js';
 
 const { createReadStream, appendFileSync } = fs;
 const { resolve } = path;
 
 const __filename = fileURLToPath(import.meta.url);
 const app = express();
+const mounted = [];
+
+const logMountedRoutes = () => {
+  if (!mounted.length) return;
+  const preferredOrder = [
+    '/api/attempt',
+    '/api/healthz',
+    '/api/version',
+    '/api/debug/content',
+    '/api/skip',
+  ];
+  const seen = new Set();
+  const ordered = [];
+
+  for (const route of preferredOrder) {
+    if (mounted.includes(route) && !seen.has(route)) {
+      ordered.push(route);
+      seen.add(route);
+    }
+  }
+
+  for (const route of mounted) {
+    if (!seen.has(route)) {
+      ordered.push(route);
+      seen.add(route);
+    }
+  }
+
+  console.log(`>>> Mounted routes: ${ordered.join(', ')}`);
+};
 
 console.log(">>> BOOTED SERVER FROM", __filename);
 
@@ -52,18 +81,30 @@ if (isProd) {
 // ====== New API routes ======
 try {
   app.use(healthRoutes);
+  mounted.push('/api/healthz');
   app.use(versionRoutes);
+  mounted.push('/api/version');
   app.use(debugContentRoutes);
+  mounted.push('/api/debug/content');
 } catch (e) {
   console.warn('Route mounting warning:', e && e.message);
 }
 
-app.use('/api/attempt', attemptRoutes);
-console.log('>>> Mounted routes: /api/attempt');
 app.use('/api', nextRoutes);
 app.use('/api', skipRoutes);
+mounted.push('/api/skip');
 
-console.log('>>> Mounted routes: /api/next, /api/skip, /api/healthz, /api/version, /api/debug/content');
+const attemptRouteMount = (async () => {
+  try {
+    const mod = await import('./routes/attempt.js');
+    const attemptRouter = mod.default || mod;
+    app.use('/api/attempt', attemptRouter);
+    mounted.push('/api/attempt');
+    logMountedRoutes();
+  } catch (err) {
+    console.error('Attempt route mount failed:', err?.message || err);
+  }
+})();
 
 // ====== Sigil JSONL endpoints (unchanged) ======
 const FILE = resolve(process.cwd(), 'labeled data', 'tweetrunk_renumbered.jsonl');
@@ -209,6 +250,8 @@ app.post('/attempt', express.json(), async (req, res) => {
     res.status(500).json({ error: 'server_error', message: String(e?.message || e) });
   }
 });
+
+await attemptRouteMount;
 
 const distDir = path.join(process.cwd(), "app", "dist");
 const hasDist = fs.existsSync(path.join(distDir, "index.html"));

--- a/server/routes/attempt.js
+++ b/server/routes/attempt.js
@@ -1,65 +1,37 @@
-import { Router } from "express";
+import express from 'express';
 
-const router = Router();
+const router = express.Router();
 
-// GET ping so we can verify the route is mounted
-router.get("/", (_req, res) => {
-  res.json({ ok: true, ping: "attempt-route-alive" });
+router.get('/', (_req, res) => {
+  res.json({ ok: true, ping: 'attempt-route-alive' });
 });
 
-/**
- * POST /api/attempt
- * body: { userId, itemId, mode, answer }
- * Returns a normalized result so the UI can render feedback.
- */
-router.post("/", async (req, res) => {
+router.post('/', express.json(), (req, res) => {
   const { userId, itemId, mode, answer } = req.body || {};
-
-  if (!userId || !itemId || !mode) {
-    return res.status(400).json({ error: "missing userId, itemId, or mode" });
-  }
-
-  const hasAnswer =
-    answer != null &&
-    (typeof answer === "string" ? answer.trim().length > 0 : true);
-
-  const score = hasAnswer ? 0.8 : 0.0;
-  const rubric = [
-    { key: "Accuracy", ok: hasAnswer },
-    { key: "Clarity", ok: hasAnswer },
-    { key: "Voice", ok: true },
-    { key: "Consistency", ok: true },
-    { key: "Professionalism", ok: true },
-  ];
-
-  const spans = [];
-  const correctSequence = [];
-  const details = {
-    message: hasAnswer
-      ? "Stub grader: received your answer and awarded provisional credit."
-      : "Stub grader: no answer detected.",
-    mode,
-    echo: typeof answer === "string" ? answer.slice(0, 240) : answer,
-  };
-
-  const nextHints = hasAnswer
-    ? ["Try adding a Reveal 👁️ before the Payoff 🎉."]
-    : ["Answer anything to proceed; this is a stub grader."];
-
-  return res.json({
+  const payload = {
     ok: true,
-    userId,
     itemId,
     mode,
-    score,
-    rubric,
-    spans,
-    correctSequence,
-    fixSuggestion: hasAnswer ? "Tighten the sentence. Cut a hedge word." : null,
-    nextHints,
-    details,
+    score: 0.8,
+    rubric: [
+      { key: 'Accuracy', ok: true },
+      { key: 'Clarity', ok: true },
+      { key: 'Voice', ok: true },
+      { key: 'Consistency', ok: true },
+      { key: 'Professionalism', ok: true },
+    ],
+    spans: [],
+    correctSequence: [],
+    fixSuggestion: 'Tighten the sentence. Cut a hedge word.',
+    nextHints: ['Try adding a Reveal 👁️ before the Payoff 🎉.'],
+    details: {
+      message: 'Stub grader: received your answer and awarded provisional credit.',
+      mode,
+      echo: String(answer ?? '')
+    },
     gradedAt: new Date().toISOString(),
-  });
+  };
+  res.json(payload);
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- add a dedicated /api/attempt router that serves a ping endpoint and stubbed grading payload
- dynamically import and mount the attempt route during server startup while preserving mounted route logging

## Testing
- npm start
- curl -sS -i http://localhost:3002/api/attempt
- curl -sS -i -X POST http://localhost:3002/api/attempt -H 'content-type: application/json' --data-binary '{"userId":"dev","itemId":"t-185","mode":"why","answer":"Great job"}'


------
https://chatgpt.com/codex/tasks/task_e_68f8194f68a4832f823f565297e7f069