### PR TITLE
Add reports route logging enhancements

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -40,6 +40,7 @@ const logMountedRoutes = () => {
     '/api/debug/content',
     '/api/skip',
     '/api/reports/latest',
+    '/api/reports/ping',
   ];
   const seen = new Set();
   const ordered = [];
@@ -121,6 +122,7 @@ const reportsRouteMount = (async () => {
     // mount at /api so router paths like /reports/latest map to /api/reports/latest
     app.use('/api', reportsRouter);
     mounted.push('/api/reports/latest');
+    mounted.push('/api/reports/ping');
     logMountedRoutes();
   } catch (err) {
     console.error('Reports route mount failed:', err?.message || err);

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -28,4 +28,5 @@ router.get('/reports/latest', (req, res) => {
   res.json({ ok: true, memo });
 });
 
+export const reportsRouter = router;
 export default router;


### PR DESCRIPTION
## Summary
- include the reports endpoints in the server's mounted route logging
- expose the reports router as both a default and named export for reuse

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f8307f7d30832f87e519d54e713b6f