### PR TITLE
Expose introduces beats and wire Sigil feedback

### DIFF
--- a/app/src/components/FeedbackTray.jsx
+++ b/app/src/components/FeedbackTray.jsx
@@ -2,30 +2,53 @@ export default function FeedbackTray({
   feedback = null,
   result = null,
   submitting = false,
-  canSubmit = false,
+  canSubmit = true,
   onSubmit = null,
   onNext = null,
   onSkip = null,
   error = '',
+  nextEnabled = false,
 }) {
   const payload = feedback ?? result ?? null;
-  const value = [
-    payload?.score != null ? `Score: ${Math.round(payload.score * 100)}%` : '',
-    Array.isArray(payload?.rubric) && payload.rubric.length
-      ? `Rubric: ${payload.rubric
-          .map((r) =>
-            typeof r === 'string' ? r : `${r.key}${r.ok ? '✓' : '✗'}`,
-          )
-          .join(', ')}`
-      : '',
-    payload?.details?.message ? `Note: ${payload.details.message}` : '',
-    payload?.fixSuggestion ? `Suggestion: ${payload.fixSuggestion}` : '',
-    Array.isArray(payload?.nextHints) && payload.nextHints.length
-      ? `Next: ${payload.nextHints.join(' | ')}`
-      : '',
-  ]
-    .filter(Boolean)
-    .join('\n');
+  const lines = [];
+
+  if (payload?.score != null) {
+    lines.push(`Score: ${Math.round(payload.score * 100)}%`);
+  }
+
+  const rubricEntries = Array.isArray(payload?.rubric) ? payload.rubric : [];
+  if (rubricEntries.length) {
+    lines.push('Rubric:');
+    for (const entry of rubricEntries) {
+      if (!entry) continue;
+      if (typeof entry === 'string') {
+        lines.push(`- ${entry}`);
+      } else {
+        const label = [entry.key, entry.ok != null ? (entry.ok ? '✓' : '✗') : null]
+          .filter(Boolean)
+          .join(' ');
+        lines.push(`- ${label || JSON.stringify(entry)}`);
+      }
+    }
+  }
+
+  const hintSources = [];
+  if (Array.isArray(payload?.nextHints)) hintSources.push(...payload.nextHints);
+  if (Array.isArray(payload?.next)) hintSources.push(...payload.next);
+  if (typeof payload?.next === 'string') hintSources.push(payload.next);
+  if (typeof payload?.nextHint === 'string') hintSources.push(payload.nextHint);
+  if (typeof payload?.fixSuggestion === 'string') hintSources.push(payload.fixSuggestion);
+  const hints = hintSources
+    .map((hint) => (hint == null ? '' : String(hint).trim()))
+    .filter(Boolean);
+  if (hints.length) {
+    lines.push('Next:');
+    for (const hint of hints) {
+      lines.push(`- ${hint}`);
+    }
+  }
+
+  const value = lines.join('\n');
 
   return (
     <div className="sigil-feedback-tray">
@@ -34,7 +57,6 @@ export default function FeedbackTray({
         readOnly
         rows={8}
         value={value}
-        placeholder="Submit to see feedback."
       />
 
       {error ? (
@@ -61,7 +83,7 @@ export default function FeedbackTray({
             data-testid="btn-next"
             className="pfp-btn"
             onClick={onNext}
-            disabled={submitting}
+            disabled={submitting || !nextEnabled}
           >
             Next
           </button>

--- a/app/src/lib/attemptApi.js
+++ b/app/src/lib/attemptApi.js
@@ -29,7 +29,38 @@ async function safeFetchJSON(url, init) {
 
 // --- API helpers required by SigilRunner.jsx ---
 export async function fetchNext(userId = 'dev') {
-  return safeFetchJSON(makeUrl(`/api/next?userId=${encodeURIComponent(userId)}`));
+  const res = await safeFetchJSON(makeUrl(`/api/next?userId=${encodeURIComponent(userId)}`));
+  if (!res || typeof res !== 'object') return res ?? null;
+
+  const base = res && typeof res.item === 'object' && res.item !== null ? res.item : res;
+  if (!base || typeof base !== 'object') return null;
+
+  const item = { ...base };
+  if (item.id == null && res.id != null) {
+    item.id = res.id;
+  }
+  if (item.id == null) return null;
+  item.id = String(item.id);
+
+  const mode = res.mode ?? base.mode;
+  if (!item.mode && mode) {
+    item.mode = mode;
+  }
+  if (!item.mode) {
+    item.mode = 'why';
+  }
+
+  const introducesTop = res.introduces_beats;
+  if (!Array.isArray(item.introduces_beats) && Array.isArray(introducesTop)) {
+    item.introduces_beats = introducesTop;
+  }
+  if (Array.isArray(item.introduces_beats)) {
+    item.introduces_beats = item.introduces_beats
+      .map((beat) => (beat == null ? '' : String(beat).trim()))
+      .filter(Boolean);
+  }
+
+  return item;
 }
 
 export async function submitAttempt({ userId = 'dev', itemId, mode, answer }) {

--- a/app/src/pages/SigilRunner.jsx
+++ b/app/src/pages/SigilRunner.jsx
@@ -10,7 +10,7 @@ import { getLesson } from '@/services/sigilLesson';
 import { fetchNext, skipItem, submitAttempt } from '@/lib/attemptApi';
 
 const USER_ID = 'dev';
-const MODE = 'sigil';
+const MODE = 'why';
 
 const defaultBeatEmoticon = {
   action: '🔨',
@@ -82,7 +82,7 @@ export default function SigilRunner() {
           const nextItem = await fetchNext(USER_ID);
           if (ignore) return;
           if (nextItem?.id) {
-            setCurrentItem(nextItem);
+            setCurrentItem({ ...nextItem, mode: nextItem.mode || MODE });
             setFeedback(null);
             setSubmitError('');
             setText('');
@@ -169,7 +169,7 @@ export default function SigilRunner() {
     if (!plainText) return 0;
     return plainText.split(/\s+/).filter(Boolean).length;
   }, [plainText]);
-  const canSubmit = plainText.length > 0;
+  const canSubmit = true;
 
   const handleBeatInsert = (beatData) => {
     setPendingInsert(beatData);
@@ -180,7 +180,7 @@ export default function SigilRunner() {
   };
 
   async function handleSubmit() {
-    if (!canSubmit || submitting) return;
+    if (submitting) return;
     const itemId = currentItem?.id || lesson?.id || id;
     if (!itemId) {
       setSubmitError('Missing lesson id.');
@@ -218,8 +218,9 @@ export default function SigilRunner() {
     setLoading(true);
     try {
       const nextItem = await fetchNext(USER_ID);
-      setCurrentItem(nextItem || null);
-      const nextId = nextItem?.id ? String(nextItem.id) : null;
+      const normalized = nextItem ? { ...nextItem, mode: nextItem.mode || MODE } : null;
+      setCurrentItem(normalized);
+      const nextId = normalized?.id ? String(normalized.id) : null;
       if (!nextId) {
         setError('No additional lessons available.');
         setLoading(false);
@@ -263,7 +264,7 @@ export default function SigilRunner() {
       return;
     }
     try {
-      await skipItem(USER_ID, String(itemId), currentItem?.mode || MODE);
+      await skipItem({ userId: USER_ID, itemId: String(itemId) });
     } catch (e) {
       setSubmitError(e?.message || 'Failed to record skip.');
     }
@@ -372,6 +373,7 @@ export default function SigilRunner() {
             onNext={handleNext}
             onSkip={handleSkip}
             error={submitError}
+            nextEnabled={Boolean(feedback)}
           />
         </section>
       </div>

--- a/server/content/loaders.js
+++ b/server/content/loaders.js
@@ -7,11 +7,45 @@ const ITEMS_DIR = path.join(__dirname, "items");
 const TWEETRUNK_DIR = path.join(__dirname, "tweetrunk");
 const PRACTICE_DIR = path.join(__dirname, "practice");
 
+function toStringArray(value) {
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => (entry == null ? "" : String(entry)))
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+  if (typeof value === "string") {
+    return value
+      .split(/[,;|]/)
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function dedupe(list) {
+  const seen = new Set();
+  const out = [];
+  for (const item of list) {
+    if (!seen.has(item)) {
+      seen.add(item);
+      out.push(item);
+    }
+  }
+  return out;
+}
+
+function normalizeIntroducesBeats(raw, meta) {
+  const fromRaw = toStringArray(raw?.introduces_beats ?? raw?.introducesBeats);
+  const fromMeta = toStringArray(meta?.introduces_beats ?? meta?.introducesBeats);
+  return dedupe([...fromRaw, ...fromMeta]);
+}
+
 function normalizeItem(raw, idx) {
   const id = String(raw?.id ?? `item-${idx + 1}`);
   const mode = String(raw?.mode ?? "why");
   const prompt = String(raw?.prompt ?? "Write one sentence about cause → effect.");
-  const meta = (() => {
+  const baseMeta = (() => {
     const metaFromField = raw && typeof raw.meta === "object" && raw.meta !== null ? { ...raw.meta } : {};
     if (raw && typeof raw === "object") {
       const extra = { ...raw };
@@ -23,7 +57,10 @@ function normalizeItem(raw, idx) {
     }
     return metaFromField;
   })();
-  return { id, mode, prompt, meta };
+  const introduces_beats = normalizeIntroducesBeats(raw, baseMeta);
+  const meta = { ...baseMeta, introduces_beats };
+  delete meta.introducesBeats;
+  return { id, mode, prompt, meta, introduces_beats };
 }
 
 async function loadDir(dir) {
@@ -76,7 +113,7 @@ export async function getCatalog() {
           id: "sample-why-1",
           mode: "why",
           prompt: "In one line, explain why short→long sentence rhythm increases impact.",
-          meta: { freshness: 1, level: 1, introduces_beats: false },
+          meta: { freshness: 1, level: 1, introduces_beats: [] },
         },
         0,
       ),
@@ -87,6 +124,20 @@ export async function getCatalog() {
 
 export async function loadPracticePool() {
   return getCatalog();
+}
+
+export async function loadIntroducesBeats() {
+  const catalog = await getCatalog();
+  const map = {};
+  for (const item of catalog) {
+    const beats = Array.isArray(item?.introduces_beats)
+      ? item.introduces_beats.filter((beat) => typeof beat === "string" && beat.trim())
+      : [];
+    if (beats.length) {
+      map[item.id] = beats.map((beat) => beat.trim());
+    }
+  }
+  return map;
 }
 
 export default getCatalog;

--- a/server/graders/index.js
+++ b/server/graders/index.js
@@ -428,7 +428,7 @@ function __normalizeResult(r = {}, ctx = {}) {
 // If _grade is missing (edge case), fall back to a no-op that yields a valid shape.
 async function __fallbackGrade() { return {}; }
 
-export async function grade(mode, payload) {
+export async function gradeNormalized(mode, payload) {
   const coerced = __coerceMode(mode);
   const base = (typeof _grade === "function" ? await _grade(coerced, payload) : await __fallbackGrade(coerced, payload)) || {};
   return __normalizeResult(


### PR DESCRIPTION
## Summary
- normalize content loaders so each lesson carries an introduces_beats array and expose a loadIntroducesBeats map helper
- rework FeedbackTray and SigilRunner to wire the attempt/next/skip loop, remove word-count gating, and surface real rubric + hints
- harden attempt API helpers and rename the duplicate grade export so the server boots cleanly

## Testing
- npm --prefix app run build
- npm start
- curl -sS http://localhost:3002/api/healthz
- curl -sS http://localhost:3002/api/next | jq -r '.id'
- printf '{"userId":"dev","itemId":"sample-why-1","mode":"why","answer":"short→long rhythm"}' | curl -sS -X POST http://localhost:3002/api/attempt -H 'content-type: application/json' --data-binary @- | jq .


------
https://chatgpt.com/codex/tasks/task_e_68f982f9eccc832fbe0864084088f620