### PR TITLE
Configure dev proxy and API helpers

### DIFF
--- a/app/src/lib/apiBase.js
+++ b/app/src/lib/apiBase.js
@@ -1,0 +1,17 @@
+// app/src/lib/apiBase.js
+// Dev: Vite proxy forwards /api -> http://localhost:3002
+// Prod: server serves app/dist and the same /api routes; relative paths just work.
+export const API_BASE = '';
+export function api(path) {
+  const base = API_BASE.replace(/\/$/, '');
+  return `${base}${path}`;
+}
+export async function safeFetchJSON(url, init) {
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    let text = '';
+    try { text = await res.text(); } catch {}
+    throw new Error(`HTTP ${res.status}${text ? ` – ${text.slice(0,120)}` : ''}`);
+  }
+  return res.json();
+}

--- a/app/src/lib/attemptApi.js
+++ b/app/src/lib/attemptApi.js
@@ -1,28 +1,89 @@
 // app/src/lib/attemptApi.js
 import * as API from '@/lib/apiBase.js'
 
-// Build a URL regardless of how apiBase is authored
 const makeUrl = typeof API.api === 'function'
   ? (p) => API.api(p)
   : (p) => {
-      const base = (API.API_BASE || '').replace(/\/$/, '')
-      return base ? base + p : p
+      const base = typeof API.API_BASE === 'string' ? API.API_BASE.replace(/\/$/, '') : ''
+      return base ? base + (p.startsWith('/') ? p : `/${p}`) : (p.startsWith('/') ? p : `/${p}`)
     }
 
-// Reuse the same safe fetch helper (if provided); otherwise a tiny fallback
-const safeFetchJSON = API.safeFetchJSON || (async (url, init) => {
-  const res = await fetch(url, init)
-  if (!res.ok) {
-    const text = await res.text().catch(()=>'')
-    throw new Error(`HTTP ${res.status}${text ? ` – ${text.slice(0,120)}` : ''}`)
-  }
-  return res.json()
-})
+const safeFetchJSON = typeof API.safeFetchJSON === 'function'
+  ? (url, init) => API.safeFetchJSON(url, init)
+  : async (url, init) => {
+      const res = await fetch(url, init)
+      if (!res.ok) {
+        const text = await res.text().catch(()=>'')
+        throw new Error(`HTTP ${res.status}${text ? ` – ${text.slice(0,120)}` : ''}`)
+      }
+      return res.json()
+    }
 
-export async function submitAttempt({ id, text, minWords }) {
-  return safeFetchJSON(makeUrl('/attempt'), {
+export async function fetchNext(userId = 'dev') {
+  const url = makeUrl(`/api/next?userId=${encodeURIComponent(userId)}`)
+  return safeFetchJSON(url)
+}
+
+export async function submitAttempt(input = {}) {
+  if (!input || typeof input !== 'object') throw new Error('submitAttempt requires an object payload')
+
+  const hasModernShape = 'itemId' in input || 'answer' in input || 'mode' in input
+  if (!hasModernShape) {
+    const legacy = {
+      id: input.id,
+      text: input.text,
+      minWords: input.minWords,
+    }
+    return safeFetchJSON(makeUrl('/attempt'), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(legacy),
+    })
+  }
+
+  const {
+    userId = 'dev',
+    itemId,
+    mode = 'why',
+    answer,
+    reason,
+  } = input
+
+  if (!itemId) throw new Error('submitAttempt requires itemId')
+
+  return safeFetchJSON(makeUrl('/api/attempt'), {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ id, text, minWords })
+    body: JSON.stringify({ userId, itemId, mode, answer, reason }),
+  })
+}
+
+export async function skipItem(arg1, arg2, arg3) {
+  let userId = 'dev'
+  let itemId
+  let reason = 'user_skip'
+  let mode
+
+  if (arg1 && typeof arg1 === 'object' && !Array.isArray(arg1)) {
+    userId = arg1.userId ?? 'dev'
+    itemId = arg1.itemId ?? arg1.id ?? arg1.lessonId
+    mode = arg1.mode
+    reason = arg1.reason ?? (mode ? `mode:${mode}` : 'user_skip')
+  } else {
+    userId = arg1 ?? 'dev'
+    itemId = arg2
+    mode = arg3
+    reason = mode ? `mode:${mode}` : 'user_skip'
+  }
+
+  if (!itemId) throw new Error('skipItem requires itemId')
+
+  const body = { userId, itemId, reason }
+  if (mode) body.mode = mode
+
+  return safeFetchJSON(makeUrl('/api/skip'), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
   })
 }

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -1,3 +1,21 @@
 import config from './vite.config.ts'
 
-export default config
+const baseServer = config.server || {}
+const baseProxy = baseServer.proxy || {}
+
+export default {
+  ...config,
+  server: {
+    ...baseServer,
+    port: 5173,
+    strictPort: true,
+    proxy: {
+      ...baseProxy,
+      '/api': {
+        target: 'http://localhost:3002',
+        changeOrigin: true,
+        // no rewrite: keep /api prefix intact
+      },
+    },
+  },
+}

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "scripts": {
     "dev:server": "node server/index.js",
     "server:server": "node server/index.js",
-    "dev:app": "npm run dev --prefix app",
+    "dev:app": "npm --prefix app run dev",
     "dev:up": "bash scripts/dev-up.sh",
     "dev:down": "bash scripts/dev-down.sh",
     "build": "node scripts/offline-vite-build.mjs",
-    "build:app": "node scripts/offline-vite-build.mjs",
+    "build:app": "npm --prefix app run build",
     "smoke:content": "ts-node scripts/smokeContent.ts",
     "start": "node server/index.js",
     "dev": "bash scripts/dev-up.sh",


### PR DESCRIPTION
## Summary
- update the root scripts so dev and build flows call into the app package correctly
- extend the app Vite config to pin the dev server to 5173 and proxy /api to the backend on 3002
- add a shared JS API helper and update the attempt API wrapper to use the proxy-aware endpoints

## Testing
- npm --prefix app run build

------
https://chatgpt.com/codex/tasks/task_e_68f9796bb8cc832f9cd5730fd66bc33e