### PR TITLE
Add reports memo endpoint and mount dynamically

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -16,7 +16,6 @@ import skipRoutes from './routes/skip.js';
 import versionRoutes from './routes/version.js';
 import healthRoutes from './routes/health.js';
 import debugContentRoutes from './routes/debugContent.js';
-import reportsRoutes from './routes/reports.js';
 
 const { createReadStream, appendFileSync } = fs;
 const { resolve } = path;
@@ -40,6 +39,7 @@ const logMountedRoutes = () => {
     '/api/version',
     '/api/debug/content',
     '/api/skip',
+    '/api/reports/latest',
   ];
   const seen = new Set();
   const ordered = [];
@@ -102,9 +102,6 @@ app.use('/api', nextRoutes);
 app.use('/api', skipRoutes);
 mounted.push('/api/skip');
 
-app.use('/api/reports', reportsRoutes);
-mounted.push('/api/reports/latest');
-
 const attemptRouteMount = (async () => {
   try {
     const mod = await import('./routes/attempt.js');
@@ -114,6 +111,19 @@ const attemptRouteMount = (async () => {
     logMountedRoutes();
   } catch (err) {
     console.error('Attempt route mount failed:', err?.message || err);
+  }
+})();
+
+const reportsRouteMount = (async () => {
+  try {
+    const mod = await import('./routes/reports.js');
+    const reportsRouter = mod.default || mod;
+    // mount at /api so router paths like /reports/latest map to /api/reports/latest
+    app.use('/api', reportsRouter);
+    mounted.push('/api/reports/latest');
+    logMountedRoutes();
+  } catch (err) {
+    console.error('Reports route mount failed:', err?.message || err);
   }
 })();
 
@@ -263,6 +273,7 @@ app.post('/attempt', express.json(), async (req, res) => {
 });
 
 await attemptRouteMount;
+await reportsRouteMount;
 
 // 🔒 Make sure unknown /api/* doesn't fall through to static site
 app.use('/api', (req, res, next) => {

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -1,33 +1,31 @@
-import { Router } from 'express';
+// server/routes/reports.js
+import express from 'express';
 
-const router = Router();
+const router = express.Router();
 
-router.get('/latest', (req, res) => {
-  const headerUserId = req.headers['x-user-id'];
-  let userId = 'dev';
+// Ping to prove router is alive (optional but handy)
+router.get('/reports/ping', (_req, res) => {
+  res.json({ ok: true, ping: 'reports-route-alive' });
+});
 
-  if (typeof headerUserId === 'string' && headerUserId.trim()) {
-    userId = headerUserId.trim();
-  } else if (Array.isArray(headerUserId) && headerUserId.length) {
-    const candidate = headerUserId.find(value => typeof value === 'string' && value.trim());
-    if (candidate) {
-      userId = candidate.trim();
-    }
-  }
-
-  const report = {
-    ok: true,
-    userId,
-    level: 7,
-    badges: ['Beat Detective', 'Comma Wrangler'],
-    memo: {
-      title: 'Professor Ray Ray memo – your current vibe',
-      body: "You lean into visible cause→effect beats and keep the world doing work. Cadence favors short clauses, then a longer gather. You're light on setup→payoff; try planting for later returns. You avoid label-y emotions (nice). Watch for hedges (just, kind of). Nearest neighbors: Baldwin × Chandler. Mortal enemies: PurpleProse, TEDTalk.",
-    },
-    generatedAt: new Date().toISOString(),
+// GET /api/reports/latest -> stub Professor Ray Ray memo
+router.get('/reports/latest', (req, res) => {
+  const userId = (req.headers['x-user-id'] || req.query.userId || 'dev') + '';
+  const memo = {
+    title: `Professor Ray Ray memo for ${userId}`,
+    body: [
+      "VOICE: you favor concrete nouns and sturdy verbs. Keep it.",
+      "CHOICE: you escalate with Red beats (Action/Decision), sprinkle Blue (Reveal/Realization).",
+      "PACE: quick starts, then longer clauses to weight the fallouts.",
+      "INFLUENCES: Hemingway-tendencies; watch for BeigeProse drift when tired.",
+      "NEXT: Try one scene with a Green lead (Nonverbal + Interaction) and an Orange assist (Atmosphere)."
+    ].join('\n'),
+    level: 2,
+    badges: ['Beat Detective', 'Clause Wrangler'],
+    influences: { like: ['Hemingway', 'Baldwin'], avoid: ['BeigeProse'] },
+    generatedAt: new Date().toISOString()
   };
-
-  res.json(report);
+  res.json({ ok: true, memo });
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- add a dedicated reports router that serves a stub Professor Ray Ray memo
- dynamically mount the reports router under /api before static handling and log it with other routes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f82ea1a69c832f8ac521971fd3f098