### PR TITLE
Normalize attempt response contract

### DIFF
--- a/server/graders/index.js
+++ b/server/graders/index.js
@@ -29,6 +29,49 @@ function ensureShape(result, extra = {}) {
   };
 }
 
+// Normalizer ensures the /api/attempt contract is always satisfied.
+function normalizeResult(r = {}, { userId = 'anon', itemId = null, mode = 'why' } = {}) {
+  const now = new Date().toISOString();
+  const normalizedUserId = typeof r.userId === 'string' && r.userId.trim()
+    ? r.userId.trim()
+    : (typeof userId === 'string' && userId.trim() ? userId.trim() : 'anon');
+  const itemIdSource = r.itemId ?? itemId;
+  const normalizedItemId = itemIdSource == null ? null : String(itemIdSource);
+  const modeSource = typeof r.mode === 'string' && r.mode.trim()
+    ? r.mode.trim()
+    : (typeof mode === 'string' && mode.trim() ? mode.trim() : 'why');
+  const gradedAtValue = r.gradedAt;
+  let gradedAt = now;
+  if (typeof gradedAtValue === 'string' && gradedAtValue.trim()) {
+    gradedAt = gradedAtValue;
+  } else if (gradedAtValue instanceof Date && !Number.isNaN(gradedAtValue.valueOf())) {
+    gradedAt = gradedAtValue.toISOString();
+  }
+  const numericScore = Number(r.score);
+  const score = Number.isFinite(numericScore) ? clamp01(numericScore) : 0.0;
+  const levelValue = Number(r.level);
+  const level = Number.isFinite(levelValue) ? levelValue : 1;
+  const detailsValue = (r.details && typeof r.details === 'object' && !Array.isArray(r.details)) ? r.details : {};
+
+  return {
+    ok: typeof r.ok === 'boolean' ? r.ok : true,
+    userId: normalizedUserId,
+    itemId: normalizedItemId,
+    mode: modeSource,
+    score,
+    rubric: Array.isArray(r.rubric) ? r.rubric : [],
+    spans: Array.isArray(r.spans) ? r.spans : [],
+    correctSequence: Array.isArray(r.correctSequence) ? r.correctSequence : [],
+    fixSuggestion: r.fixSuggestion ?? null,
+    nextHints: Array.isArray(r.nextHints) ? r.nextHints : [],
+    details: detailsValue,
+    leveledUp: !!r.leveledUp,
+    level,
+    badges: Array.isArray(r.badges) ? r.badges : [],
+    gradedAt,
+  };
+}
+
 // --- light helpers used by graders ---
 const toArray = (x) => Array.isArray(x) ? x : (x == null ? [] : [x]);
 const uniq = (arr) => Array.from(new Set(arr));
@@ -307,7 +350,7 @@ function gradeWhy(item, answer) {
 }
 
 // Public API
-export async function grade({ mode, item, answer }) {
+export async function _grade({ mode, item, answer }) {
   const m = String(mode || item?.mode || '').toLowerCase();
   try {
     switch (m) {
@@ -331,6 +374,22 @@ export async function grade({ mode, item, answer }) {
       details: { error: String(e?.message || e), mode: m },
     });
   }
+}
+
+export async function grade(modeOrPayload, maybePayload) {
+  const basePayload = (typeof modeOrPayload === 'string')
+    ? { ...(maybePayload || {}), mode: modeOrPayload }
+    : ((modeOrPayload && typeof modeOrPayload === 'object') ? modeOrPayload : {});
+  const rawMode = basePayload.mode ?? basePayload.item?.mode;
+  const mode = typeof rawMode === 'string' && rawMode.trim() ? rawMode.trim() : 'why';
+  const userIdValue = basePayload.userId;
+  const userId = typeof userIdValue === 'string' && userIdValue.trim() ? userIdValue.trim() : 'anon';
+  const itemIdSource = basePayload.itemId ?? basePayload.item?.id ?? null;
+  const itemId = itemIdSource == null ? null : String(itemIdSource);
+  const callPayload = { ...basePayload, mode, userId, itemId };
+  const raw = await _grade(callPayload);
+  const merged = { ...raw, mode, userId, itemId };
+  return normalizeResult(merged, { userId, itemId, mode });
 }
 
 export default { grade };

--- a/server/index.js
+++ b/server/index.js
@@ -10,6 +10,7 @@ import { buildReport } from './report/index.js';
 import { mark, getUserState } from './progress/store.js';
 import { listSigilIds } from './sigil/catalogIds.js';
 import * as mem from './db/mem.js';
+import * as grader from './graders/index.js';
 
 // Import new API routes
 import nextRoutes from './routes/next.js';
@@ -102,6 +103,48 @@ app.use(reportsRoutes);
 } catch (e) {
   console.warn('Route mounting warning:', e && e.message);
 }
+
+app.post('/api/attempt', async (req, res) => {
+  const body = req.body ?? {};
+  const { userId, itemId, mode, answer } = body;
+
+  const normalizedUserId = typeof userId === 'string' && userId.trim()
+    ? userId.trim()
+    : String(req.get('x-user-id') || 'dev');
+  const itemIdRaw = itemId ?? body.id;
+  const normalizedItemId = itemIdRaw != null
+    ? String(itemIdRaw)
+    : null;
+
+  if (!normalizedItemId) {
+    return res.status(400).json({ ok: false, error: 'missing_item_id' });
+  }
+
+  const normalizedMode = typeof mode === 'string' && mode.trim() ? mode.trim() : 'why';
+  const item = { id: normalizedItemId };
+
+  try {
+    const result = await grader.grade({
+      mode: normalizedMode,
+      item,
+      answer,
+      userId: normalizedUserId,
+      itemId: normalizedItemId,
+    });
+    // The grader now returns a fully-normalized object with all contract keys.
+    return res.json(result);
+  } catch (e) {
+    console.error('[attempt] grade error:', e && e.stack ? e.stack : e);
+    return res.status(200).json({
+      ok: false,
+      error: 'grading_failed',
+      message: e?.message || String(e),
+      userId: normalizedUserId,
+      itemId: normalizedItemId,
+      mode: normalizedMode,
+    });
+  }
+});
 
 app.use('/api/attempt', attemptRoutes);
 mounted.push('/api/attempt');


### PR DESCRIPTION
## Summary
- add a normalization helper in the graders so every grade result includes the full /api/attempt contract
- call the normalized grader from the /api/attempt route and return its payload directly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f966fb7538832fb25869252b23224b