### PR TITLE
Add stub reports API router

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -16,6 +16,7 @@ import skipRoutes from './routes/skip.js';
 import versionRoutes from './routes/version.js';
 import healthRoutes from './routes/health.js';
 import debugContentRoutes from './routes/debugContent.js';
+import reportsRoutes from './routes/reports.js';
 
 const { createReadStream, appendFileSync } = fs;
 const { resolve } = path;
@@ -100,6 +101,9 @@ try {
 app.use('/api', nextRoutes);
 app.use('/api', skipRoutes);
 mounted.push('/api/skip');
+
+app.use('/api/reports', reportsRoutes);
+mounted.push('/api/reports/latest');
 
 const attemptRouteMount = (async () => {
   try {

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -1,0 +1,33 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/latest', (req, res) => {
+  const headerUserId = req.headers['x-user-id'];
+  let userId = 'dev';
+
+  if (typeof headerUserId === 'string' && headerUserId.trim()) {
+    userId = headerUserId.trim();
+  } else if (Array.isArray(headerUserId) && headerUserId.length) {
+    const candidate = headerUserId.find(value => typeof value === 'string' && value.trim());
+    if (candidate) {
+      userId = candidate.trim();
+    }
+  }
+
+  const report = {
+    ok: true,
+    userId,
+    level: 7,
+    badges: ['Beat Detective', 'Comma Wrangler'],
+    memo: {
+      title: 'Professor Ray Ray memo – your current vibe',
+      body: "You lean into visible cause→effect beats and keep the world doing work. Cadence favors short clauses, then a longer gather. You're light on setup→payoff; try planting for later returns. You avoid label-y emotions (nice). Watch for hedges (just, kind of). Nearest neighbors: Baldwin × Chandler. Mortal enemies: PurpleProse, TEDTalk.",
+    },
+    generatedAt: new Date().toISOString(),
+  };
+
+  res.json(report);
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add an express router serving /api/reports/latest with a stubbed payload
- mount the reports router in the server bootstrap and log the route as mounted

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f82a41eda4832f9b6af04b100bab03