### PR TITLE
Implement mastery tracking and feedback pipeline

### DIFF
--- a/app/src/components/FeedbackTray.jsx
+++ b/app/src/components/FeedbackTray.jsx
@@ -1,6 +1,6 @@
 export default function FeedbackTray({
   item: _item = null,
-  answer: _answer = '',
+  answer = '',
   setAnswer: _setAnswer = null,
   result = null,
   onSubmit = null,
@@ -9,50 +9,86 @@ export default function FeedbackTray({
   isLoading = false,
   error = '',
 }) {
-  const lines = [];
+  const summaryLines = [];
   if (result) {
     if (result.score != null) {
-      lines.push(`Score: ${Math.round(result.score * 100)}%`);
+      const percent = Number.isFinite(result.score) ? Math.round(result.score * 100) : result.score;
+      summaryLines.push(`score: ${percent}%`);
     }
     if (Array.isArray(result.rubric) && result.rubric.length) {
-      lines.push(`Rubric: ${result.rubric.join(', ')}`);
+      summaryLines.push(`rubric: ${result.rubric.join(' | ')}`);
     }
     if (result.details?.message) {
-      lines.push(`Message: ${result.details.message}`);
+      summaryLines.push(`note: ${result.details.message}`);
     }
     if (result.fixSuggestion) {
-      lines.push(`Suggestion: ${result.fixSuggestion}`);
+      summaryLines.push(`fix: ${result.fixSuggestion}`);
     }
     if (Array.isArray(result.nextHints) && result.nextHints.length) {
-      for (const hint of result.nextHints) {
-        lines.push(`Hint: ${hint}`);
-      }
+      result.nextHints.forEach((hint, index) => {
+        summaryLines.push(`hint ${index + 1}: ${hint}`);
+      });
     }
-    if (result.leveledUp && result.level) {
-      lines.push(`Level Up! Level ${result.level}`);
-    }
-    if (result.memo?.title) {
-      lines.push(`${result.memo.title}`);
-    }
-    if (result.memo?.body) {
-      lines.push(result.memo.body);
+    if (result.details?.expAward != null) {
+      summaryLines.push(`exp earned: ${result.details.expAward}`);
     }
   }
 
-  const value = lines.join('\n\n');
+  const value = summaryLines.join('\n');
+
+  const hasAnswer = (() => {
+    if (answer == null) return false;
+    if (typeof answer === 'string') return Boolean(answer.trim());
+    if (typeof answer === 'object') return Object.keys(answer).length > 0;
+    if (Array.isArray(answer)) return answer.length > 0;
+    return Boolean(answer);
+  })();
+
+  const showLevelUp = Boolean(result?.memo);
+  const badges = Array.isArray(result?.badges) ? result.badges.filter(Boolean) : [];
 
   return (
     <div className="sigil-feedback-tray">
       <textarea
         className="feedback-box"
         readOnly
-        rows={8}
+        rows={10}
         value={value}
         placeholder="Submit to see feedback."
       />
 
+      {showLevelUp ? (
+        <div className="level-up-panel" style={{ marginTop: 12, padding: 12, border: '1px solid #000', background: '#ffe9cf' }}>
+          <div style={{ fontWeight: 700, marginBottom: 4 }}>Level Up! Level {result.level ?? '—'}</div>
+          {badges.length ? (
+            <div style={{ marginBottom: 8 }}>
+              {badges.map((badge) => (
+                <span
+                  key={badge}
+                  style={{
+                    display: 'inline-block',
+                    border: '1px solid #000',
+                    padding: '2px 6px',
+                    marginRight: 6,
+                    marginBottom: 6,
+                    background: '#fff',
+                    fontSize: 12,
+                  }}
+                >
+                  {badge}
+                </span>
+              ))}
+            </div>
+          ) : null}
+          <div style={{ fontWeight: 600 }}>{result.memo?.title}</div>
+          {result.memo?.body ? (
+            <pre style={{ whiteSpace: 'pre-wrap', marginTop: 8 }}>{result.memo.body}</pre>
+          ) : null}
+        </div>
+      ) : null}
+
       {error ? (
-        <div className="feedback-error" role="alert">
+        <div className="feedback-error" role="alert" style={{ marginTop: 8 }}>
           {error}
         </div>
       ) : null}
@@ -64,12 +100,12 @@ export default function FeedbackTray({
             data-testid="btn-submit"
             className="pfp-btn"
             onClick={onSubmit}
-            disabled={isLoading}
+            disabled={isLoading || !hasAnswer}
           >
             {isLoading ? 'Submitting…' : 'Submit & Grade'}
           </button>
         ) : null}
-        {onNext ? (
+        {onNext && result ? (
           <button
             type="button"
             data-testid="btn-next"

--- a/app/src/lib/attemptApi.js
+++ b/app/src/lib/attemptApi.js
@@ -1,4 +1,4 @@
-export async function apiNext(userId = 'dev') {
+export async function getNext(userId = 'dev') {
   const res = await fetch('/api/next', {
     headers: {
       'x-user-id': userId,
@@ -10,7 +10,7 @@ export async function apiNext(userId = 'dev') {
   return res.json();
 }
 
-export async function apiAttempt({ userId = 'dev', itemId, mode, answer }) {
+export async function postAttempt({ userId = 'dev', itemId, mode, answer }) {
   const res = await fetch('/api/attempt', {
     method: 'POST',
     headers: {
@@ -26,25 +26,30 @@ export async function apiAttempt({ userId = 'dev', itemId, mode, answer }) {
   return res.json();
 }
 
-export async function apiSkip({ userId = 'dev', itemId, mode }) {
+export async function getLatestReport(userId = 'dev') {
+  const res = await fetch('/api/reports/latest', {
+    headers: {
+      'x-user-id': userId,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`reports_failed:${res.status}`);
+  }
+  return res.json();
+}
+
+export async function skipItem({ userId = 'dev', itemId, mode }) {
   const res = await fetch('/api/skip', {
     method: 'POST',
     headers: {
       'content-type': 'application/json',
+      'x-user-id': userId,
     },
     body: JSON.stringify({ userId, itemId, mode, reason: 'user_skip' }),
   });
   if (!res.ok) {
     const text = await res.text().catch(() => '');
     throw new Error(text || `skip_failed:${res.status}`);
-  }
-  return res.json();
-}
-
-export async function apiLatestReport(userId = 'dev') {
-  const res = await fetch(`/api/reports/latest?userId=${encodeURIComponent(userId)}`);
-  if (!res.ok) {
-    throw new Error(`reports_failed:${res.status}`);
   }
   return res.json();
 }

--- a/app/src/pages/SigilRunner.jsx
+++ b/app/src/pages/SigilRunner.jsx
@@ -7,7 +7,7 @@ import BeatTextEditor from '@/components/BeatTextEditor.jsx';
 import { beatsForLesson } from '@/logic/beatUnlockSchedule';
 import { useBeatUnlocks } from '@/state/useBeatUnlocks';
 import { getLesson } from '@/services/sigilLesson';
-import { apiAttempt, apiNext, apiSkip } from '@/lib/attemptApi.js';
+import { postAttempt, getNext, skipItem } from '@/lib/attemptApi.js';
 
 const USER_ID = 'dev';
 const MODE = 'sigil';
@@ -79,7 +79,7 @@ export default function SigilRunner() {
       if (!id) {
         setLoading(true);
         try {
-          const payload = await apiNext(USER_ID);
+          const payload = await getNext(USER_ID);
           if (ignore) return;
           const nextItem = payload?.item || null;
           if (nextItem?.id) {
@@ -195,7 +195,7 @@ export default function SigilRunner() {
         plainText,
         mode: currentItem?.mode || MODE,
       });
-      const response = await apiAttempt({
+      const response = await postAttempt({
         userId: USER_ID,
         itemId: String(itemId),
         mode: currentItem?.mode || MODE,
@@ -224,7 +224,7 @@ export default function SigilRunner() {
     setPendingInsert(null);
     setLoading(true);
     try {
-      const payload = await apiNext(USER_ID);
+      const payload = await getNext(USER_ID);
       const nextItem = payload?.item || null;
       setCurrentItem(nextItem || null);
       const nextId = nextItem?.id ? String(nextItem.id) : null;
@@ -271,7 +271,7 @@ export default function SigilRunner() {
       return;
     }
     try {
-      await apiSkip({ userId: USER_ID, itemId: String(itemId), mode: currentItem?.mode || MODE });
+      await skipItem({ userId: USER_ID, itemId: String(itemId), mode: currentItem?.mode || MODE });
     } catch (e) {
       setSubmitError(e?.message || 'Failed to record skip.');
     }

--- a/server/db/mem.js
+++ b/server/db/mem.js
@@ -1,76 +1,245 @@
+const MAX_USER_ATTEMPTS = 200;
+const MAX_GLOBAL_ATTEMPTS = 2000;
+const MAX_USER_SKIPS = 200;
+const MAX_GLOBAL_SKIPS = 1000;
+
 export const mem = {
   attempts: [],
-  mastery: new Map(),
-  skips: [],
   reports: new Map(),
+  users: new Map(),
   seen: new Map(),
+  skips: [],
 };
 
+const clampScore = (value) => {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+};
+
+const normalizeRubric = (rubric) => {
+  if (!Array.isArray(rubric)) return [];
+  return rubric.map((entry) => String(entry || '')).filter(Boolean);
+};
+
+const normalizeHints = (hints) => {
+  if (!Array.isArray(hints)) return [];
+  return hints.map((hint) => String(hint || '')).filter(Boolean);
+};
+
+const normalizeSequence = (sequence) => {
+  if (!Array.isArray(sequence)) return [];
+  return sequence.map((entry) => String(entry || '')).filter(Boolean);
+};
+
+const normalizeSpans = (spans) => {
+  if (!Array.isArray(spans)) return [];
+  return spans
+    .map((span) => {
+      const start = Number(span?.start ?? span?.[0]);
+      const end = Number(span?.end ?? span?.[1]);
+      if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
+      const a = Math.max(0, Math.min(start, end));
+      const b = Math.max(0, Math.max(start, end));
+      if (b <= a) return null;
+      return { start: a, end: b };
+    })
+    .filter(Boolean);
+};
+
+const safeDetails = (details) => {
+  if (details && typeof details === 'object' && !Array.isArray(details)) {
+    return { ...details };
+  }
+  return {};
+};
+
+const computeLevel = (exp) => Math.floor(exp / 100) + 1;
+
+const BADGE_PAIRS = [
+  ['Beat Detective', 'Comma Tamer'],
+  ['Cadence Keeper', 'Image Wrangler'],
+  ['Rhythm Wrangler', 'Heat Seeker'],
+  ['Plot Architect', 'Voice Sculpter'],
+  ['Tempo Fencer', 'Pivot Hunter'],
+];
+
+function badgesForLevel(level) {
+  if (level <= 1) return [];
+  const index = (level - 2) % BADGE_PAIRS.length;
+  const pair = BADGE_PAIRS[index] || BADGE_PAIRS[0];
+  return pair.slice();
+}
+
+function ensureUser(userId) {
+  const id = String(userId || 'dev');
+  if (!mem.users.has(id)) {
+    mem.users.set(id, {
+      totalExp: 0,
+      level: 1,
+      lastLevelAck: 1,
+      skills: new Map(),
+      attempts: [],
+      skips: [],
+      badgeHistory: [],
+    });
+  }
+  return mem.users.get(id);
+}
+
 function ensureSeenSet(userId) {
-  if (!mem.seen.has(userId)) {
-    mem.seen.set(userId, new Set());
+  const id = String(userId || 'dev');
+  if (!mem.seen.has(id)) {
+    mem.seen.set(id, new Set());
   }
-  return mem.seen.get(userId);
+  return mem.seen.get(id);
 }
 
-export function addAttempt(attempt) {
-  const normalized = {
-    ...attempt,
-    userId: String(attempt.userId),
-    itemId: String(attempt.itemId),
-    mode: attempt.mode ?? 'why',
+export function recordAttempt({
+  userId,
+  itemId,
+  mode,
+  score,
+  rubric,
+  spans,
+  correctSequence,
+  fixSuggestion,
+  nextHints,
+  details,
+  gradedAt,
+} = {}) {
+  const uid = String(userId || 'dev');
+  const iid = String(itemId || '');
+  const safeMode = String(mode || 'why');
+  const ts = Date.now();
+  const record = {
+    userId: uid,
+    itemId: iid,
+    mode: safeMode,
+    score: clampScore(Number(score ?? 0)),
+    rubric: normalizeRubric(rubric),
+    spans: normalizeSpans(spans),
+    correctSequence: normalizeSequence(correctSequence),
+    fixSuggestion: fixSuggestion ? String(fixSuggestion) : null,
+    nextHints: normalizeHints(nextHints),
+    details: safeDetails(details),
+    ts,
+    gradedAt: gradedAt || new Date(ts).toISOString(),
   };
-  mem.attempts.push(normalized);
-  ensureSeenSet(normalized.userId).add(String(normalized.itemId));
-  return normalized;
-}
 
-export function addSkip(skip) {
-  const normalized = {
-    ...skip,
-    userId: String(skip.userId),
-    itemId: String(skip.itemId),
-    mode: skip.mode ?? 'why',
-    ts: skip.ts ?? Date.now(),
-  };
-  mem.skips.push(normalized);
-  ensureSeenSet(normalized.userId).add(String(normalized.itemId));
-  return normalized;
-}
-
-export function getLatestReport(userId) {
-  return mem.reports.get(String(userId)) || null;
-}
-
-export function saveReport(userId, report) {
-  mem.reports.set(String(userId), report);
-  return report;
-}
-
-export function bumpMastery(userId, skillId, delta = 10) {
-  const key = `${userId}:${skillId}`;
-  const current = mem.mastery.get(key) || { level: 1, exp: 0 };
-  current.exp += delta;
-  while (current.exp >= 100) {
-    current.exp -= 100;
-    current.level += 1;
+  mem.attempts.push(record);
+  if (mem.attempts.length > MAX_GLOBAL_ATTEMPTS) {
+    mem.attempts.splice(0, mem.attempts.length - MAX_GLOBAL_ATTEMPTS);
   }
-  mem.mastery.set(key, current);
-  return current;
+
+  const user = ensureUser(uid);
+  user.attempts.unshift(record);
+  if (user.attempts.length > MAX_USER_ATTEMPTS) {
+    user.attempts.splice(MAX_USER_ATTEMPTS);
+  }
+
+  ensureSeenSet(uid).add(iid);
+  return record;
+}
+
+export function getAttempts(userId, { limit = 50 } = {}) {
+  const user = ensureUser(userId);
+  if (!user.attempts.length) return [];
+  const slice = user.attempts.slice(0, Math.max(0, limit));
+  return slice.map((attempt) => ({ ...attempt, details: safeDetails(attempt.details) }));
+}
+
+export function addExp(userId, skillIds = [], exp = 0) {
+  const user = ensureUser(userId);
+  const award = Number.isFinite(exp) ? Math.max(0, Math.round(exp)) : 0;
+  user.totalExp += award;
+  user.level = computeLevel(user.totalExp);
+
+  const skills = Array.isArray(skillIds) ? skillIds.map((id) => String(id)).filter(Boolean) : [];
+  for (const skillId of skills) {
+    const current = user.skills.get(skillId) || { exp: 0, level: 1 };
+    current.exp += award;
+    current.level = computeLevel(current.exp);
+    user.skills.set(skillId, current);
+  }
+
+  return { totalExp: user.totalExp, level: user.level };
 }
 
 export function getMastery(userId) {
-  const prefix = `${userId}:`;
-  const out = {};
-  for (const [key, value] of mem.mastery) {
-    if (key.startsWith(prefix)) {
-      const [, skill] = key.split(':');
-      out[skill] = value;
-    }
+  const user = ensureUser(userId);
+  const skills = {};
+  for (const [skillId, data] of user.skills.entries()) {
+    skills[skillId] = { exp: data.exp, level: data.level };
   }
-  return out;
+  return {
+    totalExp: user.totalExp,
+    level: user.level,
+    skills,
+  };
+}
+
+export function checkLevelUp(userId) {
+  const user = ensureUser(userId);
+  const previous = user.lastLevelAck ?? user.level;
+  const leveledUp = user.level > previous;
+  if (!leveledUp) {
+    return { leveledUp: false, level: user.level, badges: [] };
+  }
+
+  const badges = [];
+  for (let level = previous + 1; level <= user.level; level += 1) {
+    badges.push(...badgesForLevel(level));
+  }
+
+  user.lastLevelAck = user.level;
+  user.badgeHistory.push(...badges);
+
+  return { leveledUp: true, level: user.level, badges };
+}
+
+export function saveReport(userId, memoObject) {
+  const id = String(userId || 'dev');
+  const memo = memoObject ? { ...memoObject } : null;
+  if (memo) {
+    mem.reports.set(id, memo);
+  }
+  return memo;
+}
+
+export function getLatestReport(userId) {
+  const id = String(userId || 'dev');
+  return mem.reports.get(id) || null;
+}
+
+export function markSkipped(userId, itemId, { mode, reason } = {}) {
+  const uid = String(userId || 'dev');
+  const iid = String(itemId || '');
+  const entry = {
+    userId: uid,
+    itemId: iid,
+    mode: mode ? String(mode) : undefined,
+    reason: reason ? String(reason) : 'user_skip',
+    ts: Date.now(),
+  };
+
+  mem.skips.push(entry);
+  if (mem.skips.length > MAX_GLOBAL_SKIPS) {
+    mem.skips.splice(0, mem.skips.length - MAX_GLOBAL_SKIPS);
+  }
+
+  const user = ensureUser(uid);
+  user.skips.unshift(entry);
+  if (user.skips.length > MAX_USER_SKIPS) {
+    user.skips.splice(MAX_USER_SKIPS);
+  }
+
+  ensureSeenSet(uid).add(iid);
+  return entry;
 }
 
 export function userSeenSet(userId) {
-  return mem.seen.get(String(userId)) || new Set();
+  const set = ensureSeenSet(userId);
+  return new Set(set);
 }

--- a/server/graders/index.js
+++ b/server/graders/index.js
@@ -1,3 +1,5 @@
+const SUPPORTED_MODES = ['why', 'name', 'missing', 'order', 'highlight', 'fix'];
+
 const clampScore = (value) => {
   if (!Number.isFinite(value)) return 0;
   if (value < 0) return 0;
@@ -7,174 +9,427 @@ const clampScore = (value) => {
 
 const defaultRubric = ['Accuracy', 'Clarity', 'Voice'];
 
-function normalizeSkillIds(result, item, mode) {
-  if (Array.isArray(result?.skillIds) && result.skillIds.length) {
-    return result.skillIds.map(String);
+const toLower = (value) => String(value || '').trim().toLowerCase();
+
+const normalizeStringList = (input) => {
+  if (!input) return [];
+  if (Array.isArray(input)) {
+    return input
+      .map((entry) => toLower(typeof entry === 'string' ? entry : entry?.id ?? entry))
+      .filter(Boolean);
   }
+  if (typeof input === 'string') {
+    return input
+      .split(/[\s,]+/)
+      .map((entry) => entry.trim().toLowerCase())
+      .filter(Boolean);
+  }
+  return [];
+};
+
+const normalizeSpans = (spans) => {
+  if (!Array.isArray(spans)) return [];
+  return spans
+    .map((span) => {
+      const start = Number(span?.start ?? span?.[0]);
+      const end = Number(span?.end ?? span?.[1]);
+      if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
+      const a = Math.max(0, Math.min(start, end));
+      const b = Math.max(0, Math.max(start, end));
+      if (b <= a) return null;
+      return { start: a, end: b };
+    })
+    .filter(Boolean);
+};
+
+const safeDetails = (details) => {
+  if (details && typeof details === 'object' && !Array.isArray(details)) {
+    return { ...details };
+  }
+  return {};
+};
+
+const normalizeHints = (hints) => {
+  if (!Array.isArray(hints)) return [];
+  return hints.map((hint) => String(hint || '').trim()).filter(Boolean);
+};
+
+const scoreFromWordCount = (wordCount) => {
+  if (!Number.isFinite(wordCount) || wordCount <= 0) return 0.25;
+  if (wordCount >= 120) return 0.95;
+  if (wordCount >= 60) return 0.85;
+  if (wordCount >= 30) return 0.7;
+  return 0.45;
+};
+
+const defaultDetails = (mode) => ({ mode, message: 'graded' });
+
+const skillIdFallback = (item, mode) => {
   if (Array.isArray(item?.skillIds) && item.skillIds.length) {
-    return item.skillIds.map(String);
+    return item.skillIds.map((id) => String(id));
+  }
+  if (Array.isArray(item?.meta?.beat_tags) && item.meta.beat_tags.length) {
+    return item.meta.beat_tags.map((id) => String(id));
   }
   return [`craft.${mode}`];
-}
+};
 
-function why({ answer, item, mode }) {
-  const text = typeof answer === 'string' ? answer : (answer?.text ?? '');
-  const trimmed = String(text || '').trim();
-  if (!trimmed) {
-    return {
-      score: 0,
-      rubric: defaultRubric,
-      spans: [],
-      correctSequence: [],
-      details: { message: 'Tell us why you write. An empty page cannot be graded.', mode },
-      nextHints: ['Try listing a motive, a character, or a scene fragment.'],
-      skillIds: normalizeSkillIds(null, item, mode),
-    };
+const getGoldBeats = (item) => {
+  const beats = new Set();
+  normalizeStringList(item?.gold?.order).forEach((beat) => beats.add(beat));
+  normalizeStringList(item?.meta?.beat_tags).forEach((beat) => beats.add(beat));
+  normalizeStringList(item?.skillIds).forEach((beat) => beats.add(beat));
+  return Array.from(beats);
+};
+
+const overlap = (a, b) => {
+  const entries = new Set(a);
+  let matches = 0;
+  for (const value of b) {
+    if (entries.has(value)) matches += 1;
   }
+  return { matches, total: b.length };
+};
 
-  const wordCount = trimmed.split(/\s+/).filter(Boolean).length;
-  const density = Math.min(1, wordCount / 80);
-  const score = clampScore(0.7 + density * 0.2);
-  const message = wordCount > 40
-    ? 'Strong motive and detail. Consider adding a surprising image.'
-    : 'Good start—push for one concrete image or beat.';
+const pickMessage = (score, { high, mid, low }) => {
+  if (score >= 0.85) return high;
+  if (score >= 0.6) return mid;
+  return low;
+};
+
+const gradeWhy = ({ item, answer }) => {
+  const text = typeof answer === 'string' ? answer : String(answer?.text ?? answer?.raw ?? '').trim();
+  const clean = text.trim();
+  const wordCount = clean ? clean.split(/\s+/).filter(Boolean).length : 0;
+  const beatHits = getGoldBeats(item);
+  const hasBeatCallout = beatHits.some((beat) => {
+    const escaped = beat.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp(`\\b${escaped}\\b`, 'i').test(clean);
+  });
+  const hasBecause = /\b(because|so that|therefore|to unlock)\b/i.test(clean);
+  const hasImage = /(heat|light|shadow|color|texture|sound)/i.test(clean);
+
+  const score = clampScore(Math.min(0.98, scoreFromWordCount(wordCount) + (hasBeatCallout ? 0.08 : 0) + (hasImage ? 0.04 : 0)));
+  const message = pickMessage(score, {
+    high: 'Layered rationale with specific images—keep the pressure.',
+    mid: 'Solid motive—add one more concrete beat or consequence.',
+    low: 'Give us a clear motive and the beat that will carry it.',
+  });
 
   return {
     score,
     rubric: defaultRubric,
     spans: [],
     correctSequence: [],
-    details: { message, mode },
-    fixSuggestion: 'Name one sensory detail or consequence to deepen the motive.',
-    nextHints: ['Tag a beat like [ACTION] or [REVEAL] to anchor the intent.'],
-    skillIds: normalizeSkillIds(null, item, mode),
+    fixSuggestion: 'Name the beat you are steering toward and drop in one sensory hook.',
+    nextHints: [
+      hasBeatCallout ? 'Push the reveal or payoff one step further.' : 'Try adding a Reveal 👁️ before the Payoff 🎉.',
+      hasBecause ? 'Layer the stakes: what changes if the beat lands?' : 'Connect motive to stakes with a “because” clause.',
+    ],
+    details: { message, wordCount, mode: 'why' },
   };
-}
+};
 
-function name({ answer, item, mode }) {
-  const sigils = Array.isArray(answer?.sigils) ? answer.sigils : [];
-  const unique = Array.from(new Set(sigils.map((s) => String(s).toLowerCase().trim()).filter(Boolean)));
-  const score = unique.length ? 0.7 : 0.2;
-  const message = unique.length
-    ? `Noted ${unique.length} sigil${unique.length === 1 ? '' : 's'}.`
-    : 'No sigils detected—drop in tags like [ACTION] or [REVEAL].';
+const gradeName = ({ item, answer, mode = 'name' }) => {
+  const submitted = normalizeStringList(
+    typeof answer === 'string'
+      ? answer
+      : Array.isArray(answer?.sigils)
+        ? answer.sigils
+        : answer
+  );
 
-  return {
-    score,
-    rubric: ['Identification', 'Clarity'],
-    spans: [],
-    correctSequence: [],
-    details: { message, mode },
-    nextHints: unique.length ? ['Add a reason why this beat matters.'] : ['Tag at least one beat to identify.'],
-    skillIds: normalizeSkillIds({ skillIds: [`sigil.name.${unique.length}`] }, item, mode),
-  };
-}
+  const goldBeats = normalizeStringList(item?.gold?.rationaleTags);
+  const skillBeats = normalizeStringList(item?.meta?.beat_tags);
+  const canonical = new Set([...goldBeats, ...skillBeats]);
 
-function highlight({ answer, item, mode }) {
-  const spans = Array.isArray(answer?.spans) ? answer.spans : [];
-  const totalLength = typeof item?.passage === 'string' ? item.passage.length : Number(item?.meta?.length ?? 0);
-  const denominator = totalLength > 0 ? totalLength : 1;
-  const coverage = spans.reduce((sum, span) => {
-    const start = Number(span?.start ?? 0);
-    const end = Number(span?.end ?? 0);
-    if (!Number.isFinite(start) || !Number.isFinite(end)) return sum;
-    return sum + Math.max(0, end - start);
-  }, 0);
-  const fraction = Math.max(0, Math.min(1, coverage / denominator));
-  const score = clampScore(fraction);
-
-  const message = fraction >= 0.5
-    ? 'Great coverage—your highlights track the signal.'
-    : 'Consider highlighting the key pivot sentences.';
-
-  return {
-    score,
-    rubric: ['Coverage', 'Precision'],
-    spans,
-    correctSequence: [],
-    details: { message, mode },
-    nextHints: ['Aim for the moment the tone or stakes shift.'],
-    skillIds: normalizeSkillIds(null, item, mode),
-  };
-}
-
-function order({ answer, item, mode }) {
-  const submitted = Array.isArray(answer?.order) ? answer.order.map((s) => String(s)) : [];
-  const gold = Array.isArray(item?.gold?.order) ? item.gold.order.map((s) => String(s)) : [];
-  if (!gold.length) {
+  if (!canonical.size) {
     return {
-      score: submitted.length ? 0.5 : 0,
-      rubric: ['Sequence'],
+      score: 0.7,
+      rubric: ['Identification', 'Beat Fit'],
       spans: [],
       correctSequence: [],
-      details: { message: 'No canonical order provided—awarding partial credit.', mode },
-      nextHints: [],
-      skillIds: normalizeSkillIds(null, item, mode),
+      fixSuggestion: 'List each beat explicitly—comma-separated works great.',
+      nextHints: ['Anchor each tag to a specific turn in the text.'],
+      details: { message: 'No reference beats available; granting neutral credit.', provided: submitted, mode },
     };
   }
 
+  const { matches, total } = overlap(canonical, submitted);
+  const coverage = total ? matches / canonical.size : 0;
+  const score = clampScore(Math.max(0, coverage));
+
+  const missList = [...canonical].filter((beat) => !submitted.includes(beat));
+
+  return {
+    score,
+    rubric: ['Identification', 'Beat Fit'],
+    spans: [],
+    correctSequence: [],
+    fixSuggestion: missList.length ? `Double-check the beat(s): ${missList.join(', ')}.` : null,
+    nextHints: missList.length
+      ? ['Re-read the turn where tone or stakes shift and tag that beat.']
+      : ['Add a quick why-this-matters note next time to cement the tag.'],
+    details: {
+      message: matches === canonical.size ? 'Perfect tag coverage.' : `Tagged ${matches} of ${canonical.size} reference beats.`,
+      provided: submitted,
+      expected: [...canonical],
+      mode,
+    },
+  };
+};
+
+const gradeMissing = ({ item, answer, mode = 'missing' }) => {
+  const inserted = toLower(typeof answer === 'string' ? answer : answer?.insertBeat ?? answer?.text ?? '');
+  const expected = toLower(item?.gold?.expected ?? item?.gold?.missingBeat ?? '');
+
+  if (!expected) {
+    return {
+      score: 0.7,
+      rubric: ['Beat Sense', 'Continuity'],
+      spans: [],
+      correctSequence: [],
+      fixSuggestion: 'Frame the beat in terms of how it shifts the stakes.',
+      nextHints: ['Describe the action or emotion that would bridge the gap.'],
+      details: { message: 'No gold beat provided; awarding middle credit.', provided: inserted || null, mode },
+    };
+  }
+
+  const correct = inserted === expected || (inserted && expected && expected.includes(inserted));
+  const score = correct ? 1 : inserted ? 0.45 : 0.2;
+
+  return {
+    score: clampScore(score),
+    rubric: ['Beat Sense', 'Continuity'],
+    spans: [],
+    correctSequence: [],
+    fixSuggestion: correct ? null : `Aim for “${expected}” to restore the flow.`,
+    nextHints: correct
+      ? ['Try writing that beat into the passage to cement it.']
+      : ['Name the emotion or action that would reset momentum.'],
+    details: {
+      message: correct ? 'Exactly the missing beat.' : `Expected “${expected}”.`,
+      provided: inserted || null,
+      expected,
+      mode,
+    },
+  };
+};
+
+const gradeOrder = ({ item, answer, mode = 'order' }) => {
+  const gold = normalizeStringList(item?.gold?.order);
+  if (!gold.length) {
+    return {
+      score: 0.7,
+      rubric: ['Sequence', 'Tempo'],
+      spans: [],
+      correctSequence: [],
+      fixSuggestion: 'Focus on the pivot beat and let the rest fall around it.',
+      nextHints: ['Track how tension rises—order follows that spine.'],
+      details: { message: 'No canonical order provided; neutral score.', mode },
+    };
+  }
+
+  const submitted = normalizeStringList(
+    Array.isArray(answer?.order)
+      ? answer.order
+      : typeof answer === 'string'
+        ? answer
+        : answer?.sequence ?? []
+  );
+
   const total = gold.length;
   let correct = 0;
+  const misplacements = [];
+
   for (let i = 0; i < total; i += 1) {
-    if (submitted[i] && submitted[i] === gold[i]) correct += 1;
+    if (submitted[i] === gold[i]) {
+      correct += 1;
+    } else if (submitted[i]) {
+      misplacements.push({ expected: gold[i], received: submitted[i] });
+    }
   }
+
   const score = clampScore(total ? correct / total : 0);
-  const message = score === 1
-    ? 'Perfect sequence.'
-    : `Placed ${correct} of ${total} beats correctly.`;
+  const fixSuggestion = score === 1 ? null : 'Rebuild the order around the midpoint reveal or reversal.';
 
   return {
     score,
     rubric: ['Sequence', 'Tempo'],
     spans: [],
     correctSequence: gold,
-    details: { message, mode },
-    nextHints: ['Compare your order to the gold to see what shifted.'],
-    skillIds: normalizeSkillIds(null, item, mode),
+    fixSuggestion,
+    nextHints: [
+      score === 1 ? 'Run it once more, faster—lock the tempo.' : 'Compare each slot with the gold order and adjust the pivot beats.',
+    ],
+    details: {
+      message: score === 1 ? 'Perfect sequence.' : `Placed ${correct} of ${total} beats correctly.`,
+      provided: submitted,
+      expected: gold,
+      misplacements,
+      mode,
+    },
   };
-}
+};
 
-function fix({ answer, item, mode }) {
-  const choice = typeof answer?.choice === 'string' ? answer.choice.trim().toUpperCase() : '';
-  const goldChoice = String(item?.gold?.choice ?? item?.gold?.choiceId ?? '').trim().toUpperCase();
-  const correct = Boolean(choice) && choice === goldChoice;
-  const score = correct ? 1 : 0;
+const gradeHighlight = ({ item, answer, mode = 'highlight' }) => {
+  const submittedSpans = normalizeSpans(Array.isArray(answer?.spans) ? answer.spans : answer?.spans ? [answer.spans] : []);
+  const goldInput = item?.gold?.spans ?? [];
+  const goldSpans = normalizeSpans(goldInput);
+
+  if (!submittedSpans.length) {
+    return {
+      score: goldSpans.length ? 0.2 : 0.4,
+      rubric: ['Coverage', 'Precision'],
+      spans: [],
+      correctSequence: [],
+      fixSuggestion: 'Highlight the exact sentence where the tone or stakes flip.',
+      nextHints: ['Scan for the moment pressure spikes or the reveal lands.'],
+      details: { message: 'No spans submitted.', expectedSpans: goldSpans.length, mode },
+    };
+  }
+
+  const passageLength = typeof item?.passage === 'string' ? item.passage.length : Number(item?.meta?.length ?? 0) || 0;
+  const totalSubmission = submittedSpans.reduce((sum, span) => sum + (span.end - span.start), 0);
+
+  if (!goldSpans.length) {
+    const coverageRatio = passageLength ? Math.min(1, totalSubmission / Math.max(1, passageLength)) : 0.6;
+    const score = clampScore(0.4 + coverageRatio * 0.5);
+    return {
+      score,
+      rubric: ['Coverage', 'Precision'],
+      spans: submittedSpans,
+      correctSequence: [],
+      fixSuggestion: score > 0.7 ? null : 'Tighten the highlight to the most charged sentence.',
+      nextHints: ['Focus on the language shift—the reveal hides there.'],
+      details: {
+        message: 'Gold spans unavailable; grading by coverage.',
+        coverage: coverageRatio,
+        mode,
+      },
+    };
+  }
+
+  const goldTotal = goldSpans.reduce((sum, span) => sum + (span.end - span.start), 0);
+  const overlapLength = submittedSpans.reduce((sum, span) => {
+    let overlapSum = 0;
+    for (const target of goldSpans) {
+      const start = Math.max(span.start, target.start);
+      const end = Math.min(span.end, target.end);
+      if (end > start) {
+        overlapSum += end - start;
+      }
+    }
+    return sum + overlapSum;
+  }, 0);
+
+  const recall = goldTotal ? overlapLength / goldTotal : 0;
+  const precision = totalSubmission ? overlapLength / totalSubmission : 0;
+  const harmonic = recall + precision ? (2 * recall * precision) / (recall + precision) : 0;
+  const score = clampScore(0.35 + harmonic * 0.65);
 
   return {
     score,
-    rubric: ['Accuracy'],
-    spans: [],
+    rubric: ['Coverage', 'Precision'],
+    spans: submittedSpans,
     correctSequence: [],
-    details: { message: correct ? 'Correct fix applied.' : `Gold answer is ${goldChoice || 'unknown'}.`, mode },
-    fixSuggestion: correct ? undefined : 'Re-read the passage and match the stated issue to the right fix.',
-    nextHints: correct ? ['Advance to the next beat.'] : ['Compare the tone of each option to the highlighted issue.'],
-    skillIds: normalizeSkillIds(null, item, mode),
+    fixSuggestion: precision < 0.65 ? 'Trim the highlight to the phrase doing the turn.' : null,
+    nextHints: [
+      recall < 0.8 ? 'Push the highlight further into the beat that lands the twist.' : 'Check that your highlight includes the precise verb or image.',
+    ],
+    details: {
+      message: pickMessage(score, {
+        high: 'Spot on—your highlight hugs the signal.',
+        mid: 'Close! tighten around the key clause.',
+        low: 'You brushed past the heat—zero in on the reveal.',
+      }),
+      recall,
+      precision,
+      mode,
+    },
   };
-}
+};
 
-function missing({ answer, item, mode }) {
-  const inserted = typeof answer?.insertBeat === 'string' ? answer.insertBeat.trim().toLowerCase() : '';
-  const expected = String(item?.gold?.expected ?? item?.gold?.missingBeat ?? '').trim().toLowerCase();
-  const correct = inserted && expected ? inserted === expected : false;
-  const score = correct ? 1 : 0.4;
+const gradeFix = ({ item, answer, mode = 'fix' }) => {
+  const choice = toLower(typeof answer === 'string' ? answer : answer?.choice ?? answer?.choiceId ?? '');
+  const goldChoice = toLower(item?.gold?.choice ?? item?.gold?.choiceId ?? '');
 
-  const message = correct
-    ? 'You filled the gap with the expected beat.'
-    : expected
-      ? `Expected beat: ${expected}.`
-      : 'No reference beat provided; partial credit.';
+  if (!goldChoice) {
+    return {
+      score: 0.7,
+      rubric: ['Accuracy', 'Repair'],
+      spans: [],
+      correctSequence: [],
+      fixSuggestion: 'Connect the stated issue to the option that resolves it.',
+      nextHints: ['Match tone and stakes—right fix echoes both.'],
+      details: { message: 'No gold choice set; awarding neutral score.', provided: choice || null, mode },
+    };
+  }
+
+  const correct = choice === goldChoice;
+  const score = clampScore(correct ? 1 : 0.25);
 
   return {
     score,
-    rubric: ['Beat Sense'],
+    rubric: ['Accuracy', 'Repair'],
     spans: [],
     correctSequence: [],
-    details: { message, mode },
-    nextHints: correct ? ['Try writing the beat into the scene.'] : ['Revisit what emotion or action is missing.'],
-    skillIds: normalizeSkillIds(null, item, mode),
+    fixSuggestion: correct ? null : `Key is “${goldChoice.toUpperCase()}”. Trace why the wrong beat fails.`,
+    nextHints: [
+      correct ? 'Take the win and move to the next beat.' : 'Underline the precise issue, then match the fix that patches it.',
+    ],
+    details: {
+      message: correct ? 'Correct fix applied.' : `Gold answer: ${goldChoice || '—'}.`,
+      provided: choice || null,
+      expected: goldChoice || null,
+      mode,
+    },
+  };
+};
+
+const handlers = {
+  why: gradeWhy,
+  name: gradeName,
+  missing: gradeMissing,
+  order: gradeOrder,
+  highlight: gradeHighlight,
+  fix: gradeFix,
+};
+
+export function grade(mode, payload = {}) {
+  const cleanMode = SUPPORTED_MODES.includes(mode) ? mode : 'why';
+  const handler = handlers[cleanMode] || handlers.why;
+  let raw = {};
+
+  try {
+    raw = handler({ ...payload, mode: cleanMode }) || {};
+  } catch (err) {
+    console.error('[grader] failed to grade', cleanMode, err);
+    raw = {};
+  }
+
+  const normalizedRubric = Array.isArray(raw.rubric) && raw.rubric.length ? raw.rubric : defaultRubric;
+  const normalizedSpans = normalizeSpans(raw.spans);
+  const normalizedHints = normalizeHints(raw.nextHints);
+  const normalizedSequence = Array.isArray(raw.correctSequence)
+    ? raw.correctSequence.map((entry) => String(entry || '')).filter(Boolean)
+    : [];
+  const fixSuggestion = raw.fixSuggestion ? String(raw.fixSuggestion) : null;
+
+  const details = { ...defaultDetails(cleanMode), ...safeDetails(raw.details) };
+
+  return {
+    score: clampScore(Number(raw.score ?? 0)),
+    rubric: normalizedRubric.map((entry) => String(entry)),
+    spans: normalizedSpans,
+    correctSequence: normalizedSequence,
+    fixSuggestion,
+    nextHints: normalizedHints,
+    details,
+    skillIds: Array.isArray(raw.skillIds) && raw.skillIds.length
+      ? raw.skillIds.map((id) => String(id))
+      : skillIdFallback(payload.item, cleanMode),
   };
 }
 
-export const graders = { why, name, highlight, order, fix, missing };
-
-export default graders;
+export default grade;

--- a/server/reports/buildMemo.js
+++ b/server/reports/buildMemo.js
@@ -1,57 +1,132 @@
-// ESM module. Produces a lightweight Professor Ray Ray memo so /api/attempt can mount.
+const pct = (value) => `${Math.round((value || 0) * 100)}%`;
 
-// shape helpers (defensive defaults)
-const safeStr = (v, d = "") => (typeof v === "string" && v.trim() ? v.trim() : d);
-const pct = (n) => Number.isFinite(n) ? Math.round(n * 100) + "%" : "—";
+const NEIGHBORS = ['Hemingway', 'Baldwin', 'Didion', 'Morrison', 'Le Guin', 'Okorafor', 'Ng', 'Martín', 'Díaz'];
+const FOILS = ['PurpleProse', 'TEDTalk', 'Corporate Memo', 'Soapbox', 'Infomercial', 'Algorithmic Voice'];
 
-/**
- * Build a short, human memo about the player's style.
- * @param {Object} opts
- * @param {string} opts.userId
- * @param {Array<Object>} opts.recentAttempts - array of { mode, score, details?, rubric? }
- * @param {number} [opts.level=1]
- * @param {string[]} [opts.badges=[]]
- * @returns {{ title:string, body:string, level:number, badges:string[] }}
- */
-export async function buildMemo({ userId = "unknown", recentAttempts = [], level = 1, badges = [] } = {}) {
-  const total = recentAttempts.length;
-  const avg = total ? (recentAttempts.reduce((a, b) => a + (Number(b?.score) || 0), 0) / total) : 0;
-  const topModes = (() => {
-    const counts = new Map();
-    for (const a of recentAttempts) counts.set(a.mode, (counts.get(a.mode) || 0) + 1);
-    return [...counts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 3).map(([m]) => m).filter(Boolean);
-  })();
+const verdictForAverage = (avg) => {
+  if (avg >= 0.9) return 'Verdict: Razor-sharp craft—heat with control.';
+  if (avg >= 0.75) return 'Verdict: Confident moves with flashes of fire.';
+  if (avg >= 0.6) return 'Verdict: Groove emerging—keep stacking deliberate reps.';
+  return 'Verdict: Experimental energy—tighten fundamentals to channel it.';
+};
 
-  const hits = new Map();  // rubric key -> #ok
-  const seen = new Map();  // rubric key -> total
-  for (const a of recentAttempts) {
-    for (const r of Array.isArray(a?.rubric) ? a.rubric : []) {
-      seen.set(r.key, (seen.get(r.key) || 0) + 1);
-      if (r.ok) hits.set(r.key, (hits.get(r.key) || 0) + 1);
+const trendLabel = (recent, earlier) => {
+  if (!Number.isFinite(recent) || !Number.isFinite(earlier)) return 'steady';
+  const delta = recent - earlier;
+  if (delta > 0.05) return 'rising';
+  if (delta < -0.05) return 'dipping';
+  return 'steady';
+};
+
+const averageScore = (list) => {
+  if (!list.length) return 0;
+  const total = list.reduce((sum, value) => sum + (Number(value) || 0), 0);
+  return total / list.length;
+};
+
+const summarizeRubrics = (attempts) => {
+  const store = new Map();
+  for (const attempt of attempts) {
+    const labels = Array.isArray(attempt?.rubric) ? attempt.rubric : [];
+    const score = Number(attempt?.score ?? 0);
+    for (const label of labels) {
+      const key = String(label);
+      if (!store.has(key)) {
+        store.set(key, { total: 0, strong: 0, weak: 0 });
+      }
+      const entry = store.get(key);
+      entry.total += 1;
+      if (score >= 0.75) entry.strong += 1;
+      if (score <= 0.5) entry.weak += 1;
     }
   }
-  const rubricLine = [...seen.keys()]
-    .map(k => `${k}: ${hits.get(k) || 0}/${seen.get(k)} ok`)
-    .join(" · ") || "No rubric yet";
 
-  const vibe = [
-    avg >= 0.85 ? "clean and decisive" :
-    avg >= 0.7  ? "confident with room to sharpen edges" :
-    avg >= 0.5  ? "finding the lane—keep pressing reps" :
-                   "experimental—great time to tighten fundamentals"
-  ];
+  const strong = [...store.entries()]
+    .filter(([, entry]) => entry.total > 0)
+    .sort((a, b) => (b[1].strong / b[1].total) - (a[1].strong / a[1].total))
+    .slice(0, 2)
+    .map(([label]) => label);
 
-  const title = `Professor Ray Ray: Style Readout for @${safeStr(userId, "player")}`;
-  const lines = [
-    `Level ${level}  ·  Avg score: ${pct(avg)}  ·  Recent items: ${total || 0}`,
-    topModes.length ? `You’ve been jamming on: ${topModes.join(", ")}` : `We need more attempts to read your groove.`,
-    `Rubric pulse → ${rubricLine}`,
-    ``,
-    `Judgment: Your current voice reads ${vibe[0]}. Keep stacking small, visible choices; let beats carry the scene.`,
-    badges.length ? `Badges this level: ${badges.join(", ")}` : `Badges unlock as you hit streaks and clean rounds.`,
-  ];
+  const shaky = [...store.entries()]
+    .filter(([, entry]) => entry.weak > 0)
+    .sort((a, b) => (b[1].weak / b[1].total) - (a[1].weak / a[1].total))
+    .slice(0, 2)
+    .map(([label]) => label);
 
-  return { title, body: lines.join("\n"), level, badges };
+  return { strong, shaky };
+};
+
+const summarizeModes = (attempts) => {
+  const counts = new Map();
+  for (const attempt of attempts) {
+    const mode = String(attempt?.mode || 'why');
+    counts.set(mode, (counts.get(mode) || 0) + 1);
+  }
+  const ordered = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  return ordered.map(([mode]) => mode);
+};
+
+const pickFromList = (source, seed, count) => {
+  const out = [];
+  if (!source.length || count <= 0) return out;
+  let index = Math.abs(seed) % source.length;
+  for (let i = 0; i < count; i += 1) {
+    out.push(source[index % source.length]);
+    index += 1 + ((seed >> (i % 8)) & 0x3);
+  }
+  return out;
+};
+
+export function buildMemo({ userId = 'dev', attempts = [], mastery }) {
+  const totalAttempts = attempts.length;
+  const allScores = attempts.map((attempt) => Number(attempt?.score ?? 0));
+  const avgScore = averageScore(allScores);
+  const recentSlice = attempts.slice(0, 5);
+  const earlierSlice = attempts.slice(5, 10);
+  const recentAvg = averageScore(recentSlice.map((attempt) => Number(attempt?.score ?? 0)));
+  const earlierAvg = averageScore(earlierSlice.map((attempt) => Number(attempt?.score ?? 0)));
+  const trend = trendLabel(recentAvg, earlierAvg);
+  const { strong, shaky } = summarizeRubrics(attempts);
+  const modeOrder = summarizeModes(attempts);
+
+  const verdict = verdictForAverage(avgScore);
+  const bulletLines = [];
+  bulletLines.push(`- Avg score ${pct(avgScore)} across ${totalAttempts || 0} attempts; trend is ${trend}.`);
+
+  if (strong.length || shaky.length) {
+    const reliable = strong.length ? strong.join(' • ') : 'still forming';
+    const watch = shaky.length ? shaky.join(' • ') : 'hold steady';
+    bulletLines.push(`- Reliable: ${reliable}; Watch: ${watch}.`);
+  } else {
+    bulletLines.push('- Rubric signal still forming—log a few more graded reps.');
+  }
+
+  if (modeOrder.length) {
+    const favorites = modeOrder.slice(0, 3).join(', ');
+    bulletLines.push(`- Modes in rotation: ${favorites}.`);
+  }
+
+  if (mastery) {
+    bulletLines.push(`- Level ${mastery.level || 1} • Total EXP ${mastery.totalExp || 0}.`);
+  }
+
+  const weakestCue = shaky[0] || strong[0] || 'Clarity';
+  const nextMode = modeOrder.at(-1) || modeOrder[0] || 'why';
+  const drillLine = `What to try next: Run a ${nextMode} rep that spotlights ${weakestCue} in three sentences.`;
+
+  const seed = (userId || '').split('').reduce((acc, char, idx) => acc + char.charCodeAt(0) * (idx + 1), 0);
+  const neighborList = pickFromList(NEIGHBORS, seed, 3);
+  const foilList = pickFromList(FOILS, seed >> 3, 2);
+  const influenceLine = `Neighbors: ${neighborList.join(' • ')}; Foils: ${foilList.join(' • ')}.`;
+
+  const lines = [verdict, ...bulletLines.slice(0, 4), drillLine, influenceLine];
+
+  return {
+    title: 'Professor Ray Ray: Style Notes',
+    body: lines.join('\n'),
+    level: mastery?.level ?? 1,
+    issuedAt: new Date().toISOString(),
+  };
 }
 
 export default buildMemo;

--- a/server/routes/attempt.js
+++ b/server/routes/attempt.js
@@ -1,8 +1,15 @@
 import express from 'express';
-import { graders } from '../graders/index.js';
-import { addAttempt, bumpMastery, mem, saveReport } from '../db/mem.js';
+import grade from '../graders/index.js';
 import { getItemById } from '../content/items.js';
-import { buildStyleReport } from '../reports/buildMemo.js';
+import {
+  recordAttempt,
+  getAttempts,
+  addExp,
+  getMastery,
+  checkLevelUp,
+  saveReport,
+} from '../db/mem.js';
+import { buildMemo } from '../reports/buildMemo.js';
 
 const router = express.Router();
 
@@ -29,70 +36,40 @@ router.post('/', (req, res) => {
     return res.status(404).json({ ok: false, error: 'item_not_found', itemId });
   }
 
-  const grader = graders[mode] || graders.why;
-  let gradeResult;
+  let result;
   try {
-    gradeResult = grader({ userId, itemId, mode, answer, item });
+    result = grade(mode, { item, answer, userId, itemId });
   } catch (err) {
     console.error('[attempt] grader failed', err);
     return res.status(500).json({ ok: false, error: 'grading_failed', message: err?.message });
   }
 
-  const score = Number.isFinite(gradeResult?.score) ? Math.max(0, Math.min(1, gradeResult.score)) : 0;
-  const rubric = Array.isArray(gradeResult?.rubric)
-    ? gradeResult.rubric.map((entry) => (typeof entry === 'string' ? entry : String(entry))).filter(Boolean)
-    : [];
-  const spans = Array.isArray(gradeResult?.spans) ? gradeResult.spans : [];
-  const correctSequence = Array.isArray(gradeResult?.correctSequence) ? gradeResult.correctSequence : [];
-  const fixSuggestion = gradeResult?.fixSuggestion ?? null;
-  const nextHints = Array.isArray(gradeResult?.nextHints) ? gradeResult.nextHints : [];
-  const details = gradeResult?.details && typeof gradeResult.details === 'object'
-    ? { ...gradeResult.details, mode }
-    : { message: 'graded', mode };
+  const score = Number.isFinite(result?.score) ? Math.max(0, Math.min(1, Number(result.score))) : 0;
+  const rubric = Array.isArray(result?.rubric) ? result.rubric.map((entry) => String(entry)) : [];
+  const spans = Array.isArray(result?.spans) ? result.spans : [];
+  const correctSequence = Array.isArray(result?.correctSequence) ? result.correctSequence : [];
+  const fixSuggestion = result?.fixSuggestion != null ? String(result.fixSuggestion) : null;
+  const nextHints = Array.isArray(result?.nextHints) ? result.nextHints.map((hint) => String(hint)) : [];
+  const details = result?.details && typeof result.details === 'object' ? { ...result.details } : {};
+  details.mode = details.mode || mode;
+
+  const rawSkillIds = Array.isArray(item?.skillIds) && item.skillIds.length
+    ? item.skillIds
+    : (Array.isArray(item?.meta?.beat_tags) ? item.meta.beat_tags : []);
+  const skillIds = rawSkillIds.map((id) => String(id)).filter(Boolean);
+
+  const expAward = Math.round(score * 20);
+  addExp(userId, skillIds, expAward);
+
+  details.expAward = expAward;
+  if (!details.skillIds) {
+    details.skillIds = skillIds;
+  }
+
   const gradedAt = new Date().toISOString();
 
-  const attemptRecord = {
+  recordAttempt({
     userId,
-    itemId,
-    mode,
-    answer,
-    score,
-    rubric,
-    details,
-    gradedAt,
-  };
-
-  addAttempt(attemptRecord);
-
-  const skillIds = Array.isArray(gradeResult?.skillIds) && gradeResult.skillIds.length
-    ? gradeResult.skillIds
-    : (Array.isArray(item?.skillIds) && item.skillIds.length ? item.skillIds : [`craft.${mode}`]);
-
-  let leveledUp = false;
-  let highestLevel = 1;
-  const badgeSet = new Set();
-
-  for (const skillId of skillIds) {
-    const key = String(skillId);
-    const before = mem.mastery.get(`${userId}:${key}`)?.level ?? 1;
-    const delta = Math.max(5, Math.round(score * 20));
-    const after = bumpMastery(userId, key, delta);
-    if (after.level > before) {
-      leveledUp = true;
-      highestLevel = Math.max(highestLevel, after.level);
-    }
-  }
-
-  let memo = null;
-  if (leveledUp) {
-    memo = buildStyleReport(userId);
-    saveReport(userId, memo);
-    badgeSet.add('Beat Scout');
-    badgeSet.add('Clause Wrangler');
-  }
-
-  const response = {
-    ok: true,
     itemId,
     mode,
     score,
@@ -103,18 +80,36 @@ router.post('/', (req, res) => {
     nextHints,
     details,
     gradedAt,
-  };
+  });
 
-  response.skillIds = skillIds.map((id) => String(id));
+  const { leveledUp, level, badges } = checkLevelUp(userId);
 
+  let memo;
   if (leveledUp) {
-    response.leveledUp = true;
-    response.level = highestLevel;
-    response.badges = Array.from(badgeSet);
-    response.memo = memo;
+    const attempts = getAttempts(userId, { limit: 50 });
+    const mastery = getMastery(userId);
+    memo = buildMemo({ userId, attempts, mastery });
+    saveReport(userId, memo);
   }
 
-  return res.json(response);
+  return res.json({
+    ok: true,
+    userId,
+    itemId,
+    mode,
+    score,
+    rubric,
+    spans,
+    correctSequence,
+    fixSuggestion,
+    nextHints,
+    details,
+    leveledUp,
+    level,
+    badges,
+    memo: leveledUp ? memo : undefined,
+    gradedAt,
+  });
 });
 
 export default router;

--- a/server/routes/debugContent.js
+++ b/server/routes/debugContent.js
@@ -42,6 +42,7 @@ router.get("/api/debug/content", async (req, res) => {
     }
 
     const mastery = getMastery(userId);
+    const masterySkillCount = mastery?.skills ? Object.keys(mastery.skills).length : 0;
 
     res.json({
       totalItems: items.length,
@@ -50,7 +51,11 @@ router.get("/api/debug/content", async (req, res) => {
       nextItem,
       attempts: mem.attempts.length,
       skips: mem.skips.length,
-      mastery: Object.keys(mastery).length,
+      mastery: {
+        level: mastery?.level ?? 1,
+        totalExp: mastery?.totalExp ?? 0,
+        skills: masterySkillCount,
+      },
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -8,9 +8,13 @@ router.get('/reports/ping', (_req, res) => {
 });
 
 router.get('/reports/latest', (req, res) => {
-  const userId = String(req.query.userId || req.get('x-user-id') || 'dev');
+  const userId = String(req.get('x-user-id') || req.query.userId || 'dev');
   const memo = getLatestReport(userId);
-  res.json({ ok: true, memo });
+  if (memo) {
+    res.json({ ok: true, memo });
+  } else {
+    res.json({ ok: false, memo: null });
+  }
 });
 
 export const reportsRouter = router;

--- a/server/routes/skip.js
+++ b/server/routes/skip.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { addSkip } from '../db/mem.js';
+import { markSkipped } from '../db/mem.js';
 
 const router = express.Router();
 
@@ -14,13 +14,7 @@ router.post('/skip', (req, res) => {
   }
 
   const mode = String(body.mode || '').trim() || 'why';
-  addSkip({
-    userId,
-    itemId: String(itemIdRaw),
-    mode,
-    reason: body.reason || 'user_skip',
-    ts: Date.now(),
-  });
+  markSkipped(userId, String(itemIdRaw), { mode, reason: body.reason || 'user_skip' });
 
   return res.json({ ok: true });
 });

--- a/server/scheduler/next.js
+++ b/server/scheduler/next.js
@@ -1,7 +1,9 @@
 import { getAllItems } from '../content/items.js';
-import { mem, userSeenSet } from '../db/mem.js';
+import { mem, getMastery, getAttempts, userSeenSet } from '../db/mem.js';
 
 const SUPPORTED_MODES = new Set(['why', 'name', 'highlight', 'order', 'fix', 'missing']);
+const RECENT_ATTEMPT_WINDOW = 1000 * 60 * 20; // 20 minutes
+const RECENT_SKIP_WINDOW = 1000 * 60 * 30; // 30 minutes
 
 function normalizeItemShape(item) {
   if (!item) return null;
@@ -17,11 +19,44 @@ function normalizeItemShape(item) {
   return payload;
 }
 
-function shouldPrioritize(item, seenSet) {
-  const introduces = Array.isArray(item?.meta?.introduces_beats) ? item.meta.introduces_beats : [];
-  if (!introduces.length) return false;
-  return !seenSet.has(String(item.id));
-}
+const toSkillList = (item) => {
+  if (Array.isArray(item?.skillIds) && item.skillIds.length) {
+    return item.skillIds.map((id) => String(id)).filter(Boolean);
+  }
+  if (Array.isArray(item?.meta?.beat_tags) && item.meta.beat_tags.length) {
+    return item.meta.beat_tags.map((id) => String(id)).filter(Boolean);
+  }
+  return [];
+};
+
+const computeWeakness = (skillIds, masterySkills, overallLevel) => {
+  if (!skillIds.length) {
+    return 1 / Math.max(1, overallLevel || 1);
+  }
+  let totalLevel = 0;
+  let missing = 0;
+  for (const skillId of skillIds) {
+    const data = masterySkills[skillId];
+    if (!data) {
+      missing += 1;
+      totalLevel += 0.5;
+    } else {
+      totalLevel += Math.max(0.5, data.level);
+    }
+  }
+  const average = totalLevel / skillIds.length;
+  const base = 1 / Math.max(average, 0.5);
+  const missingBonus = missing ? missing / skillIds.length : 0;
+  return base + missingBonus;
+};
+
+const computePenalty = (timestamp, window, now) => {
+  if (!timestamp) return 0;
+  const delta = now - timestamp;
+  if (delta <= 0) return 1;
+  if (delta >= window) return 0;
+  return 1 - delta / window;
+};
 
 export function pickNext({ userId }) {
   const user = userId ? String(userId) : 'dev';
@@ -30,54 +65,55 @@ export function pickNext({ userId }) {
     throw new Error('No items available');
   }
 
-  const seen = new Set(Array.from(userSeenSet(user))); 
-  const recentSkipIds = mem.skips
-    .filter((skip) => skip.userId === user && Date.now() - skip.ts < 1000 * 60 * 30)
-    .map((skip) => String(skip.itemId));
-  for (const skipId of recentSkipIds) {
-    seen.add(skipId);
-  }
+  const mastery = getMastery(user);
+  const masterySkills = mastery?.skills || {};
+  const overallLevel = mastery?.level || 1;
+  const attempts = getAttempts(user, { limit: 120 });
+  const seen = userSeenSet(user);
+  const now = Date.now();
 
-  const allowedModes = items.filter((item) => SUPPORTED_MODES.has(item.mode || 'why'));
-  const pool = allowedModes.length ? allowedModes : items.filter((item) => (item.mode || 'why') === 'why');
-  const candidates = pool.length ? pool : items;
-
-  const priority = [];
-  const unseenPreferred = [];
-  const fallback = [];
-
-  for (const item of candidates) {
-    const id = String(item.id);
-    const mode = item.mode || 'why';
-    const blocked = seen.has(id);
-    const shape = normalizeItemShape(item);
-    if (!shape) continue;
-
-    if (shouldPrioritize(item, seen)) {
-      priority.push(shape);
-      continue;
-    }
-
-    if (!blocked) {
-      if (SUPPORTED_MODES.has(mode)) {
-        unseenPreferred.push(shape);
-      } else {
-        fallback.push(shape);
-      }
+  const lastAttemptByItem = new Map();
+  for (const attempt of attempts) {
+    const id = String(attempt.itemId);
+    const ts = Number(attempt.ts ?? (attempt.gradedAt ? Date.parse(attempt.gradedAt) : 0));
+    if (!lastAttemptByItem.has(id) || ts > lastAttemptByItem.get(id)) {
+      lastAttemptByItem.set(id, ts);
     }
   }
 
-  const finalPool = priority.length
-    ? priority
-    : (unseenPreferred.length ? unseenPreferred : (fallback.length ? fallback : candidates.map(normalizeItemShape)));
-
-  if (!finalPool.length) {
-    const any = candidates.map(normalizeItemShape).filter(Boolean);
-    if (!any.length) return normalizeItemShape(items[0]);
-    return any[Math.floor(Math.random() * any.length)];
+  const lastSkipByItem = new Map();
+  for (const skip of mem.skips) {
+    if (String(skip.userId) !== user) continue;
+    const id = String(skip.itemId);
+    const ts = Number(skip.ts) || 0;
+    if (!lastSkipByItem.has(id) || ts > lastSkipByItem.get(id)) {
+      lastSkipByItem.set(id, ts);
+    }
   }
 
-  return finalPool[Math.floor(Math.random() * finalPool.length)];
+  const candidates = items.filter((item) => SUPPORTED_MODES.has(item.mode || 'why'));
+  const pool = candidates.length ? candidates : items;
+
+  const scored = pool
+    .map((item) => {
+      const itemId = String(item.id);
+      const skillIds = toSkillList(item);
+      const weakness = computeWeakness(skillIds, masterySkills, overallLevel);
+      const unseenBonus = seen.has(itemId) ? 0 : 0.8;
+      const introduceBonus = Array.isArray(item?.meta?.introduces_beats) && item.meta.introduces_beats.length ? 0.3 : 0;
+      const recencyPenalty = computePenalty(lastAttemptByItem.get(itemId), RECENT_ATTEMPT_WINDOW, now);
+      const skipPenalty = computePenalty(lastSkipByItem.get(itemId), RECENT_SKIP_WINDOW, now) * 1.3;
+      const seenPenalty = seen.has(itemId) ? 0.05 : 0;
+      const priority = weakness + unseenBonus + introduceBonus - recencyPenalty - skipPenalty - seenPenalty;
+      return { item, priority };
+    })
+    .sort((a, b) => {
+      if (b.priority !== a.priority) return b.priority - a.priority;
+      return String(a.item.id).localeCompare(String(b.item.id));
+    });
+
+  const chosen = scored.length ? scored[0].item : pool[0];
+  return normalizeItemShape(chosen);
 }
 
 export default pickNext;


### PR DESCRIPTION
## Summary
- implement mode-aware graders and wire /api/attempt to record mastery, generate memos, and emit normalized responses
- extend the in-memory store and scheduler to award EXP, detect level-ups, and surface weak-skill items while persisting reports
- update client APIs and Sigil Runner feedback tray to consume the new payloads, show memo level-ups, and allow skip/next flows

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f849709850832fb026ea632e39f9d5