### PR TITLE
Add direct /api/next handler using scheduler pickNext

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -150,6 +150,24 @@ app.use('/api/attempt', attemptRoutes);
 mounted.push('/api/attempt');
 logMountedRoutes();
 
+// Ensure GET /api/next exists
+app.get('/api/next', async (req, res) => {
+  try {
+    const userId = String(req.query.userId || 'anon');
+    const mod = await import('./scheduler/next.js');
+    const pickNext = mod?.pickNext || mod?.default;
+    if (typeof pickNext !== 'function') {
+      return res.status(500).json({ ok: false, error: 'scheduler.pickNext not available' });
+    }
+    const out = await pickNext(userId);
+    const id = out?.id ?? null;
+    const item = out?.item ?? null;
+    return res.json({ id, item, userId });
+  } catch (e) {
+    return res.status(500).json({ ok: false, error: String(e && e.message || e) });
+  }
+});
+
 app.use(nextRoutes);
 mounted.push('/api/next');
 app.use(skipRoutes);


### PR DESCRIPTION
## Summary
- add a GET /api/next handler directly in `server/index.js`
- dynamically load `scheduler/next.js`, invoke `pickNext`, and return `{ id, item, userId }`
- send structured `{ ok: false, error }` responses when `pickNext` is unavailable or throws

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f96a771808832f89035f51bcd25f1f